### PR TITLE
Add bastion resources

### DIFF
--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -158,6 +158,7 @@ internal:
       timesyncd:
         npt:
         - 169.254.169.123
+  hashSalt: salty-1
   kubeadmConfig:
     ignition:
       containerLinuxConfig:
@@ -233,6 +234,12 @@ internal:
       group: infrastructure.cluster.x-k8s.io
       version: v1beta1
       kind: AWSMachinePool
+    bastion:
+      infrastructureMachineTemplate:
+        group: infrastructure.cluster.x-k8s.io
+        version: v1beta1
+        kind: AWSMachineTemplate
+      infrastructureMachineTemplateSpecTemplateName: "cluster.test.bastion.machineTemplate.spec"
   workers:
     kubeadmConfig:
       ignition:

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -59,6 +59,24 @@ global:
             password: super_secret_password
         - endpoint: giantswarm.azurecr.io
 internal:
+  bastion:
+    kubeadmConfig:
+      ignition:
+        containerLinuxConfig:
+          additionalConfig:
+            systemd:
+              units:
+              - name: example1-bastion.service
+                enabled: false
+                mask: false
+                contents: |
+                  # Contents goes here
+                dropins:
+                - name: hello-bastion.conf
+                  contents: |
+                    # Contents goes here
+      preKubeadmCommands:
+      - sleep infinity
   controlPlane:
     kubeadmConfig:
       clusterConfiguration:

--- a/helm/cluster/files/etc/ssh/sshd_config_bastion
+++ b/helm/cluster/files/etc/ssh/sshd_config_bastion
@@ -1,0 +1,18 @@
+# Use most defaults for sshd configuration.
+Subsystem sftp internal-sftp
+ClientAliveInterval 180
+UseDNS no
+UsePAM yes
+PrintLastLog no # handled by PAM
+PrintMotd no # handled by PAM
+# Non defaults (#100)
+ClientAliveCountMax 2
+PasswordAuthentication no
+TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem
+MaxAuthTries 5
+LoginGraceTime 60
+AllowTcpForwarding yes
+AllowAgentForwarding yes
+CASignatureAlgorithms ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa
+Port 30000
+Port 22

--- a/helm/cluster/templates/_helpers.tpl
+++ b/helm/cluster/templates/_helpers.tpl
@@ -55,3 +55,16 @@ helm.sh/chart: {{ include "cluster.chart.nameAndVersion" . | quote }}
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Hash function based on data provided
+Expects two arguments (as a `dict`) E.g.
+  {{ include "hash" (dict "data" . "salt" $.Values.internal.hasSalt) }}
+Where `data` is the data to hash and `global` is the top level scope.
+*/}}
+{{- define "cluster.data.hash" -}}
+{{- $data := mustToJson .data | toString  }}
+{{- $salt := "" }}
+{{- if .salt }}{{ $salt = .salt}}{{end}}
+{{- (printf "%s%s" $data $salt) | quote | sha1sum | trunc 8 }}
+{{- end -}}

--- a/helm/cluster/templates/bastion/_helpers.tpl
+++ b/helm/cluster/templates/bastion/_helpers.tpl
@@ -1,0 +1,9 @@
+{{- define "cluster.test.bastion.machineTemplate.spec" -}}
+template:
+  metadata:
+    cluster.x-k8s.io/role: bastion
+    {{- include "cluster.labels.common" $ | nindent 4 }}
+  spec:
+    foo: 2
+    bar: "b"
+{{- end -}}

--- a/helm/cluster/templates/bastion/_helpers_files.tpl
+++ b/helm/cluster/templates/bastion/_helpers_files.tpl
@@ -1,0 +1,14 @@
+{{- define "cluster.internal.bastion.kubeadm.files" }}
+{{- include "cluster.internal.bastion.kubeadm.files.ssh" $ }}
+{{- end }}
+
+{{- define "cluster.internal.bastion.kubeadm.files.ssh" }}
+- path: /etc/ssh/trusted-user-ca-keys.pem
+  permissions: "0600"
+  encoding: base64
+  content: {{ tpl ($.Files.Get "files/etc/ssh/trusted-user-ca-keys.pem") . | b64enc }}
+- path: /etc/ssh/sshd_config
+  permissions: "0600"
+  encoding: base64
+  content: {{ $.Files.Get "files/etc/ssh/sshd_config_bastion" | b64enc }}
+{{- end }}

--- a/helm/cluster/templates/bastion/_helpers_flatcar.tpl
+++ b/helm/cluster/templates/bastion/_helpers_flatcar.tpl
@@ -1,0 +1,11 @@
+{{- define "cluster.internal.bastion.kubeadm.ignition" }}
+containerLinuxConfig:
+  additionalConfig: |
+    systemd:
+      {{- if (((((($.Values.internal.bastion).kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).systemd).units }}
+      units:
+      {{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $.Values.internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units | indent 6 }}
+      {{- else }}
+      units: []
+      {{- end }}
+{{- end }}

--- a/helm/cluster/templates/bastion/_helpers_prekubeadmcommands.tpl
+++ b/helm/cluster/templates/bastion/_helpers_prekubeadmcommands.tpl
@@ -1,0 +1,18 @@
+{{/*
+    Template cluster.internal.bastion.kubeadm.preKubeadmCommands defines extra commands to run
+    on bastion nodes before kubeadm runs. It includes prefedined commands and custom commands
+    specified in Helm values field .Values.internal.bastion.kubeadmConfig.preKubeadmCommands.
+*/}}
+{{- define "cluster.internal.bastion.kubeadm.preKubeadmCommands" }}
+{{- include "cluster.internal.kubeadm.preKubeadmCommands.flatcar" $ }}
+{{- include "cluster.internal.kubeadm.preKubeadmCommands.ssh" $ }}
+{{- include "cluster.internal.bastion.kubeadm.preKubeadmCommands.custom" $ }}
+{{- end }}
+
+{{- define "cluster.internal.bastion.kubeadm.preKubeadmCommands.custom" }}
+{{- if $.Values.internal.bastion.kubeadmConfig }}
+{{- range $command := $.Values.internal.bastion.kubeadmConfig.preKubeadmCommands }}
+- {{ $command }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/cluster/templates/bastion/_kubeadmconfigtemplatespec.yaml
+++ b/helm/cluster/templates/bastion/_kubeadmconfigtemplatespec.yaml
@@ -1,0 +1,11 @@
+{{- define "cluster.internal.bastion.kubeadmconfigtemplate.spec" }}
+format: ignition
+ignition:
+  {{- include "cluster.internal.bastion.kubeadm.ignition" $ | indent 2 }}
+preKubeadmCommands:
+{{- include "cluster.internal.bastion.kubeadm.preKubeadmCommands" $ }}
+files:
+{{- include "cluster.internal.bastion.kubeadm.files" $ }}
+users:
+{{- include "cluster.internal.kubeadm.users" $ }}
+{{- end }}

--- a/helm/cluster/templates/bastion/kubeadmconfigtemplate.yaml
+++ b/helm/cluster/templates/bastion/kubeadmconfigtemplate.yaml
@@ -1,3 +1,16 @@
-{{- define "cluster.internal.bastion.kubeadmconfigtemplate.spec" -}}
-format: ignition
-{{- end -}}
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  annotations:
+    "helm.sh/resource-policy": keep
+      {{- include "cluster.annotations.custom" $ | indent 4 }}
+  labels:
+    cluster.x-k8s.io/role: bastion
+    {{- include "cluster.labels.common" $ | nindent 4 }}
+    {{- include "cluster.labels.custom" $ | indent 4 }}
+  name: {{ include "cluster.resource.name" $ }}-bastion-{{ include "cluster.data.hash" (dict "data" (include "cluster.internal.bastion.kubeadmconfigtemplate.spec" $) "salt" $.Values.internal.hashSalt) }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  template:
+    spec:
+      {{- include "cluster.internal.bastion.kubeadmconfigtemplate.spec" $ | indent 6 }}

--- a/helm/cluster/templates/bastion/kubeadmconfigtemplate.yaml
+++ b/helm/cluster/templates/bastion/kubeadmconfigtemplate.yaml
@@ -1,0 +1,3 @@
+{{- define "cluster.internal.bastion.kubeadmconfigtemplate.spec" -}}
+format: ignition
+{{- end -}}

--- a/helm/cluster/templates/bastion/machinedeployment.yaml
+++ b/helm/cluster/templates/bastion/machinedeployment.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.global.connectivity.bastion.enabled }}
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  annotations:
+    "helm.sh/resource-policy": keep
+    {{- include "cluster.annotations.custom" $ | indent 4 }}
+  labels:
+    cluster.x-k8s.io/role: bastion
+    {{- include "cluster.labels.common" $ | nindent 4 }}
+    {{- include "cluster.labels.custom" $ | indent 4 }}
+  name: {{ include "cluster.resource.name" $ }}-bastion
+  namespace: {{ $.Release.Namespace }}
+spec:
+  clusterName: {{ include "cluster.resource.name" $ }}
+  replicas: {{ $.Values.global.connectivity.bastion.replicas }}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: {{ include "cluster.resource.name" $ }}
+      cluster.x-k8s.io/deployment-name: {{ include "cluster.resource.name" $ }}-bastion
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        {{- include "cluster.annotations.custom" $ | indent 8 }}
+      labels:
+        cluster.x-k8s.io/role: bastion
+        cluster.x-k8s.io/deployment-name: {{ include "cluster.resource.name" $ }}-bastion
+        {{- include "cluster.labels.common" $ | nindent 8 }}
+        {{- include "cluster.labels.custom" $ | indent 4 }}
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: {{ include "cluster.resource.name" $ }}-bastion-{{ include "cluster.data.hash" (dict "data" (include "cluster.internal.bastion.kubeadmconfigtemplate.spec" $) "salt" $.Values.internal.hashSalt) }}
+      clusterName: {{ include "cluster.resource.name" $ }}
+      infrastructureRef:
+        apiVersion: {{ $.Values.internal.resourcesApi.bastion.infrastructureMachineTemplate.group }}/{{ $.Values.internal.resourcesApi.bastion.infrastructureMachineTemplate.version }}
+        kind: {{ $.Values.internal.resourcesApi.bastion.infrastructureMachineTemplate.kind }}
+        name: {{ include "cluster.resource.name" $ }}-bastion-{{ include "cluster.data.hash" (dict "data" (include $.Values.internal.resourcesApi.bastion.infrastructureMachineTemplateSpecTemplateName $) "salt" $.Values.internal.hashSalt) }}
+      version: {{ $.Values.internal.kubernetesVersion }}
+{{- end }}

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -969,6 +969,27 @@
             "title": "Internal",
             "additionalProperties": false,
             "properties": {
+                "bastion": {
+                    "type": "object",
+                    "title": "Internal bastion configuration",
+                    "additionalProperties": false,
+                    "properties": {
+                        "kubeadmConfig": {
+                            "type": "object",
+                            "title": "Kubeadm config",
+                            "description": "Configuration of bastion nodes.",
+                            "additionalProperties": false,
+                            "properties": {
+                                "ignition": {
+                                    "$ref": "#/$defs/ignition"
+                                },
+                                "preKubeadmCommands": {
+                                    "$ref": "#/$defs/preKubeadmCommands"
+                                }
+                            }
+                        }
+                    }
+                },
                 "connectivity": {
                     "type": "object",
                     "title": "Connectivity",

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -152,6 +152,45 @@
                 }
             }
         },
+        "infrastructureMachineTemplate": {
+            "type": "object",
+            "title": "Infrastructure Machine template",
+            "description": "Group, version and kind of provider-specific infrastructure Machine template resource.",
+            "additionalProperties": false,
+            "required": [
+                "group",
+                "version",
+                "kind"
+            ],
+            "properties": {
+                "group": {
+                    "type": "string",
+                    "title": "API group",
+                    "examples": [
+                        "infrastructure.cluster.x-k8s.io"
+                    ]
+                },
+                "kind": {
+                    "type": "string",
+                    "title": "API kind",
+                    "examples": [
+                        "AWSMachineTemplate",
+                        "AzureMachineTemplate"
+                    ]
+                },
+                "version": {
+                    "type": "string",
+                    "title": "API version",
+                    "examples": [
+                        "v1alpha1",
+                        "v1beta1",
+                        "v1beta2",
+                        "v1",
+                        "v2"
+                    ]
+                }
+            }
+        },
         "ignition": {
             "type": "object",
             "title": "Ignition",
@@ -430,6 +469,22 @@
                         "baseDomain": {
                             "type": "string",
                             "title": "Base DNS domain"
+                        },
+                        "bastion": {
+                            "type": "object",
+                            "title": "Bastion host",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "title": "Enable",
+                                    "default": true
+                                },
+                                "replicas": {
+                                    "type": "integer",
+                                    "title": "Number of hosts",
+                                    "default": 1
+                                }
+                            }
                         },
                         "network": {
                             "type": "object",
@@ -1213,6 +1268,11 @@
                         "resources"
                     ]
                 },
+                "hashSalt": {
+                    "type": "string",
+                    "title": "Hash salt",
+                    "description": "If specified, this token is used as a salt to the hash suffix of some resource names. Can be used to force-recreate some resources."
+                },
                 "kubeadmConfig": {
                     "type": "object",
                     "title": "Kubeadm config",
@@ -1247,13 +1307,32 @@
                     "type": "object",
                     "title": "Resources API",
                     "description": "Group, version and kind configuration that is required and used by a specific Cluster API provider.",
+                    "properties": {
+                        "infrastructureCluster": {
+                            "$ref": "#/$defs/infrastructureCluster"
+                        },
+                        "bastion": {
+                            "type": "object",
+                            "title": "Bastion",
+                            "description": "Configuration of bastion resources API and names.",
+                            "properties": {
+                                "infrastructureMachineTemplate": {
+                                    "$ref": "#/$defs/infrastructureMachineTemplate"
+                                },
+                                "infrastructureMachineTemplateSpecTemplateName": {
+                                    "type": "string",
+                                    "title": "Infrastructure Machine template spec template name",
+                                    "description": "The name of Helm template that renders Infrastructure Machine template spec."
+                                }
+                            }
+                        }
+                    },
+                    "required": [
+                        "infrastructureCluster"
+                    ],
                     "oneOf": [
                         {
-                            "additionalProperties": false,
                             "properties": {
-                                "infrastructureCluster": {
-                                    "$ref": "#/$defs/infrastructureCluster"
-                                },
                                 "infrastructureMachinePool": {
                                     "$ref": "#/$defs/infrastructureMachinePool"
                                 },
@@ -1262,25 +1341,24 @@
                                 }
                             },
                             "required": [
-                                "infrastructureCluster",
                                 "infrastructureMachinePool",
                                 "nodePoolKind"
                             ]
                         },
                         {
-                            "additionalProperties": false,
                             "properties": {
-                                "infrastructureCluster": {
-                                    "$ref": "#/$defs/infrastructureCluster"
-                                },
                                 "nodePoolKind": {
                                     "const": "MachineDeployment"
                                 }
                             },
                             "required": [
-                                "infrastructureCluster",
                                 "nodePoolKind"
-                            ]
+                            ],
+                            "not": {
+                                "required": [
+                                    "infrastructureMachinePool"
+                                ]
+                            }
                         }
                     ]
                 },

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -8,6 +8,9 @@ global:
           - endpoint: registry-1.docker.io
           - endpoint: giantswarm.azurecr.io
   connectivity:
+    bastion:
+      enabled: true
+      replicas: 1
     network:
       pods:
         cidrBlocks:

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -29,6 +29,13 @@ global:
   metadata:
     servicePriority: highest
 internal:
+  bastion:
+    kubeadmConfig:
+      ignition:
+        containerLinuxConfig:
+          additionalConfig:
+            storage: {}
+            systemd: {}
   components:
     cri:
       sandboxContainerImage:
@@ -60,6 +67,10 @@ internal:
           systemd: {}
   kubernetesVersion: 1.24.10
   paused: false
+  resourcesApi:
+    bastion:
+      infrastructureMachineTemplate: {}
+    infrastructureCluster: {}
   workers:
     kubeadmConfig:
       ignition:


### PR DESCRIPTION
### What does this PR do?

This PR adds required bastion resources based on Cluster API MachineDeployment (more details here https://github.com/giantswarm/roadmap/issues/2742).

The bastion resources have been ported as is from cluster-aws, with just Helm values being adjusted for the cluster chart.

### What is the effect of this change to users?

### How does it look like?

```
    # Source: cluster/templates/bastion/machinedeployment.yaml
    apiVersion: cluster.x-k8s.io/v1beta1
    kind: MachineDeployment
    metadata:
      annotations:
        helm.sh/resource-policy: keep
        important-cluster-value: 1000
        robots-need-this-in-the-cluster: eW91IGNhbm5vdCByZWFkIHRoaXMsIGJ1dCByb2JvdHMgY2FuCg==
      labels:
        cluster.x-k8s.io/role: bastion
        app: cluster
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/version: 0.1.0-dev
        application.giantswarm.io/team: turtles
        giantswarm.io/cluster: awesome
        giantswarm.io/organization: giantswarm
        giantswarm.io/service-priority: highest
        cluster.x-k8s.io/cluster-name: awesome
        cluster.x-k8s.io/watch-filter: capi
        helm.sh/chart: cluster-0.1.0-dev
        another-cluster-label: label-2
        some-cluster-label: label-1
      name: awesome-bastion
      namespace: org-giantswarm
    spec:
      clusterName: awesome
      replicas: 1
      selector:
        matchLabels:
          cluster.x-k8s.io/cluster-name: awesome
          cluster.x-k8s.io/deployment-name: awesome-bastion
      strategy:
        rollingUpdate:
          maxSurge: 1
          maxUnavailable: 1
        type: RollingUpdate
      template:
        metadata:
          annotations:
            important-cluster-value: 1000
            robots-need-this-in-the-cluster: eW91IGNhbm5vdCByZWFkIHRoaXMsIGJ1dCByb2JvdHMgY2FuCg==
          labels:
            cluster.x-k8s.io/role: bastion
            cluster.x-k8s.io/deployment-name: awesome-bastion
            app: cluster
            app.kubernetes.io/managed-by: Helm
            app.kubernetes.io/version: 0.1.0-dev
            application.giantswarm.io/team: turtles
            giantswarm.io/cluster: awesome
            giantswarm.io/organization: giantswarm
            giantswarm.io/service-priority: highest
            cluster.x-k8s.io/cluster-name: awesome
            cluster.x-k8s.io/watch-filter: capi
            helm.sh/chart: cluster-0.1.0-dev
        another-cluster-label: label-2
        some-cluster-label: label-1
        spec:
          bootstrap:
            configRef:
              apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
              kind: KubeadmConfigTemplate
              name: awesome-bastion-3253eb7d
          clusterName: awesome
          infrastructureRef:
            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
            kind: AWSMachineTemplate
            name: awesome-bastion-8f746b70
          version: 1.24.10
    ---
        # Source: cluster/templates/bastion/machinedeployment.yaml
    apiVersion: cluster.x-k8s.io/v1beta1
    kind: MachineDeployment
    metadata:
      annotations:
        helm.sh/resource-policy: keep
        important-cluster-value: 1000
        robots-need-this-in-the-cluster: eW91IGNhbm5vdCByZWFkIHRoaXMsIGJ1dCByb2JvdHMgY2FuCg==
      labels:
        cluster.x-k8s.io/role: bastion
        app: cluster
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/version: 0.1.0-dev
        application.giantswarm.io/team: turtles
        giantswarm.io/cluster: awesome
        giantswarm.io/organization: giantswarm
        giantswarm.io/service-priority: highest
        cluster.x-k8s.io/cluster-name: awesome
        cluster.x-k8s.io/watch-filter: capi
        helm.sh/chart: cluster-0.1.0-dev
        another-cluster-label: label-2
        some-cluster-label: label-1
      name: awesome-bastion
      namespace: org-giantswarm
    spec:
      clusterName: awesome
      replicas: 1
      selector:
        matchLabels:
          cluster.x-k8s.io/cluster-name: awesome
          cluster.x-k8s.io/deployment-name: awesome-bastion
      strategy:
        rollingUpdate:
          maxSurge: 1
          maxUnavailable: 1
        type: RollingUpdate
      template:
        metadata:
          annotations:
            important-cluster-value: 1000
            robots-need-this-in-the-cluster: eW91IGNhbm5vdCByZWFkIHRoaXMsIGJ1dCByb2JvdHMgY2FuCg==
          labels:
            cluster.x-k8s.io/role: bastion
            cluster.x-k8s.io/deployment-name: awesome-bastion
            app: cluster
            app.kubernetes.io/managed-by: Helm
            app.kubernetes.io/version: 0.1.0-dev
            application.giantswarm.io/team: turtles
            giantswarm.io/cluster: awesome
            giantswarm.io/organization: giantswarm
            giantswarm.io/service-priority: highest
            cluster.x-k8s.io/cluster-name: awesome
            cluster.x-k8s.io/watch-filter: capi
            helm.sh/chart: cluster-0.1.0-dev
        another-cluster-label: label-2
        some-cluster-label: label-1
        spec:
          bootstrap:
            configRef:
              apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
              kind: KubeadmConfigTemplate
              name: awesome-bastion-3253eb7d
          clusterName: awesome
          infrastructureRef:
            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
            kind: AWSMachineTemplate
            name: awesome-bastion-8f746b70
          version: 1.24.10
```

### Any background context you can provide?

https://github.com/giantswarm/roadmap/issues/2742