### PR TITLE
Normalize schema and disable cluster-app rule-set

### DIFF
--- a/.github/workflows/zz_generated.json_schema_validation.yaml
+++ b/.github/workflows/zz_generated.json_schema_validation.yaml
@@ -30,8 +30,6 @@ jobs:
       - name: Run schemalint
         id: run-schemalint
         uses: giantswarm/schemalint/actions/verify-helm-schema@v2
-        with:
-          rule-set: 'cluster-app'
   generate:
     name: Check that values.yaml is generated from values.schema.json with helm-values-gen
     runs-on: ubuntu-latest

--- a/Makefile.gen.cluster_app.mk
+++ b/Makefile.gen.cluster_app.mk
@@ -17,7 +17,7 @@ normalize-schema: ## Normalize the JSON schema
 .PHONY: validate-schema
 validate-schema: ## Validate the JSON schema
 	go install github.com/giantswarm/schemalint/v2@v2
-	schemalint verify $(VALUES_SCHEMA) --rule-set=cluster-app
+	schemalint verify $(VALUES_SCHEMA)
 
 .PHONY: generate-docs
 generate-docs: ## Generate values documentation from schema

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1,12 +1,17 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "values.schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$defs": {
         "customNodeTaints": {
             "type": "array",
             "title": "Custom node taints",
             "items": {
                 "type": "object",
+                "required": [
+                    "effect",
+                    "key",
+                    "value"
+                ],
                 "properties": {
                     "effect": {
                         "type": "string",
@@ -25,12 +30,7 @@
                         "type": "string",
                         "title": "Value"
                     }
-                },
-                "required": [
-                    "effect",
-                    "key",
-                    "value"
-                ]
+                }
             }
         },
         "gvk": {
@@ -72,16 +72,204 @@
                 }
             }
         },
+        "ignition": {
+            "type": "object",
+            "title": "Ignition",
+            "description": "Ignition-specific configuration.",
+            "properties": {
+                "containerLinuxConfig": {
+                    "type": "object",
+                    "title": "Container Linux configuration",
+                    "properties": {
+                        "additionalConfig": {
+                            "type": "object",
+                            "title": "Additional config",
+                            "description": "Additional configuration to be merged with the Ignition. More info: https://coreos.github.io/ignition/operator-notes/#config-merging.",
+                            "properties": {
+                                "storage": {
+                                    "type": "object",
+                                    "title": "Storage",
+                                    "description": "It describes the desired state of the system’s storage devices.",
+                                    "properties": {
+                                        "directories": {
+                                            "type": "array",
+                                            "title": "Directories",
+                                            "description": "The list of directories to be created.",
+                                            "items": {
+                                                "type": "object",
+                                                "title": "Directory",
+                                                "description": "The directory to be created.",
+                                                "required": [
+                                                    "path"
+                                                ],
+                                                "properties": {
+                                                    "filesystem": {
+                                                        "type": "string",
+                                                        "title": "Filesystem",
+                                                        "description": "The internal identifier of the filesystem in which to create the directory. This matches the last filesystem with the given identifier."
+                                                    },
+                                                    "group": {
+                                                        "type": "object",
+                                                        "title": "Group",
+                                                        "description": "It specifies the group of the owner.",
+                                                        "properties": {
+                                                            "id": {
+                                                                "type": "integer",
+                                                                "title": "ID",
+                                                                "description": "The group ID of the owner."
+                                                            },
+                                                            "name": {
+                                                                "type": "string",
+                                                                "title": "Name",
+                                                                "description": "The group name of the owner."
+                                                            }
+                                                        }
+                                                    },
+                                                    "mode": {
+                                                        "type": "integer",
+                                                        "title": "Mode",
+                                                        "description": "The directory’s permission mode."
+                                                    },
+                                                    "overwrite": {
+                                                        "type": "boolean",
+                                                        "title": "Overwrite",
+                                                        "description": "Whether to delete preexisting nodes at the path."
+                                                    },
+                                                    "path": {
+                                                        "type": "string",
+                                                        "title": "Path",
+                                                        "description": "The absolute path to the directory."
+                                                    },
+                                                    "user": {
+                                                        "type": "object",
+                                                        "title": "User",
+                                                        "description": "It specifies the directory’s owner.",
+                                                        "properties": {
+                                                            "id": {
+                                                                "type": "integer",
+                                                                "title": "ID",
+                                                                "description": "The user ID of the owner."
+                                                            },
+                                                            "name": {
+                                                                "type": "string",
+                                                                "title": "Name",
+                                                                "description": "The user name of the owner."
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "filesystems": {
+                                            "type": "array",
+                                            "title": "File systems",
+                                            "description": "The list of filesystems to be configured and/or used in the “files” section. Either “mount” or “path” needs to be specified.",
+                                            "items": {
+                                                "type": "object",
+                                                "title": "File system",
+                                                "description": "The filesystem to be configured and/or used in the “files” section. Either “mount” or “path” needs to be specified.",
+                                                "properties": {
+                                                    "mount": {
+                                                        "type": "object",
+                                                        "title": "Mount",
+                                                        "description": "It contains the set of mount and formatting options for the filesystem. A non-null entry indicates that the filesystem should be mounted before it is used by Ignition.",
+                                                        "required": [
+                                                            "device",
+                                                            "format"
+                                                        ],
+                                                        "properties": {
+                                                            "device": {
+                                                                "type": "string",
+                                                                "title": "Device",
+                                                                "description": "The absolute path to the device. Devices are typically referenced by the /dev/disk/by-* symlinks."
+                                                            },
+                                                            "format": {
+                                                                "type": "string",
+                                                                "title": "Format",
+                                                                "description": "The filesystem format (ext4, btrfs, or xfs).",
+                                                                "enum": [
+                                                                    "ext4",
+                                                                    "btrfs",
+                                                                    "xfs"
+                                                                ]
+                                                            },
+                                                            "label": {
+                                                                "type": "string",
+                                                                "title": "Label",
+                                                                "description": "The label of the filesystem."
+                                                            },
+                                                            "options": {
+                                                                "type": "array",
+                                                                "title": "Options",
+                                                                "description": "Any additional options to be passed to the format-specific mkfs utility.",
+                                                                "items": {
+                                                                    "type": "string",
+                                                                    "description": "An additional option to be passed to the format-specific mkfs utility.",
+                                                                    "name": "Option"
+                                                                }
+                                                            },
+                                                            "uuid": {
+                                                                "type": "string",
+                                                                "title": "UUID",
+                                                                "description": "The uuid of the filesystem."
+                                                            },
+                                                            "wipeFilesystem": {
+                                                                "type": "boolean",
+                                                                "title": "Wipe filesystem",
+                                                                "description": "Whether or not to wipe the device before filesystem creation, see Ignition’s documentation on filesystems for more information https://github.com/coreos/ignition/blob/main/docs/operator-notes.md#filesystem-reuse-semantics."
+                                                            }
+                                                        }
+                                                    },
+                                                    "name": {
+                                                        "type": "string",
+                                                        "title": "Name",
+                                                        "description": "The identifier for the filesystem, internal to Ignition. This is only required if the filesystem needs to be referenced in the “files” section."
+                                                    },
+                                                    "path": {
+                                                        "type": "string",
+                                                        "title": "Path",
+                                                        "description": "The mount-point of the filesystem. A non-null entry indicates that the filesystem has already been mounted by the system at the specified path. This is really only useful for “/sysroot”."
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "systemd": {
+                                    "type": "object",
+                                    "title": "systemd",
+                                    "description": "It describes the desired state of the systemd units.",
+                                    "properties": {
+                                        "units": {
+                                            "type": "array",
+                                            "title": "Units",
+                                            "items": {
+                                                "$ref": "#/$defs/systemdUnit"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "strict": {
+                            "type": "boolean",
+                            "title": "Strict",
+                            "description": "It controls if AdditionalConfig should be strictly parsed. If so, warnings are treated as errors."
+                        }
+                    }
+                }
+            }
+        },
         "infrastructureCluster": {
             "type": "object",
             "title": "Infrastructure cluster",
             "description": "Group, version and kind of provider-specific infrastructure cluster resource.",
-            "additionalProperties": false,
             "required": [
                 "group",
                 "version",
                 "kind"
             ],
+            "additionalProperties": false,
             "properties": {
                 "group": {
                     "type": "string",
@@ -117,12 +305,12 @@
             "type": "object",
             "title": "Infrastructure MachinePool",
             "description": "Group, version and kind of provider-specific infrastructure MachinePool resource.",
-            "additionalProperties": false,
             "required": [
                 "group",
                 "version",
                 "kind"
             ],
+            "additionalProperties": false,
             "properties": {
                 "group": {
                     "type": "string",
@@ -156,12 +344,12 @@
             "type": "object",
             "title": "Infrastructure Machine template",
             "description": "Group, version and kind of provider-specific infrastructure Machine template resource.",
-            "additionalProperties": false,
             "required": [
                 "group",
                 "version",
                 "kind"
             ],
+            "additionalProperties": false,
             "properties": {
                 "group": {
                     "type": "string",
@@ -191,214 +379,30 @@
                 }
             }
         },
-        "ignition": {
-            "type": "object",
-            "title": "Ignition",
-            "description": "Ignition-specific configuration.",
-            "properties": {
-                "containerLinuxConfig": {
-                    "type": "object",
-                    "title": "Container Linux configuration",
-                    "properties": {
-                        "additionalConfig": {
-                            "type": "object",
-                            "title": "Additional config",
-                            "description": "Additional configuration to be merged with the Ignition. More info: https://coreos.github.io/ignition/operator-notes/#config-merging.",
-                            "properties": {
-                                "systemd": {
-                                    "type": "object",
-                                    "title": "systemd",
-                                    "description": "It describes the desired state of the systemd units.",
-                                    "properties": {
-                                        "units": {
-                                            "type": "array",
-                                            "title": "Units",
-                                            "items": {
-                                                "$ref": "#/$defs/systemdUnit"
-                                            }
-                                        }
-                                    }
-                                },
-                                "storage": {
-                                    "type": "object",
-                                    "title": "Storage",
-                                    "description": "It describes the desired state of the system’s storage devices.",
-                                    "properties": {
-                                        "directories": {
-                                            "type": "array",
-                                            "title": "Directories",
-                                            "description": "The list of directories to be created.",
-                                            "items": {
-                                                "type": "object",
-                                                "title": "Directory",
-                                                "description": "The directory to be created.",
-                                                "properties": {
-                                                    "filesystem": {
-                                                        "type": "string",
-                                                        "title": "Filesystem",
-                                                        "description": "The internal identifier of the filesystem in which to create the directory. This matches the last filesystem with the given identifier."
-                                                    },
-                                                    "path": {
-                                                        "type": "string",
-                                                        "title": "Path",
-                                                        "description": "The absolute path to the directory."
-                                                    },
-                                                    "overwrite": {
-                                                        "type": "boolean",
-                                                        "title": "Overwrite",
-                                                        "description": "Whether to delete preexisting nodes at the path."
-                                                    },
-                                                    "mode": {
-                                                        "type": "integer",
-                                                        "title": "Mode",
-                                                        "description": "The directory’s permission mode."
-                                                    },
-                                                    "user": {
-                                                        "type": "object",
-                                                        "title": "User",
-                                                        "description": "It specifies the directory’s owner.",
-                                                        "properties": {
-                                                            "id": {
-                                                                "type": "integer",
-                                                                "title": "ID",
-                                                                "description": "The user ID of the owner."
-                                                            },
-                                                            "name": {
-                                                                "type": "string",
-                                                                "title": "Name",
-                                                                "description": "The user name of the owner."
-                                                            }
-                                                        }
-                                                    },
-                                                    "group": {
-                                                        "type": "object",
-                                                        "title": "Group",
-                                                        "description": "It specifies the group of the owner.",
-                                                        "properties": {
-                                                            "id": {
-                                                                "type": "integer",
-                                                                "title": "ID",
-                                                                "description": "The group ID of the owner."
-                                                            },
-                                                            "name": {
-                                                                "type": "string",
-                                                                "title": "Name",
-                                                                "description": "The group name of the owner."
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                "required": [
-                                                    "path"
-                                                ]
-                                            }
-                                        },
-                                        "filesystems": {
-                                            "type": "array",
-                                            "title": "File systems",
-                                            "description": "The list of filesystems to be configured and/or used in the “files” section. Either “mount” or “path” needs to be specified.",
-                                            "items": {
-                                                "type": "object",
-                                                "title": "File system",
-                                                "description": "The filesystem to be configured and/or used in the “files” section. Either “mount” or “path” needs to be specified.",
-                                                "properties": {
-                                                    "name": {
-                                                        "type": "string",
-                                                        "title": "Name",
-                                                        "description": "The identifier for the filesystem, internal to Ignition. This is only required if the filesystem needs to be referenced in the “files” section."
-                                                    },
-                                                    "mount": {
-                                                        "type": "object",
-                                                        "title": "Mount",
-                                                        "description": "It contains the set of mount and formatting options for the filesystem. A non-null entry indicates that the filesystem should be mounted before it is used by Ignition.",
-                                                        "properties": {
-                                                            "device": {
-                                                                "type": "string",
-                                                                "title": "Device",
-                                                                "description": "The absolute path to the device. Devices are typically referenced by the /dev/disk/by-* symlinks."
-                                                            },
-                                                            "format": {
-                                                                "type": "string",
-                                                                "title": "Format",
-                                                                "description": "The filesystem format (ext4, btrfs, or xfs).",
-                                                                "enum": [
-                                                                    "ext4",
-                                                                    "btrfs",
-                                                                    "xfs"
-                                                                ]
-                                                            },
-                                                            "wipeFilesystem": {
-                                                                "type": "boolean",
-                                                                "title": "Wipe filesystem",
-                                                                "description": "Whether or not to wipe the device before filesystem creation, see Ignition’s documentation on filesystems for more information https://github.com/coreos/ignition/blob/main/docs/operator-notes.md#filesystem-reuse-semantics."
-                                                            },
-                                                            "label": {
-                                                                "type": "string",
-                                                                "title": "Label",
-                                                                "description": "The label of the filesystem."
-                                                            },
-                                                            "uuid": {
-                                                                "type": "string",
-                                                                "title": "UUID",
-                                                                "description": "The uuid of the filesystem."
-                                                            },
-                                                            "options": {
-                                                                "type": "array",
-                                                                "title": "Options",
-                                                                "description": "Any additional options to be passed to the format-specific mkfs utility.",
-                                                                "items": {
-                                                                    "type": "string",
-                                                                    "name": "Option",
-                                                                    "description": "An additional option to be passed to the format-specific mkfs utility."
-                                                                }
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "device",
-                                                            "format"
-                                                        ]
-                                                    },
-                                                    "path": {
-                                                        "type": "string",
-                                                        "title": "Path",
-                                                        "description": "The mount-point of the filesystem. A non-null entry indicates that the filesystem has already been mounted by the system at the specified path. This is really only useful for “/sysroot”."
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "strict": {
-                            "type": "boolean",
-                            "title": "Strict",
-                            "description": "It controls if AdditionalConfig should be strictly parsed. If so, warnings are treated as errors."
-                        }
-                    }
-                }
+        "postKubeadmCommands": {
+            "type": "array",
+            "title": "Post-kubeadm commands",
+            "description": "Extra commands to run after kubeadm runs.",
+            "items": {
+                "type": "string"
+            }
+        },
+        "preKubeadmCommands": {
+            "type": "array",
+            "title": "Pre-kubeadm commands",
+            "description": "Extra commands to run before kubeadm runs.",
+            "items": {
+                "type": "string"
             }
         },
         "systemdUnit": {
             "type": "object",
             "title": "systemd unit",
+            "required": [
+                "name"
+            ],
             "additionalProperties": false,
             "properties": {
-                "name": {
-                    "type": "string",
-                    "title": "Name",
-                    "description": "The name of the unit. This must be suffixed with a valid unit type (e.g. “thing.service”)."
-                },
-                "enabled": {
-                    "type": "boolean",
-                    "title": "Enabled?",
-                    "description": "Whether or not the service shall be enabled. When true, the service is enabled. When false, the service is disabled. When omitted, the service is unmodified. In order for this to have any effect, the unit must have an install section."
-                },
-                "mask": {
-                    "type": "boolean",
-                    "title": "Masked?",
-                    "description": "Whether or not the service shall be masked. When true, the service is masked by symlinking it to /dev/null."
-                },
                 "contents": {
                     "type": "string",
                     "title": "Contents",
@@ -411,43 +415,39 @@
                     "items": {
                         "type": "object",
                         "title": "Unit drop-in",
+                        "required": [
+                            "name"
+                        ],
                         "properties": {
+                            "contents": {
+                                "type": "string",
+                                "title": "Contents",
+                                "description": "The contents of the drop-in."
+                            },
                             "name": {
                                 "type": "string",
                                 "title": "Name",
                                 "description": "The name of the drop-in. This must be suffixed with “.conf”",
                                 "pattern": "^.+\\.conf$"
-                            },
-                            "contents": {
-                                "type": "string",
-                                "title": "Contents",
-                                "description": "The contents of the drop-in."
                             }
-                        },
-                        "required": [
-                            "name"
-                        ]
+                        }
                     }
+                },
+                "enabled": {
+                    "type": "boolean",
+                    "title": "Enabled?",
+                    "description": "Whether or not the service shall be enabled. When true, the service is enabled. When false, the service is disabled. When omitted, the service is unmodified. In order for this to have any effect, the unit must have an install section."
+                },
+                "mask": {
+                    "type": "boolean",
+                    "title": "Masked?",
+                    "description": "Whether or not the service shall be masked. When true, the service is masked by symlinking it to /dev/null."
+                },
+                "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The name of the unit. This must be suffixed with a valid unit type (e.g. “thing.service”)."
                 }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "preKubeadmCommands": {
-            "type": "array",
-            "title": "Pre-kubeadm commands",
-            "description": "Extra commands to run before kubeadm runs.",
-            "items": {
-                "type": "string"
-            }
-        },
-        "postKubeadmCommands": {
-            "type": "array",
-            "title": "Post-kubeadm commands",
-            "description": "Extra commands to run after kubeadm runs.",
-            "items": {
-                "type": "string"
             }
         }
     },
@@ -458,275 +458,30 @@
             "type": "object",
             "title": "Global properties",
             "description": "Properties that are available to all charts and subcharts.",
+            "required": [
+                "components",
+                "connectivity",
+                "controlPlane",
+                "metadata"
+            ],
             "additionalProperties": false,
             "properties": {
-                "connectivity": {
-                    "type": "object",
-                    "title": "Connectivity",
-                    "description": "Configuration of connectivity and networking options.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "baseDomain": {
-                            "type": "string",
-                            "title": "Base DNS domain"
-                        },
-                        "bastion": {
-                            "type": "object",
-                            "title": "Bastion host",
-                            "properties": {
-                                "enabled": {
-                                    "type": "boolean",
-                                    "title": "Enable",
-                                    "default": true
-                                },
-                                "replicas": {
-                                    "type": "integer",
-                                    "title": "Number of hosts",
-                                    "default": 1
-                                }
-                            }
-                        },
-                        "network": {
-                            "type": "object",
-                            "title": "Network",
-                            "additionalProperties": false,
-                            "properties": {
-                                "pods": {
-                                    "type": "object",
-                                    "title": "Pods",
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "cidrBlocks": {
-                                            "type": "array",
-                                            "title": "Pod subnets",
-                                            "items": {
-                                                "type": "string",
-                                                "title": "Pod subnet",
-                                                "description": "IPv4 address range for pods, in CIDR notation.",
-                                                "examples": [
-                                                    "10.244.0.0/16"
-                                                ]
-                                            },
-                                            "default": [
-                                                "100.64.0.0/12"
-                                            ],
-                                            "maxItems": 1,
-                                            "minItems": 1
-                                        }
-                                    },
-                                    "required": [
-                                        "cidrBlocks"
-                                    ]
-                                },
-                                "services": {
-                                    "type": "object",
-                                    "title": "Services",
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "cidrBlocks": {
-                                            "type": "array",
-                                            "title": "Kubernetes Service subnets",
-                                            "items": {
-                                                "type": "string",
-                                                "title": "Service subnet",
-                                                "description": "IPv4 address range for kubernetes services, in CIDR notation.",
-                                                "examples": [
-                                                    "172.31.0.0/16"
-                                                ]
-                                            },
-                                            "default": [
-                                                "172.31.0.0/16"
-                                            ],
-                                            "maxItems": 1,
-                                            "minItems": 1
-                                        }
-                                    },
-                                    "required": [
-                                        "cidrBlocks"
-                                    ]
-                                }
-                            },
-                            "required": [
-                                "pods",
-                                "services"
-                            ]
-                        },
-                        "proxy": {
-                            "title": "Proxy",
-                            "description": "Whether/how outgoing traffic is routed through proxy servers.",
-                            "default": null,
-                            "oneOf": [
-                                {
-                                    "type": "null"
-                                },
-                                {
-                                    "type": "object",
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "enabled": {
-                                            "type": "boolean",
-                                            "title": "Enable"
-                                        },
-                                        "httpProxy": {
-                                            "type": "string",
-                                            "title": "HTTP proxy",
-                                            "description": "To be passed to the HTTP_PROXY environment variable in all hosts."
-                                        },
-                                        "httpsProxy": {
-                                            "type": "string",
-                                            "title": "HTTPS proxy",
-                                            "description": "To be passed to the HTTPS_PROXY environment variable in all hosts."
-                                        },
-                                        "noProxy": {
-                                            "type": "object",
-                                            "title": "No proxy",
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "addresses": {
-                                                    "type": "array",
-                                                    "title": "Addresses",
-                                                    "description": "To be passed to the NO_PROXY environment variable in all hosts.",
-                                                    "items": {
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "addressesTemplate": {
-                                                    "type": "string",
-                                                    "title": "Addresses template",
-                                                    "description": "Name of Helm template that renders a YAML array with NO_PROXY addresses"
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            ]
-                        }
-                    },
-                    "required": [
-                        "baseDomain",
-                        "network"
-                    ]
-                },
-                "controlPlane": {
-                    "type": "object",
-                    "title": "Control plane",
-                    "description": "Configuration of the control plane.",
-                    "properties": {
-                        "customNodeTaints": {
-                            "$ref": "#/$defs/customNodeTaints"
-                        },
-                        "machineHealthCheck": {
-                            "type": "object",
-                            "title": "Machine health check",
-                            "properties": {
-                                "enabled": {
-                                    "type": "boolean",
-                                    "title": "Enable",
-                                    "default": true
-                                },
-                                "maxUnhealthy": {
-                                    "type": "string",
-                                    "title": "Maximum unhealthy nodes",
-                                    "examples": [
-                                        "40%"
-                                    ],
-                                    "default": "40%"
-                                },
-                                "nodeStartupTimeout": {
-                                    "type": "string",
-                                    "title": "Node startup timeout",
-                                    "description": "Determines how long a machine health check should wait for a node to join the cluster, before considering a machine unhealthy.",
-                                    "examples": [
-                                        "10m",
-                                        "100s"
-                                    ],
-                                    "default": "8m0s"
-                                },
-                                "unhealthyNotReadyTimeout": {
-                                    "type": "string",
-                                    "title": "Timeout for ready",
-                                    "description": "If a node is not in condition 'Ready' after this timeout, it will be considered unhealthy.",
-                                    "examples": [
-                                        "300s"
-                                    ],
-                                    "default": "10m0s"
-                                },
-                                "unhealthyUnknownTimeout": {
-                                    "type": "string",
-                                    "title": "Timeout for unknown condition",
-                                    "description": "If a node is in 'Unknown' condition after this timeout, it will be considered unhealthy.",
-                                    "examples": [
-                                        "300s"
-                                    ],
-                                    "default": "10m0s"
-                                }
-                            }
-                        },
-                        "oidc": {
-                            "title": "OIDC authentication",
-                            "oneOf": [
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "caPem": {
-                                            "type": "string",
-                                            "title": "Certificate authority",
-                                            "description": "Identity provider's CA certificate in PEM format."
-                                        },
-                                        "clientId": {
-                                            "type": "string",
-                                            "title": "Client ID"
-                                        },
-                                        "groupsClaim": {
-                                            "type": "string",
-                                            "title": "Groups claim"
-                                        },
-                                        "issuerUrl": {
-                                            "type": "string",
-                                            "title": "Issuer URL",
-                                            "description": "Exact issuer URL that will be included in identity tokens."
-                                        },
-                                        "usernameClaim": {
-                                            "type": "string",
-                                            "title": "Username claim"
-                                        }
-                                    },
-                                    "required": [
-                                        "clientId",
-                                        "groupsClaim",
-                                        "issuerUrl",
-                                        "usernameClaim"
-                                    ]
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "default": null
-                        },
-                        "replicas": {
-                            "type": "integer",
-                            "title": "Replicas",
-                            "description": "The number of control plane nodes.",
-                            "enum": [1, 3, 5],
-                            "default": 3
-                        }
-                    },
-                    "required": [
-                        "machineHealthCheck",
-                        "replicas"
-                    ]
-                },
                 "components": {
                     "type": "object",
                     "title": "Components",
                     "description": "Advanced configuration of machine and cluster components.",
+                    "required": [
+                        "cri"
+                    ],
                     "additionalProperties": false,
                     "properties": {
                         "cri": {
                             "type": "object",
                             "title": "CRI (container runtime interface)",
                             "description": "Configuration of container runtime interface.",
+                            "required": [
+                                "registries"
+                            ],
                             "additionalProperties": false,
                             "properties": {
                                 "registries": {
@@ -789,38 +544,299 @@
                                         ]
                                     }
                                 }
-                            },
+                            }
+                        }
+                    }
+                },
+                "connectivity": {
+                    "type": "object",
+                    "title": "Connectivity",
+                    "description": "Configuration of connectivity and networking options.",
+                    "required": [
+                        "baseDomain",
+                        "network"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                        "baseDomain": {
+                            "type": "string",
+                            "title": "Base DNS domain"
+                        },
+                        "bastion": {
+                            "type": "object",
+                            "title": "Bastion host",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "title": "Enable",
+                                    "default": true
+                                },
+                                "replicas": {
+                                    "type": "integer",
+                                    "title": "Number of hosts",
+                                    "default": 1
+                                }
+                            }
+                        },
+                        "network": {
+                            "type": "object",
+                            "title": "Network",
                             "required": [
-                                "registries"
+                                "pods",
+                                "services"
+                            ],
+                            "additionalProperties": false,
+                            "properties": {
+                                "pods": {
+                                    "type": "object",
+                                    "title": "Pods",
+                                    "required": [
+                                        "cidrBlocks"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "cidrBlocks": {
+                                            "type": "array",
+                                            "title": "Pod subnets",
+                                            "items": {
+                                                "type": "string",
+                                                "title": "Pod subnet",
+                                                "description": "IPv4 address range for pods, in CIDR notation.",
+                                                "examples": [
+                                                    "10.244.0.0/16"
+                                                ]
+                                            },
+                                            "default": [
+                                                "100.64.0.0/12"
+                                            ],
+                                            "maxItems": 1,
+                                            "minItems": 1
+                                        }
+                                    }
+                                },
+                                "services": {
+                                    "type": "object",
+                                    "title": "Services",
+                                    "required": [
+                                        "cidrBlocks"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "cidrBlocks": {
+                                            "type": "array",
+                                            "title": "Kubernetes Service subnets",
+                                            "items": {
+                                                "type": "string",
+                                                "title": "Service subnet",
+                                                "description": "IPv4 address range for kubernetes services, in CIDR notation.",
+                                                "examples": [
+                                                    "172.31.0.0/16"
+                                                ]
+                                            },
+                                            "default": [
+                                                "172.31.0.0/16"
+                                            ],
+                                            "maxItems": 1,
+                                            "minItems": 1
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "proxy": {
+                            "title": "Proxy",
+                            "description": "Whether/how outgoing traffic is routed through proxy servers.",
+                            "default": null,
+                            "oneOf": [
+                                {
+                                    "type": "null"
+                                },
+                                {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "enabled": {
+                                            "type": "boolean",
+                                            "title": "Enable"
+                                        },
+                                        "httpProxy": {
+                                            "type": "string",
+                                            "title": "HTTP proxy",
+                                            "description": "To be passed to the HTTP_PROXY environment variable in all hosts."
+                                        },
+                                        "httpsProxy": {
+                                            "type": "string",
+                                            "title": "HTTPS proxy",
+                                            "description": "To be passed to the HTTPS_PROXY environment variable in all hosts."
+                                        },
+                                        "noProxy": {
+                                            "type": "object",
+                                            "title": "No proxy",
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "addresses": {
+                                                    "type": "array",
+                                                    "title": "Addresses",
+                                                    "description": "To be passed to the NO_PROXY environment variable in all hosts.",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "addressesTemplate": {
+                                                    "type": "string",
+                                                    "title": "Addresses template",
+                                                    "description": "Name of Helm template that renders a YAML array with NO_PROXY addresses"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
                             ]
                         }
-                    },
+                    }
+                },
+                "controlPlane": {
+                    "type": "object",
+                    "title": "Control plane",
+                    "description": "Configuration of the control plane.",
                     "required": [
-                        "cri"
-                    ]
+                        "machineHealthCheck",
+                        "replicas"
+                    ],
+                    "properties": {
+                        "customNodeTaints": {
+                            "$ref": "#/$defs/customNodeTaints"
+                        },
+                        "machineHealthCheck": {
+                            "type": "object",
+                            "title": "Machine health check",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "title": "Enable",
+                                    "default": true
+                                },
+                                "maxUnhealthy": {
+                                    "type": "string",
+                                    "title": "Maximum unhealthy nodes",
+                                    "examples": [
+                                        "40%"
+                                    ],
+                                    "default": "40%"
+                                },
+                                "nodeStartupTimeout": {
+                                    "type": "string",
+                                    "title": "Node startup timeout",
+                                    "description": "Determines how long a machine health check should wait for a node to join the cluster, before considering a machine unhealthy.",
+                                    "examples": [
+                                        "10m",
+                                        "100s"
+                                    ],
+                                    "default": "8m0s"
+                                },
+                                "unhealthyNotReadyTimeout": {
+                                    "type": "string",
+                                    "title": "Timeout for ready",
+                                    "description": "If a node is not in condition 'Ready' after this timeout, it will be considered unhealthy.",
+                                    "examples": [
+                                        "300s"
+                                    ],
+                                    "default": "10m0s"
+                                },
+                                "unhealthyUnknownTimeout": {
+                                    "type": "string",
+                                    "title": "Timeout for unknown condition",
+                                    "description": "If a node is in 'Unknown' condition after this timeout, it will be considered unhealthy.",
+                                    "examples": [
+                                        "300s"
+                                    ],
+                                    "default": "10m0s"
+                                }
+                            }
+                        },
+                        "oidc": {
+                            "title": "OIDC authentication",
+                            "default": null,
+                            "oneOf": [
+                                {
+                                    "type": "object",
+                                    "required": [
+                                        "clientId",
+                                        "groupsClaim",
+                                        "issuerUrl",
+                                        "usernameClaim"
+                                    ],
+                                    "properties": {
+                                        "caPem": {
+                                            "type": "string",
+                                            "title": "Certificate authority",
+                                            "description": "Identity provider's CA certificate in PEM format."
+                                        },
+                                        "clientId": {
+                                            "type": "string",
+                                            "title": "Client ID"
+                                        },
+                                        "groupsClaim": {
+                                            "type": "string",
+                                            "title": "Groups claim"
+                                        },
+                                        "issuerUrl": {
+                                            "type": "string",
+                                            "title": "Issuer URL",
+                                            "description": "Exact issuer URL that will be included in identity tokens."
+                                        },
+                                        "usernameClaim": {
+                                            "type": "string",
+                                            "title": "Username claim"
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "replicas": {
+                            "type": "integer",
+                            "title": "Replicas",
+                            "description": "The number of control plane nodes.",
+                            "enum": [
+                                1,
+                                3,
+                                5
+                            ],
+                            "default": 3
+                        }
+                    }
                 },
                 "metadata": {
                     "type": "object",
                     "title": "Metadata",
+                    "required": [
+                        "description",
+                        "name",
+                        "organization",
+                        "servicePriority"
+                    ],
                     "additionalProperties": false,
                     "properties": {
+                        "description": {
+                            "type": "string",
+                            "title": "Cluster description",
+                            "description": "User-friendly description of the cluster's purpose."
+                        },
                         "annotations": {
                             "type": "object",
                             "title": "Annotations",
                             "description": "These annotations are added to all Kubernetes resources defining this cluster.",
                             "additionalProperties": false,
                             "patternProperties": {
-                                "^([a-zA-Z0-9\\.-]{1,253}\/)?[a-zA-Z0-9\\._-]{1,63}$": {
+                                "^([a-zA-Z0-9\\.-]{1,253}/)?[a-zA-Z0-9\\._-]{1,63}$": {
                                     "type": "string",
                                     "title": "Annotation",
                                     "minLength": 1
                                 }
                             }
-                        },
-                        "description": {
-                            "type": "string",
-                            "title": "Cluster description",
-                            "description": "User-friendly description of the cluster's purpose."
                         },
                         "labels": {
                             "type": "object",
@@ -861,13 +877,7 @@
                             ],
                             "default": "highest"
                         }
-                    },
-                    "required": [
-                        "description",
-                        "name",
-                        "organization",
-                        "servicePriority"
-                    ]
+                    }
                 },
                 "nodePools": {
                     "type": "object",
@@ -883,7 +893,7 @@
                                     "description": "These annotations are added to all Kubernetes resources defining this node pool.",
                                     "additionalProperties": false,
                                     "patternProperties": {
-                                        "^([a-zA-Z0-9\\.-]{1,253}\/)?[a-zA-Z0-9\\._-]{1,63}$": {
+                                        "^([a-zA-Z0-9\\.-]{1,253}/)?[a-zA-Z0-9\\._-]{1,63}$": {
                                             "type": "string",
                                             "title": "Annotation",
                                             "minLength": 1
@@ -949,24 +959,26 @@
                                     "type": "integer",
                                     "title": "Replicas",
                                     "description": "The number of node pool nodes.",
-                                    "minimum": 0,
-                                    "maximum": 1000
+                                    "maximum": 1000,
+                                    "minimum": 0
                                 }
                             }
                         }
                     }
                 }
-            },
-            "required": [
-                "components",
-                "connectivity",
-                "controlPlane",
-                "metadata"
-            ]
+            }
         },
         "internal": {
             "type": "object",
             "title": "Internal",
+            "required": [
+                "connectivity",
+                "components",
+                "controlPlane",
+                "kubernetesVersion",
+                "paused",
+                "resourcesApi"
+            ],
             "additionalProperties": false,
             "properties": {
                 "bastion": {
@@ -990,37 +1002,32 @@
                         }
                     }
                 },
-                "connectivity": {
-                    "type": "object",
-                    "title": "Connectivity",
-                    "description": "Internal connectivity configuration.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "sshSsoPublicKey": {
-                            "type": "string",
-                            "title": "SSH public key for single sign-on",
-                            "default": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"
-                        }
-                    },
-                    "required": [
-                        "sshSsoPublicKey"
-                    ]
-                },
                 "components": {
                     "type": "object",
                     "title": "Components",
                     "description": "Internal configuration of various components that form the Kubernetes cluster.",
+                    "required": [
+                        "cri"
+                    ],
                     "additionalProperties": false,
                     "properties": {
                         "cri": {
                             "type": "object",
                             "title": "CRI (container runtime interface)",
                             "description": "Configuration of container runtime interface.",
+                            "required": [
+                                "sandboxContainerImage"
+                            ],
                             "additionalProperties": false,
                             "properties": {
                                 "sandboxContainerImage": {
                                     "type": "object",
                                     "title": "Kubectl image",
+                                    "required": [
+                                        "name",
+                                        "registry",
+                                        "tag"
+                                    ],
                                     "properties": {
                                         "name": {
                                             "type": "string",
@@ -1037,17 +1044,9 @@
                                             "title": "Tag",
                                             "default": "3.9"
                                         }
-                                    },
-                                    "required": [
-                                        "name",
-                                        "registry",
-                                        "tag"
-                                    ]
+                                    }
                                 }
-                            },
-                            "required": [
-                                "sandboxContainerImage"
-                            ]
+                            }
                         },
                         "kubelet": {
                             "title": "Kubelet",
@@ -1114,25 +1113,42 @@
                                 }
                             ]
                         }
-                    },
+                    }
+                },
+                "connectivity": {
+                    "type": "object",
+                    "title": "Connectivity",
+                    "description": "Internal connectivity configuration.",
                     "required": [
-                        "cri"
-                    ]
+                        "sshSsoPublicKey"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                        "sshSsoPublicKey": {
+                            "type": "string",
+                            "title": "SSH public key for single sign-on",
+                            "default": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"
+                        }
+                    }
                 },
                 "controlPlane": {
                     "type": "object",
                     "title": "Internal control plane configuration",
+                    "required": [
+                        "kubeadmConfig",
+                        "resources"
+                    ],
                     "additionalProperties": false,
                     "properties": {
                         "kubeadmConfig": {
                             "type": "object",
                             "title": "Kubeadm config",
                             "description": "Configuration of control plane nodes.",
+                            "required": [
+                                "ignition"
+                            ],
                             "additionalProperties": false,
                             "properties": {
-                                "ignition": {
-                                    "$ref": "#/$defs/ignition"
-                                },
                                 "clusterConfiguration": {
                                     "type": "object",
                                     "title": "Cluster configuration",
@@ -1166,6 +1182,9 @@
                                                         },
                                                         {
                                                             "type": "object",
+                                                            "required": [
+                                                                "templateName"
+                                                            ],
                                                             "additionalProperties": false,
                                                             "properties": {
                                                                 "templateName": {
@@ -1173,8 +1192,7 @@
                                                                     "title": "Template name",
                                                                     "description": "The name of the Helm template which renders the 'api-audiences' value"
                                                                 }
-                                                            },
-                                                            "required": ["templateName"]
+                                                            }
                                                         }
                                                     ]
                                                 },
@@ -1184,21 +1202,21 @@
                                                     "items": {
                                                         "type": "object",
                                                         "title": "Feature gate",
-                                                        "additionalProperties": false,
-                                                        "properties": {
-                                                            "name": {
-                                                                "type": "string",
-                                                                "title": "Name"
-                                                            },
-                                                            "enabled": {
-                                                                "type": "boolean",
-                                                                "title": "Enabled"
-                                                            }
-                                                        },
                                                         "required": [
                                                             "name",
                                                             "enabled"
-                                                        ]
+                                                        ],
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "enabled": {
+                                                                "type": "boolean",
+                                                                "title": "Enabled"
+                                                            },
+                                                            "name": {
+                                                                "type": "string",
+                                                                "title": "Name"
+                                                            }
+                                                        }
                                                     }
                                                 },
                                                 "serviceAccountIssuer": {
@@ -1212,25 +1230,37 @@
                                                             "type": "object",
                                                             "additionalProperties": false,
                                                             "properties": {
-                                                                "url": {
-                                                                    "type": "string",
-                                                                    "title": "URL",
-                                                                    "description": "This URL is used as the identifier of the service account token issuer."
-                                                                },
                                                                 "clusterDomainPrefix": {
                                                                     "type": "string",
                                                                     "title": "Cluster domain prefix",
                                                                     "description": "Prefix that is prepended to the cluster domain name, so that resulting URL is used as the identifier of the service account token issuer."
+                                                                },
+                                                                "url": {
+                                                                    "type": "string",
+                                                                    "title": "URL",
+                                                                    "description": "This URL is used as the identifier of the service account token issuer."
                                                                 }
                                                             },
                                                             "oneOf": [
                                                                 {
-                                                                    "required": ["url"],
-                                                                    "not": {"required": ["clusterDomainPrefix"]}
+                                                                    "required": [
+                                                                        "url"
+                                                                    ],
+                                                                    "not": {
+                                                                        "required": [
+                                                                            "clusterDomainPrefix"
+                                                                        ]
+                                                                    }
                                                                 },
                                                                 {
-                                                                    "required": ["clusterDomainPrefix"],
-                                                                    "not": {"required": ["url"]}
+                                                                    "required": [
+                                                                        "clusterDomainPrefix"
+                                                                    ],
+                                                                    "not": {
+                                                                        "required": [
+                                                                            "url"
+                                                                        ]
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -1241,26 +1271,32 @@
                                         }
                                     }
                                 },
-                                "preKubeadmCommands": {
-                                    "$ref": "#/$defs/preKubeadmCommands"
+                                "ignition": {
+                                    "$ref": "#/$defs/ignition"
                                 },
                                 "postKubeadmCommands": {
                                     "$ref": "#/$defs/postKubeadmCommands"
+                                },
+                                "preKubeadmCommands": {
+                                    "$ref": "#/$defs/preKubeadmCommands"
                                 }
-                            },
-                            "required": [
-                                "ignition"
-                            ]
+                            }
                         },
                         "resources": {
                             "type": "object",
                             "title": "Resources configuration",
                             "description": "GVK and other configuration for control plane resources.",
+                            "required": [
+                                "controlPlane"
+                            ],
                             "additionalProperties": false,
                             "properties": {
                                 "controlPlane": {
                                     "type": "object",
                                     "title": "Control plane resource config",
+                                    "required": [
+                                        "api"
+                                    ],
                                     "additionalProperties": false,
                                     "properties": {
                                         "api": {
@@ -1270,24 +1306,14 @@
                                     "default": {
                                         "api": {
                                             "group": "controlplane.cluster.x-k8s.io",
-                                            "version": "v1beta1",
-                                            "kind": "KubeadmControlPlane"
+                                            "kind": "KubeadmControlPlane",
+                                            "version": "v1beta1"
                                         }
-                                    },
-                                    "required": [
-                                        "api"
-                                    ]
+                                    }
                                 }
-                            },
-                            "required": [
-                                "controlPlane"
-                            ]
+                            }
                         }
-                    },
-                    "required": [
-                        "kubeadmConfig",
-                        "resources"
-                    ]
+                    }
                 },
                 "hashSalt": {
                     "type": "string",
@@ -1303,11 +1329,11 @@
                         "ignition": {
                             "$ref": "#/$defs/ignition"
                         },
-                        "preKubeadmCommands": {
-                            "$ref": "#/$defs/preKubeadmCommands"
-                        },
                         "postKubeadmCommands": {
                             "$ref": "#/$defs/postKubeadmCommands"
+                        },
+                        "preKubeadmCommands": {
+                            "$ref": "#/$defs/preKubeadmCommands"
                         }
                     }
                 },
@@ -1328,10 +1354,10 @@
                     "type": "object",
                     "title": "Resources API",
                     "description": "Group, version and kind configuration that is required and used by a specific Cluster API provider.",
+                    "required": [
+                        "infrastructureCluster"
+                    ],
                     "properties": {
-                        "infrastructureCluster": {
-                            "$ref": "#/$defs/infrastructureCluster"
-                        },
                         "bastion": {
                             "type": "object",
                             "title": "Bastion",
@@ -1346,13 +1372,17 @@
                                     "description": "The name of Helm template that renders Infrastructure Machine template spec."
                                 }
                             }
+                        },
+                        "infrastructureCluster": {
+                            "$ref": "#/$defs/infrastructureCluster"
                         }
                     },
-                    "required": [
-                        "infrastructureCluster"
-                    ],
                     "oneOf": [
                         {
+                            "required": [
+                                "infrastructureMachinePool",
+                                "nodePoolKind"
+                            ],
                             "properties": {
                                 "infrastructureMachinePool": {
                                     "$ref": "#/$defs/infrastructureMachinePool"
@@ -1360,21 +1390,17 @@
                                 "nodePoolKind": {
                                     "const": "MachinePool"
                                 }
-                            },
-                            "required": [
-                                "infrastructureMachinePool",
-                                "nodePoolKind"
-                            ]
+                            }
                         },
                         {
+                            "required": [
+                                "nodePoolKind"
+                            ],
                             "properties": {
                                 "nodePoolKind": {
                                     "const": "MachineDeployment"
                                 }
                             },
-                            "required": [
-                                "nodePoolKind"
-                            ],
                             "not": {
                                 "required": [
                                     "infrastructureMachinePool"
@@ -1392,33 +1418,25 @@
                             "type": "object",
                             "title": "Kubeadm config",
                             "description": "Configuration of workers nodes.",
+                            "required": [
+                                "ignition"
+                            ],
                             "additionalProperties": false,
                             "properties": {
                                 "ignition": {
                                     "$ref": "#/$defs/ignition"
                                 },
-                                "preKubeadmCommands": {
-                                    "$ref": "#/$defs/preKubeadmCommands"
-                                },
                                 "postKubeadmCommands": {
                                     "$ref": "#/$defs/postKubeadmCommands"
+                                },
+                                "preKubeadmCommands": {
+                                    "$ref": "#/$defs/preKubeadmCommands"
                                 }
-                            },
-                            "required": [
-                                "ignition"
-                            ]
+                            }
                         }
                     }
                 }
-            },
-            "required":[
-                "connectivity",
-                "components",
-                "controlPlane",
-                "kubernetesVersion",
-                "paused",
-                "resourcesApi"
-            ]
+            }
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?

The PR normalizes the schema, as until this point it was built without being normalized (fast-paced development, it was changing a lot, and I forgot to run normalization it the whole process).

The PR also disables cluster-app rule-set in schema lint, as that is still not working for the `cluster` chart since it has some assumptions that should be updated (like which top level properties we must have in the schema). We will enable this again when we update the schema linter.
