### PR TITLE
Add feature flags to enable/disable resources

### DIFF
--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -243,6 +243,11 @@ internal:
   kubernetesVersion: 1.24.10
   paused: false
   resourcesApi:
+    clusterResourceEnabled: true
+    controlPlaneResourceEnabled: true
+    machinePoolResourcesEnabled: true
+    machineHealthCheckResourceEnabled: true
+    bastionResourceEnabled: true
     nodePoolKind: MachinePool
     infrastructureCluster:
       group: infrastructure.cluster.x-k8s.io

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -161,12 +161,6 @@ internal:
       postKubeadmCommands:
       - echo "hello control plane after kubeadm"
       - echo "cluster control plane after kubeadm"
-    resources:
-      controlPlane:
-        api:
-          group: asd
-          version: v1
-          kind: KubeadmControlPlane
   components:
     kubelet:
       gracefulNodeShutdown:

--- a/helm/cluster/templates/_helpers.tpl
+++ b/helm/cluster/templates/_helpers.tpl
@@ -4,14 +4,14 @@
 Expand the name of the chart.
 */}}
 {{- define "cluster.chart.name" -}}
-{{- $.Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "cluster.chart.nameAndVersion" -}}
-{{- printf "%s-%s" $.Chart.Name $.Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -21,7 +21,7 @@ Given that Kubernetes allows 63 characters for resource names, the stem is trunc
 room for such suffix.
 */}}
 {{- define "cluster.resource.name" -}}
-{{- $.Values.global.metadata.name | default ($.Release.Name | replace "." "-" | trunc 47 | trimSuffix "-") -}}
+{{- .Values.global.metadata.name | default (.Release.Name | replace "." "-" | trunc 47 | trimSuffix "-") -}}
 {{- end -}}
 
 {{/*
@@ -29,28 +29,28 @@ Common labels
 */}}
 {{- define "cluster.labels.common" -}}
 app: {{ include "cluster.chart.name" . | quote }}
-app.kubernetes.io/managed-by: {{ $.Release.Service | quote }}
-app.kubernetes.io/version: {{ $.Chart.Version | quote }}
-application.giantswarm.io/team: {{ index $.Chart.Annotations "application.giantswarm.io/team" | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+app.kubernetes.io/version: {{ .Chart.Version | quote }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
 giantswarm.io/cluster: {{ include "cluster.resource.name" . | quote }}
-giantswarm.io/organization: {{ required "You must provide an existing organization name in .global.metadata.organization" $.Values.global.metadata.organization | quote }}
-giantswarm.io/service-priority: {{ $.Values.global.metadata.servicePriority }}
-cluster.x-k8s.io/cluster-name: {{ include "cluster.resource.name" . | quote }}
+giantswarm.io/organization: {{ required "You must provide an existing organization name in .global.metadata.organization" .Values.global.metadata.organization | quote }}
+giantswarm.io/service-priority: {{ .Values.global.metadata.servicePriority }}
+cluster.x-k8s.io/cluster-name: {{ include "cluster.resource.name" $ | quote }}
 cluster.x-k8s.io/watch-filter: capi
-helm.sh/chart: {{ include "cluster.chart.nameAndVersion" . | quote }}
+helm.sh/chart: {{ include "cluster.chart.nameAndVersion" $ | quote }}
 {{- end -}}
 
 {{- define "cluster.labels.custom" }}
-{{- if $.Values.global.metadata.labels }}
-{{- range $key, $val := $.Values.global.metadata.labels }}
+{{- if .Values.global.metadata.labels }}
+{{- range $key, $val := .Values.global.metadata.labels }}
 {{ $key }}: {{ $val | quote }}
 {{- end }}
 {{- end }}
 {{- end }}
 
 {{- define "cluster.annotations.custom" }}
-{{- if $.Values.global.metadata.annotations }}
-{{- range $key, $val := $.Values.global.metadata.annotations }}
+{{- if .Values.global.metadata.annotations }}
+{{- range $key, $val := .Values.global.metadata.annotations }}
 {{ $key }}: {{ $val | quote }}
 {{- end }}
 {{- end }}
@@ -59,7 +59,7 @@ helm.sh/chart: {{ include "cluster.chart.nameAndVersion" . | quote }}
 {{/*
 Hash function based on data provided
 Expects two arguments (as a `dict`) E.g.
-  {{ include "hash" (dict "data" . "salt" $.Values.internal.hasSalt) }}
+  {{ include "hash" (dict "data" . "salt" .Values.internal.hasSalt) }}
 Where `data` is the data to hash and `global` is the top level scope.
 */}}
 {{- define "cluster.data.hash" -}}

--- a/helm/cluster/templates/bastion/kubeadmconfigtemplate.yaml
+++ b/helm/cluster/templates/bastion/kubeadmconfigtemplate.yaml
@@ -1,3 +1,5 @@
+{{- if $.Values.internal.resourcesApi.bastionResourceEnabled }}
+{{- if .Values.global.connectivity.bastion.enabled }}
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
@@ -14,3 +16,5 @@ spec:
   template:
     spec:
       {{- include "cluster.internal.bastion.kubeadmconfigtemplate.spec" $ | indent 6 }}
+{{- end }}
+{{- end }}

--- a/helm/cluster/templates/bastion/machinedeployment.yaml
+++ b/helm/cluster/templates/bastion/machinedeployment.yaml
@@ -1,3 +1,4 @@
+{{- if $.Values.internal.resourcesApi.bastionResourceEnabled }}
 {{- if .Values.global.connectivity.bastion.enabled }}
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -44,4 +45,5 @@ spec:
         kind: {{ $.Values.internal.resourcesApi.bastion.infrastructureMachineTemplate.kind }}
         name: {{ include "cluster.resource.name" $ }}-bastion-{{ include "cluster.data.hash" (dict "data" (include $.Values.internal.resourcesApi.bastion.infrastructureMachineTemplateSpecTemplateName $) "salt" $.Values.internal.hashSalt) }}
       version: {{ $.Values.internal.kubernetesVersion }}
+{{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/cluster.yaml
+++ b/helm/cluster/templates/clusterapi/cluster.yaml
@@ -1,3 +1,4 @@
+{{- if $.Values.internal.resourcesApi.clusterResourceEnabled }}
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
@@ -34,3 +35,4 @@ spec:
   {{- if .Values.internal.paused }}
   paused: true
   {{- end -}}
+{{- end }}

--- a/helm/cluster/templates/clusterapi/controlplane/kubeadmcontrolplane.yaml
+++ b/helm/cluster/templates/clusterapi/controlplane/kubeadmcontrolplane.yaml
@@ -1,3 +1,4 @@
+{{- if $.Values.internal.resourcesApi.controlPlaneResourceEnabled }}
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
 metadata:
@@ -50,3 +51,4 @@ spec:
     {{- include "cluster.internal.controlPlane.kubeadm.postKubeadmCommands" $ | indent 4 }}
     users:
     {{- include "cluster.internal.kubeadm.users" $ | indent 4 }}
+{{- end }}

--- a/helm/cluster/templates/clusterapi/controlplane/machinehealthcheck.yaml
+++ b/helm/cluster/templates/clusterapi/controlplane/machinehealthcheck.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- end }}
     {{- end }}
   labels:
-    {{- include "cluster.labels.common" . | nindent 4 }}
+    {{- include "cluster.labels.common" $ | nindent 4 }}
     {{- if $.Values.global.metadata.labels }}
     {{- range $key, $val := $.Values.global.metadata.labels }}
     {{ $key }}: {{ $val | quote }}

--- a/helm/cluster/templates/clusterapi/controlplane/machinehealthcheck.yaml
+++ b/helm/cluster/templates/clusterapi/controlplane/machinehealthcheck.yaml
@@ -1,3 +1,5 @@
+{{- if $.Values.internal.resourcesApi.controlPlaneResourceEnabled }}
+{{- if $.Values.internal.resourcesApi.machineHealthCheckResourceEnabled }}
 {{- if $.Values.global.controlPlane.machineHealthCheck.enabled }}
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck
@@ -32,4 +34,6 @@ spec:
   - type: Ready
     status: "False"
     timeout: {{ $.Values.global.controlPlane.machineHealthCheck.unhealthyNotReadyTimeout }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/workers/kubeadmconfig.yaml
+++ b/helm/cluster/templates/clusterapi/workers/kubeadmconfig.yaml
@@ -1,3 +1,4 @@
+{{- if $.Values.internal.resourcesApi.machinePoolResourcesEnabled }}
 {{- if eq $.Values.internal.resourcesApi.nodePoolKind "MachinePool" }}
 {{- range $nodePoolName, $nodePoolConfig := $.Values.global.nodePools }}
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
@@ -37,5 +38,6 @@ spec:
   files:
   {{- include "cluster.internal.workers.kubeadm.files" $ | indent 2 }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/workers/machinepool.yaml
+++ b/helm/cluster/templates/clusterapi/workers/machinepool.yaml
@@ -1,3 +1,4 @@
+{{- if $.Values.internal.resourcesApi.machinePoolResourcesEnabled }}
 {{- if eq $.Values.internal.resourcesApi.nodePoolKind "MachinePool" }}
 {{- range $nodePoolName, $nodePoolConfig := $.Values.global.nodePools }}
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -40,5 +41,6 @@ spec:
         name: {{ include "cluster.resource.name" $ }}-{{ $nodePoolName }}
       version: {{ $.Values.internal.kubernetesVersion }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/containerd_config.yaml
+++ b/helm/cluster/templates/containerd_config.yaml
@@ -1,6 +1,8 @@
+{{- if or $.Values.internal.resourcesApi.controlPlaneResourceEnabled $.Values.internal.resourcesApi.machinePoolResourcesEnabled }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "cluster.resource.name" $ }}-registry-configuration
 data:
   registry-config.toml: {{ tpl ($.Files.Get "files/etc/containerd/config.toml") $ | b64enc | quote }}
+{{- end }}

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1355,7 +1355,12 @@
                     "title": "Resources API",
                     "description": "Group, version and kind configuration that is required and used by a specific Cluster API provider.",
                     "required": [
-                        "infrastructureCluster"
+                        "infrastructureCluster",
+                        "clusterResourceEnabled",
+                        "controlPlaneResourceEnabled",
+                        "machinePoolResourcesEnabled",
+                        "machineHealthCheckResourceEnabled",
+                        "bastionResourceEnabled"
                     ],
                     "properties": {
                         "bastion": {
@@ -1373,8 +1378,38 @@
                                 }
                             }
                         },
+                        "bastionResourceEnabled": {
+                            "type": "boolean",
+                            "title": "Bastion resource enabled",
+                            "description": "Flag that indicates if the Bastion resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.",
+                            "default": true
+                        },
+                        "clusterResourceEnabled": {
+                            "type": "boolean",
+                            "title": "Cluster resource enabled",
+                            "description": "Flag that indicates if the Cluster resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.",
+                            "default": true
+                        },
+                        "controlPlaneResourceEnabled": {
+                            "type": "boolean",
+                            "title": "Control plane resource enabled",
+                            "description": "Flag that indicates if the control plane resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.",
+                            "default": true
+                        },
                         "infrastructureCluster": {
                             "$ref": "#/$defs/infrastructureCluster"
+                        },
+                        "machineHealthCheckResourceEnabled": {
+                            "type": "boolean",
+                            "title": "MachineHealthCheck resource enabled",
+                            "description": "Flag that indicates if the MachineHealthCheck resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.",
+                            "default": true
+                        },
+                        "machinePoolResourcesEnabled": {
+                            "type": "boolean",
+                            "title": "Machine pool resources enabled",
+                            "description": "Flag that indicates if the machine pool resources are enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.",
+                            "default": true
                         }
                     },
                     "oneOf": [

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -70,7 +70,12 @@ internal:
   resourcesApi:
     bastion:
       infrastructureMachineTemplate: {}
+    bastionResourceEnabled: true
+    clusterResourceEnabled: true
+    controlPlaneResourceEnabled: true
     infrastructureCluster: {}
+    machineHealthCheckResourceEnabled: true
+    machinePoolResourcesEnabled: true
   workers:
     kubeadmConfig:
       ignition:


### PR DESCRIPTION
### What does this PR do?

This PR adds feature flags so we can select which resources are templated.

### What is the effect of this change to users?

The sole purpose of this is for the initial development so we can incrementally (but quickly) introduce `cluster` chart into `cluster-$provider` apps.

So we can introduce the change in multiple pull requests, e.g.
- A PR that removes Cluster resource in `cluster-aws` and uses Cluster resource from `cluster-chart`
- A PR that removes KubeadmControlPlane resource in `cluster-aws` and uses KubeadmControlPlane resource from `cluster-chart`
- A PR that removes MachinePool and KubeadmConfig resources for node pools in `cluster-aws` and uses MachinePool and KubeadmConfig resources from `cluster-chart`
- etc.

### How does it look like?

In `cluster-$provider` helm values we will have something like this:
```
cluster:
  internal:
    resourcesApi:
      clusterResourceEnabled: true
      controlPlaneResourceEnabled: false
      machinePoolResourcesEnabled: false
      machineHealthCheckResourceEnabled: false
      bastionResourceEnabled: false
```

So we enable one flag in every PR.

### Any background context you can provide?

Cluster chart will introduce a very big structural change in existing `cluster-$provider` apps, so this will help to introduce it more easily as it will enable smaller PRs which will be more easily reviewed.
