### PR TITLE
Add MachinePool resources

### DIFF
--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -3,6 +3,12 @@ global:
     name: awesome
     organization: giantswarm
     description: "Awesome Giant Swarm cluster"
+    labels:
+      some-cluster-label: label-1
+      another-cluster-label: label-2
+    annotations:
+      important-cluster-value: "1000"
+      robots-need-this-in-the-cluster: "eW91IGNhbm5vdCByZWFkIHRoaXMsIGJ1dCByb2JvdHMgY2FuCg=="
   connectivity:
     baseDomain: example.gigantic.io
     proxy:
@@ -26,6 +32,23 @@ global:
       usernameClaim: usernameClaim
       caPem: "..."
     replicas: 3
+  nodePools:
+    def00:
+      replicas: 3
+      labels:
+        nodepool-workload-type: ai
+      annotations:
+        for-robots-in-nodepool: "cm9ib3RzIGFyZSBvcGVyYXRpbmcgb24gdGhpcyBub2RlIHBvb2wK"
+      nodeLabels:
+        workload-type: ai
+      nodeTaints:
+      - key: supernodepool
+        value: hello
+        effect: NoSchedule
+    rt5y7:
+      replicas: 100
+      nodeLabels:
+        workload-type: robots
   components:
     cri:
       registries:
@@ -197,8 +220,13 @@ internal:
     - echo "cluster"
   kubernetesVersion: 1.24.10
   paused: false
-  providerSpecific:
-    resources:
-      cluster:
-        api:
-          kind: AWSCluster
+  resourcesApi:
+    nodePoolKind: MachinePool
+    infrastructureCluster:
+      group: infrastructure.cluster.x-k8s.io
+      version: v1beta1
+      kind: AWSCluster
+    infrastructureMachinePool:
+      group: infrastructure.cluster.x-k8s.io
+      version: v1beta1
+      kind: AWSMachinePool

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -82,64 +82,7 @@ internal:
           additionalConfig:
             systemd:
               units:
-              - name: kubereserved.slice
-                contents: |
-                  [Unit]
-                  Description=Limited resources slice for Kubernetes services
-                  Documentation=man:systemd.special(7)
-                  DefaultDependencies=no
-                  Before=slices.target
-                  Requires=-.slice
-                  After=-.slice
-              - name: kubeadm.service
-                dropins:
-                - name: 10-flatcar.conf
-                  contents: |
-                    [Unit]
-                    # kubeadm must run after coreos-metadata populated /run/metadata directory.
-                    Requires=coreos-metadata.service
-                    After=coreos-metadata.service
-                    [Service]
-                    # Ensure kubeadm service has access to kubeadm binary in /opt/bin on Flatcar.
-                    Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/bin
-                    # To make metadata environment variables available for pre-kubeadm commands.
-                    EnvironmentFile=/run/metadata/*
-              - name: containerd.service
-                enabled: true
-                contents: |
-                dropins:
-                - name: 10-change-cgroup.conf
-                  contents: |
-                    [Service]
-                    CPUAccounting=true
-                    MemoryAccounting=true
-                    Slice=kubereserved.slice
-              - name: os-hardening.service
-                enabled: true
-                contents: |
-                  [Unit]
-                  Description=Apply os hardening
-                  [Service]
-                  Type=oneshot
-                  ExecStartPre=-/bin/bash -c "gpasswd -d core rkt; gpasswd -d core docker; gpasswd -d core wheel"
-                  ExecStartPre=/bin/bash -c "until [ -f '/etc/sysctl.d/hardening.conf' ]; do echo Waiting for sysctl file; sleep 1s;done;"
-                  ExecStart=/usr/sbin/sysctl -p /etc/sysctl.d/hardening.conf
-                  [Install]
-                  WantedBy=multi-user.target
-              - name: audit-rules.service
-                enabled: true
-                dropins:
-                - name: 10-wait-for-containerd.conf
-                  contents: |
-                    [Service]
-                    ExecStartPre=/bin/bash -c "while [ ! -f /etc/audit/rules.d/containerd.rules ]; do echo 'Waiting for /etc/audit/rules.d/containerd.rules to be written' && sleep 1; done"
-              - name: update-engine.service
-                enabled: false
-                mask: true
-              - name: locksmithd.service
-                enabled: false
-                mask: true
-              - name: example1.service
+              - name: example1-control-plane.service
                 enabled: false
                 mask: false
                 contents: |
@@ -148,18 +91,18 @@ internal:
                 - name: hello.conf
                   contents: |
                     # Contents goes here
-              - name: example2.service
+              - name: example2-control-plane.service
                 enabled: false
                 mask: false
                 contents: |
                   # Multi-line
                   # contents goes here
                 dropins:
-                - name: hello1.conf
+                - name: hello1-control-plane.conf
                   contents: |
                     # Multi-line
                     # contents goes here
-                - name: hello2.conf
+                - name: hello2-control-plane.conf
                   contents: |
                     # Multi-line
                     # contents goes here
@@ -184,7 +127,7 @@ internal:
                   label: kubelet
                   format: xfs
               directories:
-              - path: /var/lib/kubelet/temporary/stuff
+              - path: /var/lib/kubelet/temporary/stuff/control-plane
                 overwrite: true
                 filesystem: kubelet
                 mode: 750
@@ -218,6 +161,62 @@ internal:
         npt:
         - 169.254.169.123
   kubeadmConfig:
+    ignition:
+      containerLinuxConfig:
+        additionalConfig:
+          systemd:
+            units:
+            - name: kubeadm.service
+              dropins:
+              - name: 10-flatcar.conf
+                contents: |
+                  [Unit]
+                  # kubeadm must run after coreos-metadata populated /run/metadata directory.
+                  Requires=coreos-metadata.service
+                  After=coreos-metadata.service
+                  [Service]
+                  # Ensure kubeadm service has access to kubeadm binary in /opt/bin on Flatcar.
+                  Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/bin
+                  # To make metadata environment variables available for pre-kubeadm commands.
+                  EnvironmentFile=/run/metadata/*
+            - name: example1.service
+              enabled: false
+              mask: false
+              contents: |
+                # Contents goes here
+              dropins:
+              - name: hello.conf
+                contents: |
+                  # Contents goes here
+            - name: example2.service
+              enabled: false
+              mask: false
+              contents: |
+                # Multi-line
+                # contents goes here
+              dropins:
+              - name: hello1.conf
+                contents: |
+                  # Multi-line
+                  # contents goes here
+              - name: hello2.conf
+                contents: |
+                  # Multi-line
+                  # contents goes here
+          storage:
+            directories:
+            - path: /var/lib/kubelet/temporary/stuff
+              overwrite: true
+              filesystem: kubelet
+              mode: 750
+              user:
+                id: 12345
+                name: giantswarm
+              group:
+                id: 23456
+                name: giantswarm
+            - path: /var/lib/kubelet
+              mode: 750
     preKubeadmCommands:
     - echo "hello all nodes before kubeadm"
     - echo "all cluster nodes before kubeadm"
@@ -238,6 +237,47 @@ internal:
       kind: AWSMachinePool
   workers:
     kubeadmConfig:
+      ignition:
+        containerLinuxConfig:
+          additionalConfig:
+            systemd:
+              units:
+              - name: example1-workers.service
+                enabled: false
+                mask: false
+                contents: |
+                  # Contents goes here
+                dropins:
+                - name: hello.conf
+                  contents: |
+                    # Contents goes here
+              - name: example2-workers.service
+                enabled: false
+                mask: false
+                contents: |
+                  # Multi-line
+                  # contents goes here
+                dropins:
+                - name: hello1-workers.conf
+                  contents: |
+                    # Multi-line
+                    # contents goes here
+                - name: hello2-workers.conf
+                  contents: |
+                    # Multi-line
+                    # contents goes here
+            storage:
+              directories:
+              - path: /var/lib/kubelet/temporary/stuff/workers
+                overwrite: true
+                filesystem: kubelet
+                mode: 750
+                user:
+                  id: 12345
+                  name: giantswarm
+                group:
+                  id: 23456
+                  name: giantswarm
       preKubeadmCommands:
       - echo "hello workers before kubeadm"
       - echo "cluster workers before kubeadm"

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -196,6 +196,12 @@ internal:
                   name: giantswarm
               - path: /var/lib/kubelet
                 mode: 750
+      preKubeadmCommands:
+      - echo "hello control plane before kubeadm"
+      - echo "cluster control plane before kubeadm"
+      postKubeadmCommands:
+      - echo "hello control plane after kubeadm"
+      - echo "cluster control plane after kubeadm"
     resources:
       controlPlane:
         api:
@@ -213,11 +219,11 @@ internal:
         - 169.254.169.123
   kubeadmConfig:
     preKubeadmCommands:
-    - echo "hello"
-    - echo "cluster"
+    - echo "hello all nodes before kubeadm"
+    - echo "all cluster nodes before kubeadm"
     postKubeadmCommands:
-    - echo "hello"
-    - echo "cluster"
+    - echo "hello all nodes after kubeadm"
+    - echo "all cluster nodes after kubeadm"
   kubernetesVersion: 1.24.10
   paused: false
   resourcesApi:
@@ -230,3 +236,11 @@ internal:
       group: infrastructure.cluster.x-k8s.io
       version: v1beta1
       kind: AWSMachinePool
+  workers:
+    kubeadmConfig:
+      preKubeadmCommands:
+      - echo "hello workers before kubeadm"
+      - echo "cluster workers before kubeadm"
+      postKubeadmCommands:
+      - echo "hello workers after kubeadm"
+      - echo "cluster workers after kubeadm"

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -137,8 +137,6 @@ internal:
                 group:
                   id: 23456
                   name: giantswarm
-              - path: /var/lib/kubelet
-                mode: 750
       preKubeadmCommands:
       - echo "hello control plane before kubeadm"
       - echo "cluster control plane before kubeadm"

--- a/helm/cluster/templates/_helpers.tpl
+++ b/helm/cluster/templates/_helpers.tpl
@@ -4,14 +4,14 @@
 Expand the name of the chart.
 */}}
 {{- define "cluster.chart.name" -}}
-{{- .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- $.Chart.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "cluster.chart.nameAndVersion" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" $.Chart.Name $.Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -29,9 +29,9 @@ Common labels
 */}}
 {{- define "cluster.labels.common" -}}
 app: {{ include "cluster.chart.name" . | quote }}
-app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-app.kubernetes.io/version: {{ .Chart.Version | quote }}
-application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
+app.kubernetes.io/managed-by: {{ $.Release.Service | quote }}
+app.kubernetes.io/version: {{ $.Chart.Version | quote }}
+application.giantswarm.io/team: {{ index $.Chart.Annotations "application.giantswarm.io/team" | quote }}
 giantswarm.io/cluster: {{ include "cluster.resource.name" . | quote }}
 giantswarm.io/organization: {{ required "You must provide an existing organization name in .global.metadata.organization" $.Values.global.metadata.organization | quote }}
 giantswarm.io/service-priority: {{ $.Values.global.metadata.servicePriority }}

--- a/helm/cluster/templates/_helpers.tpl
+++ b/helm/cluster/templates/_helpers.tpl
@@ -39,3 +39,19 @@ cluster.x-k8s.io/cluster-name: {{ include "cluster.resource.name" . | quote }}
 cluster.x-k8s.io/watch-filter: capi
 helm.sh/chart: {{ include "cluster.chart.nameAndVersion" . | quote }}
 {{- end -}}
+
+{{- define "cluster.labels.custom" }}
+{{- if $.Values.global.metadata.labels }}
+{{- range $key, $val := $.Values.global.metadata.labels }}
+{{ $key }}: {{ $val | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "cluster.annotations.custom" }}
+{{- if $.Values.global.metadata.annotations }}
+{{- range $key, $val := $.Values.global.metadata.annotations }}
+{{ $key }}: {{ $val | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/cluster/templates/_helpers.tpl
+++ b/helm/cluster/templates/_helpers.tpl
@@ -21,7 +21,7 @@ Given that Kubernetes allows 63 characters for resource names, the stem is trunc
 room for such suffix.
 */}}
 {{- define "cluster.resource.name" -}}
-{{- $.Values.global.metadata.name | default (.Release.Name | replace "." "-" | trunc 47 | trimSuffix "-") -}}
+{{- $.Values.global.metadata.name | default ($.Release.Name | replace "." "-" | trunc 47 | trimSuffix "-") -}}
 {{- end -}}
 
 {{/*

--- a/helm/cluster/templates/clusterapi/_helpers_files.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_files.tpl
@@ -1,11 +1,10 @@
 {{- define "cluster.internal.kubeadm.files" }}
-{{- include "cluster.internal.kubeadm.files.sysctl" . }}
-{{- include "cluster.internal.kubeadm.files.systemd" . }}
-{{- include "cluster.internal.kubeadm.files.ssh" . }}
-{{- include "cluster.internal.kubeadm.files.cri" . }}
-{{- include "cluster.internal.kubeadm.files.kubelet" . }}
-{{- include "cluster.internal.kubeadm.files.kubernetes" . }}
-{{- include "cluster.internal.kubeadm.files.proxy" . }}
+{{- include "cluster.internal.kubeadm.files.sysctl" $ }}
+{{- include "cluster.internal.kubeadm.files.systemd" $ }}
+{{- include "cluster.internal.kubeadm.files.ssh" $ }}
+{{- include "cluster.internal.kubeadm.files.cri" $ }}
+{{- include "cluster.internal.kubeadm.files.kubelet" $ }}
+{{- include "cluster.internal.kubeadm.files.proxy" $ }}
 {{- end }}
 
 {{- define "cluster.internal.kubeadm.files.sysctl" }}
@@ -59,19 +58,6 @@
   content: {{ $.Files.Get "files/etc/systemd/logind.conf.d/zzz-kubelet-graceful-shutdown.conf" | b64enc }}
 {{- end }}
 {{- end }}
-{{- end }}
-
-{{- define "cluster.internal.kubeadm.files.kubernetes" }}
-- path: /etc/kubernetes/policies/audit-policy.yaml
-  permissions: "0600"
-  encoding: base64
-  content: {{ $.Files.Get "files/etc/kubernetes/policies/audit-policy.yaml" | b64enc }}
-- path: /etc/kubernetes/encryption/config.yaml
-  permissions: "0600"
-  contentFrom:
-    secret:
-      name: {{ include "cluster.resource.name" $ }}-encryption-provider-config
-      key: encryption
 {{- end }}
 
 {{- define "cluster.internal.kubeadm.files.proxy" }}

--- a/helm/cluster/templates/clusterapi/_helpers_flatcar.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_flatcar.tpl
@@ -1,0 +1,86 @@
+{{- define "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" }}
+{{- range . }}
+- name: {{ .name }}
+  {{- if hasKey . "enabled" }}
+  enabled: {{ .enabled }}
+  {{- end }}
+  {{- if hasKey . "mask" }}
+  mask: {{ .mask }}
+  {{- end }}
+  {{- if .contents }}
+  contents: |
+    {{- .contents | trim | nindent 4 }}
+  {{- end }}
+  {{- if .dropins }}
+  dropins:
+  {{- range .dropins }}
+  - name: {{ .name }}
+    {{- if .contents }}
+    contents: |
+      {{- .contents | trim | nindent 6 }}
+    {{- end }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.filesystems" }}
+{{- range . }}
+- name: {{ .name }}
+  {{- if .mount }}
+  mount:
+    device: {{ .mount.device }}
+    format: {{ .mount.format }}
+    {{- if hasKey . "wipeFilesystem" }}
+    wipeFilesystem: {{ .mount.wipeFilesystem }}
+    {{- end }}
+    {{- if .mount.label }}
+    label: {{ .mount.label }}
+    {{- end }}
+    {{- if .mount.uuid }}
+    uuid: {{ .mount.uuid }}
+    {{- end }}
+    {{- if .mount.options }}
+    {{- range $option := .mount.options }}
+    - {{ $option }}
+    {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- if .path }}
+  path: {{ .path }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.directories" }}
+{{- range . }}
+- path: {{ .path }}
+  {{- if hasKey . "overwrite" }}
+  overwrite: {{ .overwrite }}
+  {{- end }}
+  {{- if .filesystem }}
+  filesystem: {{ .filesystem }}
+  {{- end }}
+  {{- if .mode }}
+  mode: {{ .mode }}
+  {{- end }}
+  {{- if .user }}
+  user:
+    {{- if .user.id }}
+    id: {{ .user.id }}
+    {{- end }}
+    {{- if .user.name }}
+    name: {{ .user.name }}
+    {{- end }}
+  {{- end }}
+  {{- if .group }}
+  group:
+    {{- if .group.id }}
+    id: {{ .group.id }}
+    {{- end }}
+    {{- if .group.name }}
+    name: {{ .group.name }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/cluster/templates/clusterapi/_helpers_postkubeadmcommands.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_postkubeadmcommands.tpl
@@ -1,6 +1,11 @@
+{{/*
+    Template cluster.internal.kubeadm.postKubeadmCommands defines common extra commands to run on all
+    (control plane and workers) nodes after kubeadm runs. It includes prefedined commands and custom
+    commands specified in Helm values field .Values.internal.kubeadmConfig.postKubeadmCommands.
+*/}}
 {{- define "cluster.internal.kubeadm.postKubeadmCommands" }}
-{{- include "cluster.internal.kubeadm.postKubeadmCommands.kubelet" . }}
-{{- include "cluster.internal.kubeadm.postKubeadmCommands.custom" . }}
+{{- include "cluster.internal.kubeadm.postKubeadmCommands.kubelet" $ }}
+{{- include "cluster.internal.kubeadm.postKubeadmCommands.custom" $ }}
 {{- end }}
 
 {{- define "cluster.internal.kubeadm.postKubeadmCommands.kubelet" }}

--- a/helm/cluster/templates/clusterapi/_helpers_prekubeadmcommands.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_prekubeadmcommands.tpl
@@ -1,8 +1,13 @@
+{{/*
+    Template cluster.internal.kubeadm.preKubeadmCommands defines common extra commands to run on all
+    (control plane and workers) nodes before kubeadm runs. It includes prefedined commands and
+    custom commands specified in Helm values field .Values.internal.kubeadmConfig.preKubeadmCommands.
+*/}}
 {{- define "cluster.internal.kubeadm.preKubeadmCommands" }}
-{{- include "cluster.internal.kubeadm.preKubeadmCommands.flatcar" . }}
-{{- include "cluster.internal.kubeadm.preKubeadmCommands.ssh" . }}
-{{- include "cluster.internal.kubeadm.preKubeadmCommands.proxy" . }}
-{{- include "cluster.internal.kubeadm.preKubeadmCommands.custom" . }}
+{{- include "cluster.internal.kubeadm.preKubeadmCommands.flatcar" $ }}
+{{- include "cluster.internal.kubeadm.preKubeadmCommands.ssh" $ }}
+{{- include "cluster.internal.kubeadm.preKubeadmCommands.proxy" $ }}
+{{- include "cluster.internal.kubeadm.preKubeadmCommands.custom" $ }}
 {{- end }}
 
 {{- define "cluster.internal.kubeadm.preKubeadmCommands.flatcar" }}

--- a/helm/cluster/templates/clusterapi/cluster.yaml
+++ b/helm/cluster/templates/clusterapi/cluster.yaml
@@ -28,8 +28,8 @@ spec:
     kind: {{ .Values.internal.controlPlane.resources.controlPlane.api.kind }}
     name: {{ include "cluster.resource.name" $ }}
   infrastructureRef:
-    apiVersion: {{ .Values.internal.providerSpecific.resources.cluster.api.group }}/{{ .Values.internal.providerSpecific.resources.cluster.api.version }}
-    kind: {{ .Values.internal.providerSpecific.resources.cluster.api.kind }}
+    apiVersion: {{ .Values.internal.resourcesApi.infrastructureCluster.group }}/{{ .Values.internal.resourcesApi.infrastructureCluster.version }}
+    kind: {{ .Values.internal.resourcesApi.infrastructureCluster.kind }}
     name: {{ include "cluster.resource.name" $ }}
   {{- if .Values.internal.paused }}
   paused: true

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_files.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_files.tpl
@@ -1,9 +1,23 @@
 {{- define "cluster.internal.controlPlane.kubeadm.files" }}
-{{- include "cluster.internal.kubeadm.files" . -}}
+{{- include "cluster.internal.kubeadm.files" $ -}}
+{{- include "cluster.internal.kubeadm.files.kubernetes" . }}
 {{- if $.Values.global.controlPlane.oidc.caPem }}
 - path: /etc/ssl/certs/oidc.pem
   permissions: "0600"
   encoding: base64
   content: {{ tpl ($.Files.Get "files/etc/ssl/certs/oidc.pem") . | b64enc }}
 {{- end }}
+{{- end }}
+
+{{- define "cluster.internal.kubeadm.files.kubernetes" }}
+- path: /etc/kubernetes/policies/audit-policy.yaml
+  permissions: "0600"
+  encoding: base64
+  content: {{ $.Files.Get "files/etc/kubernetes/policies/audit-policy.yaml" | b64enc }}
+- path: /etc/kubernetes/encryption/config.yaml
+  permissions: "0600"
+  contentFrom:
+    secret:
+      name: {{ include "cluster.resource.name" $ }}-encryption-provider-config
+      key: encryption
 {{- end }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_flatcar.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_flatcar.tpl
@@ -1,86 +1,39 @@
-{{- define "cluster.kubeadmControlPlane.kubeadmConfigSpec.ignition.containerLinuxConfig.additionalConfig.systemd.units" }}
-{{- range $.Values.internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units }}
-- name: {{ .name }}
-  {{- if hasKey . "enabled" }}
-  enabled: {{ .enabled }}
-  {{- end }}
-  {{- if hasKey . "mask" }}
-  mask: {{ .mask }}
-  {{- end }}
-  {{- if .contents }}
-  contents: |
-    {{- .contents | trim | nindent 4 }}
-  {{- end }}
-  {{- if .dropins }}
-  dropins:
-  {{- range .dropins }}
-  - name: {{ .name }}
-    {{- if .contents }}
-    contents: |
-      {{- .contents | trim | nindent 6 }}
-    {{- end }}
-  {{- end }}
-  {{- end }}
+{{- define "cluster.internal.controlPlane.kubeadm.ignition" }}
+containerLinuxConfig:
+  additionalConfig: |
+    systemd:
+      units:
+      {{- include "cluster.internal.controlPlane.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $ | indent 6 }}
+    storage:
+      filesystems:
+      {{- include "cluster.internal.controlPlane.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.filesystems" $ | indent 6 }}
+      directories:
+      {{- include "cluster.internal.controlPlane.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.directories" $ | indent 6 }}
+{{- end }}
+
+{{- define "cluster.internal.controlPlane.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" }}
+{{- if ((((($.Values.internal.kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).systemd).units }}
+{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $.Values.internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units }}
+{{- end }}
+{{- if (((((($.Values.internal.controlPlane).kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).systemd).units }}
+{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $.Values.internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units }}
 {{- end }}
 {{- end }}
 
-{{- define "cluster.kubeadmControlPlane.kubeadmConfigSpec.ignition.containerLinuxConfig.additionalConfig.storage.filesystems" }}
-{{- range $.Values.internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems }}
-- name: {{ .name }}
-  {{- if .mount }}
-  mount:
-    device: {{ .mount.device }}
-    format: {{ .mount.format }}
-    {{- if hasKey . "wipeFilesystem" }}
-    wipeFilesystem: {{ .mount.wipeFilesystem }}
-    {{- end }}
-    {{- if .mount.label }}
-    label: {{ .mount.label }}
-    {{- end }}
-    {{- if .mount.uuid }}
-    uuid: {{ .mount.uuid }}
-    {{- end }}
-    {{- if .mount.options }}
-    {{- range $option := .mount.options }}
-    - {{ $option }}
-    {{- end }}
-    {{- end }}
-  {{- end }}
-  {{- if .path }}
-  path: {{ .path }}
-  {{- end }}
+{{- define "cluster.internal.controlPlane.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.filesystems" }}
+{{- if ((((($.Values.internal.kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).storage).filesystems }}
+{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.filesystems" $.Values.internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems }}
+{{- end }}
+{{- if (((((($.Values.internal.controlPlane).kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).storage).filesystems }}
+{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.filesystems" $.Values.internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems }}
 {{- end }}
 {{- end }}
 
-{{- define "cluster.kubeadmControlPlane.kubeadmConfigSpec.ignition.containerLinuxConfig.additionalConfig.storage.directories" }}
-{{- range $.Values.internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories }}
-- path: {{ .path }}
-  {{- if hasKey . "overwrite" }}
-  overwrite: {{ .overwrite }}
-  {{- end }}
-  {{- if .filesystem }}
-  filesystem: {{ .filesystem }}
-  {{- end }}
-  {{- if .mode }}
-  mode: {{ .mode }}
-  {{- end }}
-  {{- if .user }}
-  user:
-    {{- if .user.id }}
-    id: {{ .user.id }}
-    {{- end }}
-    {{- if .user.name }}
-    name: {{ .user.name }}
-    {{- end }}
-  {{- end }}
-  {{- if .group }}
-  group:
-    {{- if .group.id }}
-    id: {{ .group.id }}
-    {{- end }}
-    {{- if .group.name }}
-    name: {{ .group.name }}
-    {{- end }}
-  {{- end }}
+{{- define "cluster.internal.controlPlane.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.directories" }}
+{{- if ((((($.Values.internal.kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).storage).directories }}
+{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.directories" $.Values.internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories }}
+{{- end }}
+{{- if (((((($.Values.internal.controlPlane).kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).storage).directories }}
+{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.directories" $.Values.internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_postkubeadmcommands.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_postkubeadmcommands.tpl
@@ -1,3 +1,17 @@
+{{/*
+    Template cluster.internal.controlPlane.kubeadm.postKubeadmCommands defines extra commands to run
+    on control plane nodes after kubeadm runs. It includes prefedined commands and custom commands
+    specified in Helm values field .Values.internal.controlPlane.kubeadmConfig.postKubeadmCommands.
+*/}}
 {{- define "cluster.internal.controlPlane.kubeadm.postKubeadmCommands" }}
-{{- include "cluster.internal.kubeadm.postKubeadmCommands" . }}
+{{- include "cluster.internal.kubeadm.postKubeadmCommands" $ }}
+{{- include "cluster.internal.controlPlane.kubeadm.postKubeadmCommands.custom" $ }}
+{{- end }}
+
+{{- define "cluster.internal.controlPlane.kubeadm.postKubeadmCommands.custom" }}
+{{- if $.Values.internal.controlPlane.kubeadmConfig }}
+{{- range $command := $.Values.internal.controlPlane.kubeadmConfig.postKubeadmCommands }}
+- {{ $command }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_prekubeadmcommands.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_prekubeadmcommands.tpl
@@ -1,3 +1,17 @@
+{{/*
+    Template cluster.internal.controlPlane.kubeadm.preKubeadmCommands defines extra commands to run
+    on control plane nodes before kubeadm runs. It includes prefedined commands and custom commands
+    specified in Helm values field .Values.internal.controlPlane.kubeadmConfig.preKubeadmCommands.
+*/}}
 {{- define "cluster.internal.controlPlane.kubeadm.preKubeadmCommands" }}
-{{- include "cluster.internal.kubeadm.preKubeadmCommands" . }}
+{{- include "cluster.internal.kubeadm.preKubeadmCommands" $ }}
+{{- include "cluster.internal.controlPlane.kubeadm.preKubeadmCommands.custom" $ }}
+{{- end }}
+
+{{- define "cluster.internal.controlPlane.kubeadm.preKubeadmCommands.custom" }}
+{{- if $.Values.internal.controlPlane.kubeadmConfig }}
+{{- range $command := $.Values.internal.controlPlane.kubeadmConfig.preKubeadmCommands }}
+- {{ $command }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/controlplane/kubeadmcontrolplane.yaml
+++ b/helm/cluster/templates/clusterapi/controlplane/kubeadmcontrolplane.yaml
@@ -54,8 +54,8 @@ spec:
     files:
     {{- include "cluster.internal.controlPlane.kubeadm.files" . | indent 4 }}
     preKubeadmCommands:
-    {{- include "cluster.internal.controlPlane.kubeadm.preKubeadmCommands" . | indent 4 }}
+    {{- include "cluster.internal.controlPlane.kubeadm.preKubeadmCommands" $ | indent 4 }}
     postKubeadmCommands:
-    {{- include "cluster.internal.controlPlane.kubeadm.postKubeadmCommands" . | indent 4 }}
+    {{- include "cluster.internal.controlPlane.kubeadm.postKubeadmCommands" $ | indent 4 }}
     users:
-    {{- include "cluster.internal.kubeadm.users" . | indent 4 }}
+    {{- include "cluster.internal.kubeadm.users" $ | indent 4 }}

--- a/helm/cluster/templates/clusterapi/controlplane/kubeadmcontrolplane.yaml
+++ b/helm/cluster/templates/clusterapi/controlplane/kubeadmcontrolplane.yaml
@@ -43,7 +43,7 @@ spec:
     joinConfiguration:
       {{- include "cluster.internal.controlPlane.kubeadm.joinConfiguration" $ | indent 6 }}
     files:
-    {{- include "cluster.internal.controlPlane.kubeadm.files" . | indent 4 }}
+    {{- include "cluster.internal.controlPlane.kubeadm.files" $ | indent 4 }}
     preKubeadmCommands:
     {{- include "cluster.internal.controlPlane.kubeadm.preKubeadmCommands" $ | indent 4 }}
     postKubeadmCommands:

--- a/helm/cluster/templates/clusterapi/controlplane/kubeadmcontrolplane.yaml
+++ b/helm/cluster/templates/clusterapi/controlplane/kubeadmcontrolplane.yaml
@@ -22,16 +22,7 @@ spec:
   kubeadmConfigSpec:
     format: ignition
     ignition:
-      containerLinuxConfig:
-        additionalConfig: |
-          systemd:
-            units:
-            {{- include "cluster.kubeadmControlPlane.kubeadmConfigSpec.ignition.containerLinuxConfig.additionalConfig.systemd.units" $ | indent 12 }}
-          storage:
-            filesystems:
-            {{- include "cluster.kubeadmControlPlane.kubeadmConfigSpec.ignition.containerLinuxConfig.additionalConfig.storage.filesystems" $ | indent 12 }}
-            directories:
-            {{- include "cluster.kubeadmControlPlane.kubeadmConfigSpec.ignition.containerLinuxConfig.additionalConfig.storage.directories" $ | indent 12 }}
+      {{- include "cluster.internal.controlPlane.kubeadm.ignition" $ | indent 6 }}
     clusterConfiguration:
       # Avoid accessibility issues (e.g. on private clusters) and potential future rate limits for
       # the default `registry.k8s.io`.

--- a/helm/cluster/templates/clusterapi/workers/_helpers_files.tpl
+++ b/helm/cluster/templates/clusterapi/workers/_helpers_files.tpl
@@ -1,0 +1,3 @@
+{{- define "cluster.internal.workers.kubeadm.files" }}
+{{- include "cluster.internal.kubeadm.files" $ -}}
+{{- end }}

--- a/helm/cluster/templates/clusterapi/workers/_helpers_flatcar.tpl
+++ b/helm/cluster/templates/clusterapi/workers/_helpers_flatcar.tpl
@@ -1,0 +1,37 @@
+{{- define "cluster.internal.workers.kubeadm.ignition" }}
+containerLinuxConfig:
+  additionalConfig: |
+    systemd:
+      units:
+      {{- include "cluster.internal.workers.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $ | indent 6 }}
+    storage:
+      directories:
+      {{- include "cluster.internal.workers.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.directories" $ | indent 6 }}
+{{- end }}
+
+{{- define "cluster.internal.workers.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" }}
+{{- if ((((($.Values.internal.kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).systemd).units }}
+{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $.Values.internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units }}
+{{- end }}
+{{- if (((((($.Values.internal.workers).kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).systemd).units }}
+{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $.Values.internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units }}
+{{- end }}
+{{- end }}
+
+{{- define "cluster.internal.workers.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.filesystems" }}
+{{- if ((((($.Values.internal.kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).storage).filesystems }}
+{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.filesystems" $.Values.internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems }}
+{{- end }}
+{{- if (((((($.Values.internal.workers).kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).storage).filesystems }}
+{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.filesystems" $.Values.internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems }}
+{{- end }}
+{{- end }}
+
+{{- define "cluster.internal.workers.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.directories" }}
+{{- if ((((($.Values.internal.kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).storage).directories }}
+{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.directories" $.Values.internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories }}
+{{- end }}
+{{- if (((((($.Values.internal.workers).kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).storage).directories }}
+{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.directories" $.Values.internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories }}
+{{- end }}
+{{- end }}

--- a/helm/cluster/templates/clusterapi/workers/_helpers_joinconfiguration.tpl
+++ b/helm/cluster/templates/clusterapi/workers/_helpers_joinconfiguration.tpl
@@ -6,7 +6,7 @@
     .config: node pool config, a value from $.Values.global.nodepools map.
 */}}
 {{- define "cluster.internal.workers.kubeadm.joinConfiguration" }}
-{{ with $machinePool := .nodePool }}
+{{- with $machinePool := .nodePool }}
 nodeRegistration:
   name: ${COREOS_EC2_HOSTNAME}
   kubeletExtraArgs:
@@ -26,5 +26,5 @@ nodeRegistration:
   {{- end }}
   {{- end }}
   {{- end }}
-{{ end }}
+{{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/workers/_helpers_joinconfiguration.tpl
+++ b/helm/cluster/templates/clusterapi/workers/_helpers_joinconfiguration.tpl
@@ -1,0 +1,30 @@
+{{/*
+  Named template that renders join configuration for worker nodes.
+
+  Template argument is a dictinary with the following values:
+    .name: Node pool name, a key from $.Values.global.nodepools map.
+    .config: node pool config, a value from $.Values.global.nodepools map.
+*/}}
+{{- define "cluster.internal.workers.kubeadm.joinConfiguration" }}
+{{ with $machinePool := .nodePool }}
+nodeRegistration:
+  name: ${COREOS_EC2_HOSTNAME}
+  kubeletExtraArgs:
+    cloud-provider: external
+    feature-gates: CronJobTimeZone=true
+    healthz-bind-address: 0.0.0.0
+    node-ip: ${COREOS_EC2_IPV4_LOCAL}
+    node-labels: role=worker,giantswarm.io/machine-pool={{ include "cluster.resource.name" $ }}-{{ $machinePool.name }},{{- join "," $machinePool.config.nodeLabels }}
+    v: "2"
+  {{- if $machinePool.config.nodeTaints }}
+  {{- if (gt (len $machinePool.config.nodeTaints) 0) }}
+  taints:
+  {{- range $machinePool.config.nodeTaints }}
+  - key: {{ .key | quote }}
+    value: {{ .value | quote }}
+    effect: {{ .effect | quote }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+{{ end }}
+{{- end }}

--- a/helm/cluster/templates/clusterapi/workers/_helpers_postkubeadmcommands.tpl
+++ b/helm/cluster/templates/clusterapi/workers/_helpers_postkubeadmcommands.tpl
@@ -1,0 +1,17 @@
+{{/*
+    Template cluster.internal.controlPlane.kubeadm.postKubeadmCommands defines extra commands to run
+    on worker nodes after kubeadm runs. It includes prefedined commands and custom commands
+    specified in Helm values field .Values.internal.workers.kubeadmConfig.postKubeadmCommands.
+*/}}
+{{- define "cluster.internal.workers.kubeadm.postKubeadmCommands" }}
+{{- include "cluster.internal.kubeadm.postKubeadmCommands" . }}
+{{- include "cluster.internal.workers.kubeadm.postKubeadmCommands.custom" . }}
+{{- end }}
+
+{{- define "cluster.internal.workers.kubeadm.postKubeadmCommands.custom" }}
+{{- if $.Values.internal.workers.kubeadmConfig }}
+{{- range $command := $.Values.internal.workers.kubeadmConfig.postKubeadmCommands }}
+- {{ $command }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/cluster/templates/clusterapi/workers/_helpers_prekubeadmcommands.tpl
+++ b/helm/cluster/templates/clusterapi/workers/_helpers_prekubeadmcommands.tpl
@@ -1,0 +1,17 @@
+{{/*
+    Template cluster.internal.workers.kubeadm.preKubeadmCommands defines extra commands to run
+    on worker nodes before kubeadm runs. It includes prefedined commands and custom commands
+    specified in Helm values field .Values.internal.workers.kubeadmConfig.preKubeadmCommands.
+*/}}
+{{- define "cluster.internal.workers.kubeadm.preKubeadmCommands" }}
+{{- include "cluster.internal.kubeadm.preKubeadmCommands" $ }}
+{{- include "cluster.internal.workers.kubeadm.preKubeadmCommands.custom" $ }}
+{{- end }}
+
+{{- define "cluster.internal.workers.kubeadm.preKubeadmCommands.custom" }}
+{{- if $.Values.internal.workers.kubeadmConfig }}
+{{- range $command := $.Values.internal.workers.kubeadmConfig.preKubeadmCommands }}
+- {{ $command }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/cluster/templates/clusterapi/workers/kubeadmconfig.yaml
+++ b/helm/cluster/templates/clusterapi/workers/kubeadmconfig.yaml
@@ -25,14 +25,7 @@ metadata:
 spec:
   format: ignition
   ignition:
-    containerLinuxConfig:
-      additionalConfig: |
-        systemd:
-          units:
-          {{ printf "- TODO" }}
-        storage:
-          directories:
-          {{ printf "- TODO" }}
+    {{- include "cluster.internal.workers.kubeadm.ignition" $ | indent 4 }}
   joinConfiguration:
     {{- include "cluster.internal.workers.kubeadm.joinConfiguration" (dict "Values" $.Values "Release" $.Release "nodePool" (dict "name" $nodePoolName "config" $nodePoolConfig)) | indent 4 }}
   preKubeadmCommands:

--- a/helm/cluster/templates/clusterapi/workers/kubeadmconfig.yaml
+++ b/helm/cluster/templates/clusterapi/workers/kubeadmconfig.yaml
@@ -32,6 +32,10 @@ spec:
   {{- include "cluster.internal.workers.kubeadm.preKubeadmCommands" $ | indent 2 }}
   postKubeadmCommands:
   {{- include "cluster.internal.workers.kubeadm.postKubeadmCommands" $ | indent 2 }}
+  users:
+  {{- include "cluster.internal.kubeadm.users" $ | indent 2 }}
+  files:
+  {{- include "cluster.internal.workers.kubeadm.files" $ | indent 2 }}
 ---
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/workers/kubeadmconfig.yaml
+++ b/helm/cluster/templates/clusterapi/workers/kubeadmconfig.yaml
@@ -1,0 +1,44 @@
+{{- if eq $.Values.internal.resourcesApi.nodePoolKind "MachinePool" }}
+{{- range $nodePoolName, $nodePoolConfig := $.Values.global.nodePools }}
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfig
+metadata:
+  annotations:
+    machine-pool.giantswarm.io/name: {{ include "cluster.resource.name" $ }}-{{ $nodePoolName }}
+    {{- include "cluster.annotations.custom" $ | indent 4 }}
+    {{- if $nodePoolConfig.annotations }}
+    {{- range $key, $val := $nodePoolConfig.annotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+    {{- end }}
+  labels:
+    {{- include "cluster.labels.common" $ | nindent 4 }}
+    {{- include "cluster.labels.custom" $ | indent 4 }}
+    giantswarm.io/machine-pool: {{ include "cluster.resource.name" $ }}-{{ $nodePoolName }}
+    {{- if $nodePoolConfig.labels }}
+    {{- range $key, $val := $nodePoolConfig.labels }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+    {{- end }}
+  name: {{ include "cluster.resource.name" $ }}-{{ $nodePoolName }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  format: ignition
+  ignition:
+    containerLinuxConfig:
+      additionalConfig: |
+        systemd:
+          units:
+          {{ printf "- TODO" }}
+        storage:
+          directories:
+          {{ printf "- TODO" }}
+  joinConfiguration:
+    {{- include "cluster.internal.workers.kubeadm.joinConfiguration" (dict "Values" $.Values "Release" $.Release "nodePool" (dict "name" $nodePoolName "config" $nodePoolConfig)) | indent 4 }}
+  preKubeadmCommands:
+  {{- include "cluster.internal.workers.kubeadm.preKubeadmCommands" $ | indent 2 }}
+  postKubeadmCommands:
+  {{- include "cluster.internal.workers.kubeadm.postKubeadmCommands" $ | indent 2 }}
+---
+{{- end }}
+{{- end }}

--- a/helm/cluster/templates/clusterapi/workers/machinepool.yaml
+++ b/helm/cluster/templates/clusterapi/workers/machinepool.yaml
@@ -1,0 +1,44 @@
+{{- if eq $.Values.internal.resourcesApi.nodePoolKind "MachinePool" }}
+{{- range $nodePoolName, $nodePoolConfig := $.Values.global.nodePools }}
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachinePool
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+    machine-pool.giantswarm.io/name: {{ include "cluster.resource.name" $ }}-{{ $nodePoolName }}
+    {{- include "cluster.annotations.custom" $ | indent 4 }}
+    {{- if $nodePoolConfig.annotations }}
+    {{- range $key, $val := $nodePoolConfig.annotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+    {{- end }}
+  labels:
+    {{- include "cluster.labels.common" $ | nindent 4 }}
+    {{- include "cluster.labels.custom" $ | indent 4 }}
+    giantswarm.io/machine-pool: {{ include "cluster.resource.name" $ }}-{{ $nodePoolName }}
+    {{- if $nodePoolConfig.labels }}
+    {{- range $key, $val := $nodePoolConfig.labels }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+    {{- end }}
+  name: {{ include "cluster.resource.name" $ }}-{{ $nodePoolName }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  clusterName: {{ include "cluster.resource.name" $ }}
+  replicas: {{ $nodePoolConfig.replicas }}
+  template:
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfig
+          name: {{ include "cluster.resource.name" $ }}-{{ $nodePoolName }}
+      clusterName: {{ include "cluster.resource.name" $ }}
+      infrastructureRef:
+        apiVersion: {{ $.Values.internal.resourcesApi.infrastructureMachinePool.group }}/{{ $.Values.internal.resourcesApi.infrastructureMachinePool.version }}
+        kind: {{ $.Values.internal.resourcesApi.infrastructureMachinePool.kind }}
+        name: {{ include "cluster.resource.name" $ }}-{{ $nodePoolName }}
+      version: {{ $.Values.internal.kubernetesVersion }}
+---
+{{- end }}
+{{- end }}

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1171,6 +1171,9 @@
                     "description": "Common kubeadm config for all nodes, including both control plane and workers.",
                     "additionalProperties": false,
                     "properties": {
+                        "ignition": {
+                            "$ref": "#/$defs/ignition"
+                        },
                         "preKubeadmCommands": {
                             "$ref": "#/$defs/preKubeadmCommands"
                         },

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -394,6 +394,22 @@
             "required": [
                 "name"
             ]
+        },
+        "preKubeadmCommands": {
+            "type": "array",
+            "title": "Pre-kubeadm commands",
+            "description": "Extra commands to run before kubeadm runs.",
+            "items": {
+                "type": "string"
+            }
+        },
+        "postKubeadmCommands": {
+            "type": "array",
+            "title": "Post-kubeadm commands",
+            "description": "Extra commands to run after kubeadm runs.",
+            "items": {
+                "type": "string"
+            }
         }
     },
     "type": "object",
@@ -1100,6 +1116,12 @@
                                             "default": {}
                                         }
                                     }
+                                },
+                                "preKubeadmCommands": {
+                                    "$ref": "#/$defs/preKubeadmCommands"
+                                },
+                                "postKubeadmCommands": {
+                                    "$ref": "#/$defs/postKubeadmCommands"
                                 }
                             },
                             "required": [
@@ -1146,24 +1168,14 @@
                 "kubeadmConfig": {
                     "type": "object",
                     "title": "Kubeadm config",
-                    "description": "Kubeadm config for all control plane and worker nodes.",
+                    "description": "Common kubeadm config for all nodes, including both control plane and workers.",
                     "additionalProperties": false,
                     "properties": {
                         "preKubeadmCommands": {
-                            "type": "array",
-                            "title": "Pre-kubeadm commands",
-                            "description": "Extra commands to run before kubeadm runs.",
-                            "items": {
-                                "type": "string"
-                            }
+                            "$ref": "#/$defs/preKubeadmCommands"
                         },
                         "postKubeadmCommands": {
-                            "type": "array",
-                            "title": "Post-kubeadm commands",
-                            "description": "Extra commands to run after kubeadm runs.",
-                            "items": {
-                                "type": "string"
-                            }
+                            "$ref": "#/$defs/postKubeadmCommands"
                         }
                     }
                 },
@@ -1220,6 +1232,33 @@
                             ]
                         }
                     ]
+                },
+                "workers": {
+                    "type": "object",
+                    "title": "Internal workers configuration",
+                    "additionalProperties": false,
+                    "properties": {
+                        "kubeadmConfig": {
+                            "type": "object",
+                            "title": "Kubeadm config",
+                            "description": "Configuration of workers nodes.",
+                            "additionalProperties": false,
+                            "properties": {
+                                "ignition": {
+                                    "$ref": "#/$defs/ignition"
+                                },
+                                "preKubeadmCommands": {
+                                    "$ref": "#/$defs/preKubeadmCommands"
+                                },
+                                "postKubeadmCommands": {
+                                    "$ref": "#/$defs/postKubeadmCommands"
+                                }
+                            },
+                            "required": [
+                                "ignition"
+                            ]
+                        }
+                    }
                 }
             },
             "required":[

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -72,6 +72,86 @@
                 }
             }
         },
+        "infrastructureCluster": {
+            "type": "object",
+            "title": "Infrastructure cluster",
+            "description": "Group, version and kind of provider-specific infrastructure cluster resource.",
+            "additionalProperties": false,
+            "required": [
+                "group",
+                "version",
+                "kind"
+            ],
+            "properties": {
+                "group": {
+                    "type": "string",
+                    "title": "API group",
+                    "examples": [
+                        "infrastructure.cluster.x-k8s.io"
+                    ]
+                },
+                "kind": {
+                    "type": "string",
+                    "title": "API kind",
+                    "examples": [
+                        "AWSCluster",
+                        "AzureCluster",
+                        "VCDCluster",
+                        "VSphereCluster"
+                    ]
+                },
+                "version": {
+                    "type": "string",
+                    "title": "API version",
+                    "examples": [
+                        "v1alpha1",
+                        "v1beta1",
+                        "v1beta2",
+                        "v1",
+                        "v2"
+                    ]
+                }
+            }
+        },
+        "infrastructureMachinePool": {
+            "type": "object",
+            "title": "Infrastructure MachinePool",
+            "description": "Group, version and kind of provider-specific infrastructure MachinePool resource.",
+            "additionalProperties": false,
+            "required": [
+                "group",
+                "version",
+                "kind"
+            ],
+            "properties": {
+                "group": {
+                    "type": "string",
+                    "title": "API group",
+                    "examples": [
+                        "infrastructure.cluster.x-k8s.io"
+                    ]
+                },
+                "kind": {
+                    "type": "string",
+                    "title": "API kind",
+                    "examples": [
+                        "AWSMachinePool",
+                        "AzureMachinePool"
+                    ]
+                },
+                "version": {
+                    "type": "string",
+                    "title": "API version",
+                    "examples": [
+                        "v1alpha1",
+                        "v1beta1",
+                        "v1beta2",
+                        "v1",
+                        "v2"
+                    ]
+                }
+            }
+        },
         "ignition": {
             "type": "object",
             "title": "Ignition",
@@ -669,6 +749,93 @@
                         "organization",
                         "servicePriority"
                     ]
+                },
+                "nodePools": {
+                    "type": "object",
+                    "title": "Node pools",
+                    "patternProperties": {
+                        "^[a-z0-9]{5,10}$": {
+                            "type": "object",
+                            "title": "Node pool",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "title": "Annotations",
+                                    "description": "These annotations are added to all Kubernetes resources defining this node pool.",
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                        "^([a-zA-Z0-9\\.-]{1,253}\/)?[a-zA-Z0-9\\._-]{1,63}$": {
+                                            "type": "string",
+                                            "title": "Annotation",
+                                            "minLength": 1
+                                        }
+                                    }
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "title": "Labels",
+                                    "description": "These labels are added to all Kubernetes resources defining this node pool.",
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                        "^[a-zA-Z0-9/\\._-]+$": {
+                                            "type": "string",
+                                            "title": "Label",
+                                            "maxLength": 63,
+                                            "minLength": 0,
+                                            "pattern": "^[a-zA-Z0-9\\._-]+$"
+                                        }
+                                    }
+                                },
+                                "nodeLabels": {
+                                    "type": "object",
+                                    "title": "Node labels",
+                                    "description": "Labels that are passed to kubelet argument 'node-labels'.",
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    }
+                                },
+                                "nodeTaints": {
+                                    "type": "array",
+                                    "title": "Custom node taints",
+                                    "items": {
+                                        "type": "object",
+                                        "required": [
+                                            "effect",
+                                            "key",
+                                            "value"
+                                        ],
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "effect": {
+                                                "type": "string",
+                                                "title": "Effect",
+                                                "enum": [
+                                                    "NoSchedule",
+                                                    "PreferNoSchedule",
+                                                    "NoExecute"
+                                                ]
+                                            },
+                                            "key": {
+                                                "type": "string",
+                                                "title": "Key"
+                                            },
+                                            "value": {
+                                                "type": "string",
+                                                "title": "Value"
+                                            }
+                                        }
+                                    }
+                                },
+                                "replicas": {
+                                    "type": "integer",
+                                    "title": "Replicas",
+                                    "description": "The number of node pool nodes.",
+                                    "minimum": 0,
+                                    "maximum": 1000
+                                }
+                            }
+                        }
+                    }
                 }
             },
             "required": [
@@ -1013,43 +1180,45 @@
                     "title": "Paused",
                     "default": false
                 },
-                "providerSpecific": {
+                "resourcesApi": {
                     "type": "object",
-                    "title": "Internal provider specific configuration",
-                    "additionalProperties": false,
-                    "properties": {
-                        "resources": {
-                            "type": "object",
-                            "title": "Resources configuration",
-                            "description": "GVK and other configuration for provider-specific infrastructure resources.",
+                    "title": "Resources API",
+                    "description": "Group, version and kind configuration that is required and used by a specific Cluster API provider.",
+                    "oneOf": [
+                        {
                             "additionalProperties": false,
                             "properties": {
-                                "cluster": {
-                                    "type": "object",
-                                    "title": "Provider specific cluster resource",
-                                    "properties": {
-                                        "api": {
-                                            "$ref": "#/$defs/gvk"
-                                        }
-                                    },
-                                    "default":{
-                                        "api": {
-                                            "group": "infrastructure.cluster.x-k8s.io",
-                                            "version": "v1beta1"
-                                        }
-                                    },
-                                    "required": [
-                                        "api"
-                                    ]
+                                "infrastructureCluster": {
+                                    "$ref": "#/$defs/infrastructureCluster"
+                                },
+                                "infrastructureMachinePool": {
+                                    "$ref": "#/$defs/infrastructureMachinePool"
+                                },
+                                "nodePoolKind": {
+                                    "const": "MachinePool"
                                 }
                             },
                             "required": [
-                                "cluster"
+                                "infrastructureCluster",
+                                "infrastructureMachinePool",
+                                "nodePoolKind"
+                            ]
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "infrastructureCluster": {
+                                    "$ref": "#/$defs/infrastructureCluster"
+                                },
+                                "nodePoolKind": {
+                                    "const": "MachineDeployment"
+                                }
+                            },
+                            "required": [
+                                "infrastructureCluster",
+                                "nodePoolKind"
                             ]
                         }
-                    },
-                    "required": [
-                        "resources"
                     ]
                 }
             },
@@ -1059,7 +1228,7 @@
                 "controlPlane",
                 "kubernetesVersion",
                 "paused",
-                "providerSpecific"
+                "resourcesApi"
             ]
         }
     }

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -43,11 +43,6 @@ internal:
           group: controlplane.cluster.x-k8s.io
           kind: KubeadmControlPlane
           version: v1beta1
+  kubeadmConfig: {}
   kubernetesVersion: 1.24.10
   paused: false
-  providerSpecific:
-    resources:
-      cluster:
-        api:
-          group: infrastructure.cluster.x-k8s.io
-          version: v1beta1

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -43,7 +43,12 @@ internal:
           group: controlplane.cluster.x-k8s.io
           kind: KubeadmControlPlane
           version: v1beta1
-  kubeadmConfig: {}
+  kubeadmConfig:
+    ignition:
+      containerLinuxConfig:
+        additionalConfig:
+          storage: {}
+          systemd: {}
   kubernetesVersion: 1.24.10
   paused: false
   workers:

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -46,3 +46,10 @@ internal:
   kubeadmConfig: {}
   kubernetesVersion: 1.24.10
   paused: false
+  workers:
+    kubeadmConfig:
+      ignition:
+        containerLinuxConfig:
+          additionalConfig:
+            storage: {}
+            systemd: {}


### PR DESCRIPTION
### What does this PR do?

This PR adds machine pool resources and all other resources that are required to correctly deploy machine pools (more details here https://github.com/giantswarm/roadmap/issues/2742).

### What is the effect of this change to users?

Using this `cluster-$provider` apps will mean that very large portion of machine pools functionality is moved to a common chart.

Common codebase across all providers for (just the highlights):
- Operating system: starting to use this in onprem providers will mean that those providers switch from Ubuntu to Flatcar.
- Config of Kubernetes components: kubelet
- containerd config
- Commands that run before/after kubeadm on nodes
- Kubernetes version

### How does it look like?

Rendered by CI in one of the next PRs where the CI is fixed:

```
    ---
    # Source: cluster/templates/clusterapi/workers/kubeadmconfig.yaml
    apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
    kind: KubeadmConfig
    metadata:
      name: awesome-def00
      namespace: org-giantswarm
      annotations:
        machine-pool.giantswarm.io/name: awesome-def00
        important-cluster-value: 1000
        robots-need-this-in-the-cluster: eW91IGNhbm5vdCByZWFkIHRoaXMsIGJ1dCByb2JvdHMgY2FuCg==
        for-robots-in-nodepool: cm9ib3RzIGFyZSBvcGVyYXRpbmcgb24gdGhpcyBub2RlIHBvb2wK
      labels:
        app: cluster
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/version: 0.1.0-dev
        application.giantswarm.io/team: turtles
        giantswarm.io/cluster: awesome
        giantswarm.io/organization: giantswarm
        giantswarm.io/service-priority: highest
        cluster.x-k8s.io/cluster-name: awesome
        cluster.x-k8s.io/watch-filter: capi
        helm.sh/chart: cluster-0.1.0-dev
        another-cluster-label: label-2
        some-cluster-label: label-1
        giantswarm.io/machine-pool: awesome-def00
        nodepool-workload-type: ai
    spec:
      format: ignition
      ignition:
        containerLinuxConfig:
          additionalConfig: |
            systemd:
              units:      
              - name: kubeadm.service
                dropins:
                - name: 10-flatcar.conf
                  contents: |
                    [Unit]
                    # kubeadm must run after coreos-metadata populated /run/metadata directory.
                    Requires=coreos-metadata.service
                    After=coreos-metadata.service
                    [Service]
                    # Ensure kubeadm service has access to kubeadm binary in /opt/bin on Flatcar.
                    Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/bin
                    # To make metadata environment variables available for pre-kubeadm commands.
                    EnvironmentFile=/run/metadata/*
              - name: example1.service
                enabled: false
                mask: false
                contents: |
                  # Contents goes here
                dropins:
                - name: hello.conf
                  contents: |
                    # Contents goes here
              - name: example2.service
                enabled: false
                mask: false
                contents: |
                  # Multi-line
                  # contents goes here
                dropins:
                - name: hello1.conf
                  contents: |
                    # Multi-line
                    # contents goes here
                - name: hello2.conf
                  contents: |
                    # Multi-line
                    # contents goes here
              - name: example1-workers.service
                enabled: false
                mask: false
                contents: |
                  # Contents goes here
                dropins:
                - name: hello.conf
                  contents: |
                    # Contents goes here
              - name: example2-workers.service
                enabled: false
                mask: false
                contents: |
                  # Multi-line
                  # contents goes here
                dropins:
                - name: hello1-workers.conf
                  contents: |
                    # Multi-line
                    # contents goes here
                - name: hello2-workers.conf
                  contents: |
                    # Multi-line
                    # contents goes here
            storage:
              directories:      
              - path: /var/lib/kubelet/temporary/stuff
                overwrite: true
                filesystem: kubelet
                mode: 750
                user:
                  id: 12345
                  name: giantswarm
                group:
                  id: 23456
                  name: giantswarm
              - path: /var/lib/kubelet
                mode: 750
              - path: /var/lib/kubelet/temporary/stuff/workers
                overwrite: true
                filesystem: kubelet
                mode: 750
                user:
                  id: 12345
                  name: giantswarm
                group:
                  id: 23456
                  name: giantswarm
            
      joinConfiguration:
        nodeRegistration:
          name: ${COREOS_EC2_HOSTNAME}
          kubeletExtraArgs:
            cloud-provider: external
            feature-gates: CronJobTimeZone=true
            healthz-bind-address: 0.0.0.0
            node-ip: ${COREOS_EC2_IPV4_LOCAL}
            node-labels: "role=worker,giantswarm.io/machine-pool=awesome-def00,map[workload-type:ai]"
            v: 2
          taints:
          - key: supernodepool
            value: hello
            effect: NoSchedule
      preKubeadmCommands:
      - "envsubst < /etc/kubeadm.yml > /etc/kubeadm.yml.tmp"
      - "mv /etc/kubeadm.yml.tmp /etc/kubeadm.yml"
      - "systemctl restart sshd"
      - "export HTTP_PROXY=http://proxy.giantswarm.io"
      - "export HTTPS_PROXY=https://proxy.giantswarm.io"
      - "export NO_PROXY="127.0.0.1,localhost,svc,local,awesome.example.gigantic.io,172.31.0.0/16,100.64.0.0/12,elb.amazonaws.com,169.254.169.254,some.noproxy.address.giantswarm.io,another.noproxy.address.giantswarm.io""
      - "export http_proxy=http://proxy.giantswarm.io"
      - "export https_proxy=https://proxy.giantswarm.io"
      - "export no_proxy="127.0.0.1,localhost,svc,local,awesome.example.gigantic.io,172.31.0.0/16,100.64.0.0/12,elb.amazonaws.com,169.254.169.254,some.noproxy.address.giantswarm.io,another.noproxy.address.giantswarm.io""
      - "echo "hello all nodes before kubeadm""
      - "echo "all cluster nodes before kubeadm""
      - "echo "hello workers before kubeadm""
      - "echo "cluster workers before kubeadm""
      postKubeadmCommands:
      - "/bin/sh /opt/kubelet-config.sh"
      - "echo "hello all nodes after kubeadm""
      - "echo "all cluster nodes after kubeadm""
      - "echo "hello workers after kubeadm""
      - "echo "cluster workers after kubeadm""
      users:
      - name: giantswarm
        groups: sudo
        sudo: "ALL=(ALL) NOPASSWD:ALL"
      files:
      - path: /etc/sysctl.d/hardening.conf
        permissions: 0644
        encoding: base64
        content: ZnMuaW5vdGlmeS5tYXhfdXNlcl93YXRjaGVzID0gMTYzODQKZnMuaW5vdGlmeS5tYXhfdXNlcl9pbnN0YW5jZXMgPSA4MTkyCmtlcm5lbC5rcHRyX3Jlc3RyaWN0ID0gMgprZXJuZWwuc3lzcnEgPSAwCm5ldC5pcHY0LmNvbmYuYWxsLmxvZ19tYXJ0aWFucyA9IDEKbmV0LmlwdjQuY29uZi5hbGwuc2VuZF9yZWRpcmVjdHMgPSAwCm5ldC5pcHY0LmNvbmYuZGVmYXVsdC5hY2NlcHRfcmVkaXJlY3RzID0gMApuZXQuaXB2NC5jb25mLmRlZmF1bHQubG9nX21hcnRpYW5zID0gMQpuZXQuaXB2NC50Y3BfdGltZXN0YW1wcyA9IDAKbmV0LmlwdjYuY29uZi5hbGwuYWNjZXB0X3JlZGlyZWN0cyA9IDAKbmV0LmlwdjYuY29uZi5kZWZhdWx0LmFjY2VwdF9yZWRpcmVjdHMgPSAwCiMgSW5jcmVhc2VkIG1tYXBmcyBiZWNhdXNlIHNvbWUgYXBwbGljYXRpb25zLCBsaWtlIEVTLCBuZWVkIGhpZ2hlciBsaW1pdCB0byBzdG9yZSBkYXRhIHByb3Blcmx5CnZtLm1heF9tYXBfY291bnQgPSAyNjIxNDQKIyBSZXNlcnZlZCB0byBhdm9pZCBjb25mbGljdHMgd2l0aCBrdWJlLWFwaXNlcnZlciwgd2hpY2ggYWxsb2NhdGVzIHdpdGhpbiB0aGlzIHJhbmdlCm5ldC5pcHY0LmlwX2xvY2FsX3Jlc2VydmVkX3BvcnRzPTMwMDAwLTMyNzY3Cm5ldC5pcHY0LmNvbmYuYWxsLnJwX2ZpbHRlciA9IDEKbmV0LmlwdjQuY29uZi5hbGwuYXJwX2lnbm9yZSA9IDEKbmV0LmlwdjQuY29uZi5hbGwuYXJwX2Fubm91bmNlID0gMgoKIyBUaGVzZSBhcmUgcmVxdWlyZWQgZm9yIHRoZSBrdWJlbGV0ICctLXByb3RlY3Qta2VybmVsLWRlZmF1bHRzJyBmbGFnCiMgU2VlIGh0dHBzOi8vZ2l0aHViLmNvbS9naWFudHN3YXJtL2dpYW50c3dhcm0vaXNzdWVzLzEzNTg3CnZtLm92ZXJjb21taXRfbWVtb3J5PTEKa2VybmVsLnBhbmljPTEwCmtlcm5lbC5wYW5pY19vbl9vb3BzPTEK
      - path: /etc/ssh/trusted-user-ca-keys.pem
        permissions: 0600
        encoding: base64
        content: c3NoLWVkMjU1MTkgQUFBQUMzTnphQzFsWkRJMU5URTVBQUFBSU00Y3ZaMDFmTG1POWNKYldVajdzZkYrTmhFQ2d5K0NsMGJhelNyWlg3c1UgdmF1bHQtY2FAdmF1bHQub3BlcmF0aW9ucy5naWFudHN3YXJtLmlvCg==
      - path: /etc/ssh/sshd_config
        permissions: 0600
        encoding: base64
        content: IyBVc2UgbW9zdCBkZWZhdWx0cyBmb3Igc3NoZCBjb25maWd1cmF0aW9uLgpTdWJzeXN0ZW0gc2Z0cCBpbnRlcm5hbC1zZnRwCkNsaWVudEFsaXZlSW50ZXJ2YWwgMTgwClVzZUROUyBubwpVc2VQQU0geWVzClByaW50TGFzdExvZyBubyAjIGhhbmRsZWQgYnkgUEFNClByaW50TW90ZCBubyAjIGhhbmRsZWQgYnkgUEFNCiMgTm9uIGRlZmF1bHRzICgjMTAwKQpDbGllbnRBbGl2ZUNvdW50TWF4IDIKUGFzc3dvcmRBdXRoZW50aWNhdGlvbiBubwpUcnVzdGVkVXNlckNBS2V5cyAvZXRjL3NzaC90cnVzdGVkLXVzZXItY2Eta2V5cy5wZW0KTWF4QXV0aFRyaWVzIDUKTG9naW5HcmFjZVRpbWUgNjAKQWxsb3dUY3BGb3J3YXJkaW5nIG5vCkFsbG93QWdlbnRGb3J3YXJkaW5nIG5vCkNBU2lnbmF0dXJlQWxnb3JpdGhtcyBlY2RzYS1zaGEyLW5pc3RwMjU2LGVjZHNhLXNoYTItbmlzdHAzODQsZWNkc2Etc2hhMi1uaXN0cDUyMSxzc2gtZWQyNTUxOSxyc2Etc2hhMi01MTIscnNhLXNoYTItMjU2LHNzaC1yc2EK
      - path: /etc/containerd/config.toml
        permissions: 0644
        contentFrom:
          secret:
            name: awesome-registry-configuration
            key: registry-config.toml
      - path: /etc/systemd/system/containerd.service.d/http-proxy.conf
        permissions: 0644
        encoding: base64
        content: W1NlcnZpY2VdCkVudmlyb25tZW50PSJIVFRQX1BST1hZPWh0dHA6Ly9wcm94eS5naWFudHN3YXJtLmlvIgpFbnZpcm9ubWVudD0iSFRUUFNfUFJPWFk9aHR0cHM6Ly9wcm94eS5naWFudHN3YXJtLmlvIgpFbnZpcm9ubWVudD0iTk9fUFJPWFk9MTI3LjAuMC4xLGxvY2FsaG9zdCxzdmMsbG9jYWwsYXdlc29tZS5leGFtcGxlLmdpZ2FudGljLmlvLDE3Mi4zMS4wLjAvMTYsMTAwLjY0LjAuMC8xMixlbGIuYW1hem9uYXdzLmNvbSwxNjkuMjU0LjE2OS4yNTQsc29tZS5ub3Byb3h5LmFkZHJlc3MuZ2lhbnRzd2FybS5pbyxhbm90aGVyLm5vcHJveHkuYWRkcmVzcy5naWFudHN3YXJtLmlvIgpFbnZpcm9ubWVudD0iaHR0cF9wcm94eT1odHRwOi8vcHJveHkuZ2lhbnRzd2FybS5pbyIKRW52aXJvbm1lbnQ9Imh0dHBzX3Byb3h5PWh0dHBzOi8vcHJveHkuZ2lhbnRzd2FybS5pbyIKRW52aXJvbm1lbnQ9Im5vX3Byb3h5PTEyNy4wLjAuMSxsb2NhbGhvc3Qsc3ZjLGxvY2FsLGF3ZXNvbWUuZXhhbXBsZS5naWdhbnRpYy5pbywxNzIuMzEuMC4wLzE2LDEwMC42NC4wLjAvMTIsZWxiLmFtYXpvbmF3cy5jb20sMTY5LjI1NC4xNjkuMjU0LHNvbWUubm9wcm94eS5hZGRyZXNzLmdpYW50c3dhcm0uaW8sYW5vdGhlci5ub3Byb3h5LmFkZHJlc3MuZ2lhbnRzd2FybS5pbyIK
      - path: /etc/systemd/system/kubelet.service.d/http-proxy.conf
        permissions: 0644
        encoding: base64
        content: W1NlcnZpY2VdCkVudmlyb25tZW50PSJIVFRQX1BST1hZPWh0dHA6Ly9wcm94eS5naWFudHN3YXJtLmlvIgpFbnZpcm9ubWVudD0iSFRUUFNfUFJPWFk9aHR0cHM6Ly9wcm94eS5naWFudHN3YXJtLmlvIgpFbnZpcm9ubWVudD0iTk9fUFJPWFk9MTI3LjAuMC4xLGxvY2FsaG9zdCxzdmMsbG9jYWwsYXdlc29tZS5leGFtcGxlLmdpZ2FudGljLmlvLDE3Mi4zMS4wLjAvMTYsMTAwLjY0LjAuMC8xMixlbGIuYW1hem9uYXdzLmNvbSwxNjkuMjU0LjE2OS4yNTQsc29tZS5ub3Byb3h5LmFkZHJlc3MuZ2lhbnRzd2FybS5pbyxhbm90aGVyLm5vcHJveHkuYWRkcmVzcy5naWFudHN3YXJtLmlvIgpFbnZpcm9ubWVudD0iaHR0cF9wcm94eT1odHRwOi8vcHJveHkuZ2lhbnRzd2FybS5pbyIKRW52aXJvbm1lbnQ9Imh0dHBzX3Byb3h5PWh0dHBzOi8vcHJveHkuZ2lhbnRzd2FybS5pbyIKRW52aXJvbm1lbnQ9Im5vX3Byb3h5PTEyNy4wLjAuMSxsb2NhbGhvc3Qsc3ZjLGxvY2FsLGF3ZXNvbWUuZXhhbXBsZS5naWdhbnRpYy5pbywxNzIuMzEuMC4wLzE2LDEwMC42NC4wLjAvMTIsZWxiLmFtYXpvbmF3cy5jb20sMTY5LjI1NC4xNjkuMjU0LHNvbWUubm9wcm94eS5hZGRyZXNzLmdpYW50c3dhcm0uaW8sYW5vdGhlci5ub3Byb3h5LmFkZHJlc3MuZ2lhbnRzd2FybS5pbyIK
    
    ---
    # Source: cluster/templates/clusterapi/workers/machinepool.yaml
    apiVersion: cluster.x-k8s.io/v1beta1
    kind: MachinePool
    metadata:
      annotations:
        helm.sh/resource-policy: keep
        machine-pool.giantswarm.io/name: awesome-def00
        important-cluster-value: 1000
        robots-need-this-in-the-cluster: eW91IGNhbm5vdCByZWFkIHRoaXMsIGJ1dCByb2JvdHMgY2FuCg==
        for-robots-in-nodepool: cm9ib3RzIGFyZSBvcGVyYXRpbmcgb24gdGhpcyBub2RlIHBvb2wK
      labels:
        app: cluster
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/version: 0.1.0-dev
        application.giantswarm.io/team: turtles
        giantswarm.io/cluster: awesome
        giantswarm.io/organization: giantswarm
        giantswarm.io/service-priority: highest
        cluster.x-k8s.io/cluster-name: awesome
        cluster.x-k8s.io/watch-filter: capi
        helm.sh/chart: cluster-0.1.0-dev
        another-cluster-label: label-2
        some-cluster-label: label-1
        giantswarm.io/machine-pool: awesome-def00
        nodepool-workload-type: ai
      name: awesome-def00
      namespace: org-giantswarm
    spec:
      clusterName: awesome
      replicas: 3
      template:
        spec:
          bootstrap:
            configRef:
              apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
              kind: KubeadmConfig
              name: awesome-def00
          clusterName: awesome
          infrastructureRef:
            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
            kind: AWSMachinePool
            name: awesome-def00
          version: 1.24.10
```

### Any background context you can provide?

https://github.com/giantswarm/roadmap/issues/2742