### PR TITLE
Fix KubeadmControlPlane

### DIFF
--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -161,6 +161,12 @@ internal:
       postKubeadmCommands:
       - echo "hello control plane after kubeadm"
       - echo "cluster control plane after kubeadm"
+    resources:
+      infrastructureMachineTemplate:
+        group: infrastructure.cluster.x-k8s.io
+        version: v1beta1
+        kind: AWSMachineTemplate
+      infrastructureMachineTemplateSpecTemplateName: "cluster.internal.test.controlPlane.machineTemplate.spec"
   components:
     kubelet:
       gracefulNodeShutdown:

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers.tpl
@@ -1,0 +1,8 @@
+{{- define "cluster.internal.test.controlPlane.machineTemplate.spec" -}}
+template:
+  metadata:
+    cluster.x-k8s.io/role: controlPlane
+    {{- include "cluster.labels.common" $ | nindent 4 }}
+  spec:
+    machineType: "superBig"
+{{- end -}}

--- a/helm/cluster/templates/clusterapi/controlplane/kubeadmcontrolplane.yaml
+++ b/helm/cluster/templates/clusterapi/controlplane/kubeadmcontrolplane.yaml
@@ -11,15 +11,19 @@ metadata:
     {{- end }}
   labels:
     {{- include "cluster.labels.common" $ | nindent 4 }}
-    {{- if $.Values.global.metadata.labels }}
-    {{- range $key, $val := $.Values.global.metadata.labels }}
-    {{ $key }}: {{ $val | quote }}
-    {{- end }}
-    {{- end }}
+    {{- include "cluster.labels.custom" $ | indent 4 }}
   name: {{ include "cluster.resource.name" $ }}
   namespace: {{ .Release.Namespace }}
 spec:
-  version: v{{ trimPrefix "v" .Values.internal.kubernetesVersion }}
+  machineTemplate:
+    metadata:
+      labels:
+        {{- include "cluster.labels.common" $ | nindent 8 }}
+        {{- include "cluster.labels.custom" $ | indent 8 }}
+    infrastructureRef:
+      apiVersion: {{ $.Values.internal.controlPlane.resources.infrastructureMachineTemplate.group }}/{{ $.Values.internal.controlPlane.resources.infrastructureMachineTemplate.version }}
+      kind: {{ $.Values.internal.controlPlane.resources.infrastructureMachineTemplate.kind }}
+      name: {{ include "cluster.resource.name" $ }}-control-plane-{{ include "cluster.data.hash" (dict "data" (include $.Values.internal.controlPlane.resources.infrastructureMachineTemplateSpecTemplateName $) "salt" $.Values.internal.hashSalt) }}
   kubeadmConfigSpec:
     format: ignition
     ignition:
@@ -51,4 +55,6 @@ spec:
     {{- include "cluster.internal.controlPlane.kubeadm.postKubeadmCommands" $ | indent 4 }}
     users:
     {{- include "cluster.internal.kubeadm.users" $ | indent 4 }}
+  replicas: {{ .Values.global.controlPlane.replicas }}
+  version: v{{ trimPrefix "v" .Values.internal.kubernetesVersion }}
 {{- end }}

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1287,7 +1287,9 @@
                             "title": "Resources configuration",
                             "description": "GVK and other configuration for control plane resources.",
                             "required": [
-                                "controlPlane"
+                                "controlPlane",
+                                "infrastructureMachineTemplate",
+                                "infrastructureMachineTemplateSpecTemplateName"
                             ],
                             "additionalProperties": false,
                             "properties": {
@@ -1310,6 +1312,14 @@
                                             "version": "v1beta1"
                                         }
                                     }
+                                },
+                                "infrastructureMachineTemplate": {
+                                    "$ref": "#/$defs/infrastructureMachineTemplate"
+                                },
+                                "infrastructureMachineTemplateSpecTemplateName": {
+                                    "type": "string",
+                                    "title": "Infrastructure Machine template spec template name",
+                                    "description": "The name of Helm template that renders Infrastructure Machine template spec."
                                 }
                             }
                         }

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -59,6 +59,7 @@ internal:
           group: controlplane.cluster.x-k8s.io
           kind: KubeadmControlPlane
           version: v1beta1
+      infrastructureMachineTemplate: {}
   kubeadmConfig:
     ignition:
       containerLinuxConfig:


### PR DESCRIPTION
### What does this PR do?

This PR fixes control plane resources:
- Add missing machine template to KubeadmControlPlane.

### What is the effect of this change to users?

Control plane resources are templated correctly.

### How does it look like?

Updated KubeadmControlPlane resource:

```
/spec  (KubeadmControlPlane/org-giantswarm/awesome)
  + two map entries added:
    machineTemplate:
      metadata:
        labels:
          app: cluster
          app.kubernetes.io/managed-by: Helm
          app.kubernetes.io/version: 0.1.0-dev
          application.giantswarm.io/team: turtles
          giantswarm.io/cluster: awesome
          giantswarm.io/organization: giantswarm
          giantswarm.io/service-priority: highest
          cluster.x-k8s.io/cluster-name: awesome
          cluster.x-k8s.io/watch-filter: capi
          helm.sh/chart: cluster-0.1.0-dev
          another-cluster-label: label-2
          some-cluster-label: label-1
      infrastructureRef:
        name: awesome-control-plane-f786309f
        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
        kind: AWSMachineTemplate
    replicas: 3
```

### Any background context you can provide?

https://github.com/giantswarm/roadmap/issues/2742