### PR TITLE
Add MachineHealthCheck resource

### DIFF
--- a/helm/cluster/templates/clusterapi/controlplane/machinehealthcheck.yaml
+++ b/helm/cluster/templates/clusterapi/controlplane/machinehealthcheck.yaml
@@ -1,0 +1,35 @@
+{{- if $.Values.global.controlPlane.machineHealthCheck.enabled }}
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  annotations:
+    {{- if $.Values.global.metadata.annotations }}
+    {{- range $key, $val := $.Values.global.metadata.annotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+    {{- end }}
+  labels:
+    {{- include "cluster.labels.common" . | nindent 4 }}
+    {{- if $.Values.global.metadata.labels }}
+    {{- range $key, $val := $.Values.global.metadata.labels }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+    {{- end }}
+  name: {{ include "cluster.resource.name" . }}-control-plane
+  namespace: {{ $.Release.Namespace }}
+spec:
+  clusterName: {{ include "cluster.resource.name" $ }}
+  maxUnhealthy: {{ $.Values.global.controlPlane.machineHealthCheck.maxUnhealthy }}
+  nodeStartupTimeout: {{ $.Values.global.controlPlane.machineHealthCheck.nodeStartupTimeout }}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: {{ include "cluster.resource.name" $ }}
+      cluster.x-k8s.io/control-plane: ""
+  unhealthyConditions:
+  - type: Ready
+    status: Unknown
+    timeout: {{ $.Values.global.controlPlane.machineHealthCheck.unhealthyUnknownTimeout }}
+  - type: Ready
+    status: "False"
+    timeout: {{ $.Values.global.controlPlane.machineHealthCheck.unhealthyNotReadyTimeout }}
+{{- end }}

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -560,6 +560,53 @@
                         "customNodeTaints": {
                             "$ref": "#/$defs/customNodeTaints"
                         },
+                        "machineHealthCheck": {
+                            "type": "object",
+                            "title": "Machine health check",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "title": "Enable",
+                                    "default": true
+                                },
+                                "maxUnhealthy": {
+                                    "type": "string",
+                                    "title": "Maximum unhealthy nodes",
+                                    "examples": [
+                                        "40%"
+                                    ],
+                                    "default": "40%"
+                                },
+                                "nodeStartupTimeout": {
+                                    "type": "string",
+                                    "title": "Node startup timeout",
+                                    "description": "Determines how long a machine health check should wait for a node to join the cluster, before considering a machine unhealthy.",
+                                    "examples": [
+                                        "10m",
+                                        "100s"
+                                    ],
+                                    "default": "8m0s"
+                                },
+                                "unhealthyNotReadyTimeout": {
+                                    "type": "string",
+                                    "title": "Timeout for ready",
+                                    "description": "If a node is not in condition 'Ready' after this timeout, it will be considered unhealthy.",
+                                    "examples": [
+                                        "300s"
+                                    ],
+                                    "default": "10m0s"
+                                },
+                                "unhealthyUnknownTimeout": {
+                                    "type": "string",
+                                    "title": "Timeout for unknown condition",
+                                    "description": "If a node is in 'Unknown' condition after this timeout, it will be considered unhealthy.",
+                                    "examples": [
+                                        "300s"
+                                    ],
+                                    "default": "10m0s"
+                                }
+                            }
+                        },
                         "oidc": {
                             "title": "OIDC authentication",
                             "oneOf": [
@@ -611,6 +658,7 @@
                         }
                     },
                     "required": [
+                        "machineHealthCheck",
                         "replicas"
                     ]
                 },

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -16,6 +16,12 @@ global:
         cidrBlocks:
           - 172.31.0.0/16
   controlPlane:
+    machineHealthCheck:
+      enabled: true
+      maxUnhealthy: 40%
+      nodeStartupTimeout: 8m0s
+      unhealthyNotReadyTimeout: 10m0s
+      unhealthyUnknownTimeout: 10m0s
     replicas: 3
   metadata:
     servicePriority: highest


### PR DESCRIPTION
### What does this PR do?

This PR adds MachineHealthCheck resource (more details here https://github.com/giantswarm/roadmap/issues/2742).

The MachineHealthCheck resource has been ported as is from `cluster-aws`, with just Helm values being adjusted for the `cluster` chart.

### What is the effect of this change to users?

`cluster-$provider` apps that use `cluster` chart will be able to use MachineHealthCheck for control plane nodes.

### How does it look like?

```yaml
    # Source: cluster/templates/clusterapi/controlplane/machinehealthcheck.yaml
    apiVersion: cluster.x-k8s.io/v1beta1
    kind: MachineHealthCheck
    metadata:
      annotations:
        important-cluster-value: 1000
        robots-need-this-in-the-cluster: eW91IGNhbm5vdCByZWFkIHRoaXMsIGJ1dCByb2JvdHMgY2FuCg==
      labels:
        app: cluster
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/version: 0.1.0-dev
        application.giantswarm.io/team: turtles
        giantswarm.io/cluster: awesome
        giantswarm.io/organization: giantswarm
        giantswarm.io/service-priority: highest
        cluster.x-k8s.io/cluster-name: awesome
        cluster.x-k8s.io/watch-filter: capi
        helm.sh/chart: cluster-0.1.0-dev
        another-cluster-label: label-2
        some-cluster-label: label-1
      name: awesome-control-plane
      namespace: org-giantswarm
    spec:
      clusterName: awesome
      maxUnhealthy: 40%!(NOVERB)
      nodeStartupTimeout: 8m0s
      selector:
        matchLabels:
          cluster.x-k8s.io/cluster-name: awesome
          cluster.x-k8s.io/control-plane: 
      unhealthyConditions:
      - type: Ready
        status: Unknown
        timeout: 10m0s
      - type: Ready
        status: False
        timeout: 10m0s
```

### Any background context you can provide?

https://github.com/giantswarm/roadmap/issues/2742

