### PR TITLE
Add Teleport support

### DIFF
--- a/Makefile.development.mk
+++ b/Makefile.development.mk
@@ -14,6 +14,4 @@ generate-schema: ensure-schema-gen ## Generate the values.schema.json file from 
 .PHONY: template
 template: ## Output the rendered Helm template
 	@cd helm/cluster && \
-		sed -i 's/version: \[/version: 1 #\[/' Chart.yaml && \
-		helm template -f ci/ci-values.yaml --debug . && \
-		sed -i 's/version: 1 #\[/version: \[/' Chart.yaml
+		helm template -f ci/ci-values.yaml --debug .

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -3,6 +3,7 @@ global:
     name: awesome
     organization: giantswarm
     description: "Awesome Giant Swarm cluster"
+    managementCluster: giantmc
     labels:
       some-cluster-label: label-1
       another-cluster-label: label-2
@@ -294,6 +295,8 @@ internal:
         version: v1beta1
         kind: AWSMachineTemplate
       infrastructureMachineTemplateSpecTemplateName: "cluster.test.bastion.machineTemplate.spec"
+  teleport:
+    enabled: true
   workers:
     kubeadmConfig:
       files:

--- a/helm/cluster/files/etc/teleport.yaml
+++ b/helm/cluster/files/etc/teleport.yaml
@@ -1,0 +1,32 @@
+version: v3
+teleport:
+  data_dir: /var/lib/teleport
+  join_params:
+    token_name: /etc/teleport-join-token
+    method: token
+  proxy_server: {{ .Values.internal.teleport.proxyAddr }}
+  log:
+    output: stderr
+auth_service:
+  enabled: "no"
+ssh_service:
+  enabled: "yes"
+  commands:
+  - name: node
+    command: [hostname]
+    period: 24h0m0s
+  - name: arch
+    command: [uname, -m]
+    period: 24h0m0s
+  - name: role
+    command: [/opt/teleport-node-role.sh]
+    period: 1m0s
+  labels:
+    mc: {{ .Values.global.metadata.managementCluster }}
+    {{- $clusterName := include "cluster.resource.name" $ }}
+    {{- if ne .Values.managementCluster $clusterName }}
+    cluster: {{ include "cluster.resource.name" $ }}
+    {{- end }}
+    baseDomain: {{ .Values.global.connectivity.baseDomain }}
+proxy_service:
+  enabled: "no"

--- a/helm/cluster/files/opt/teleport-node-role.sh
+++ b/helm/cluster/files/opt/teleport-node-role.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if systemctl is-active -q kubelet.service; then
+    if [ -e "/etc/kubernetes/manifests/kube-apiserver.yaml" ]; then
+        echo "control-plane"
+    else
+        echo "worker"
+    fi
+else
+    echo ""
+fi

--- a/helm/cluster/templates/clusterapi/_helpers_files.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_files.tpl
@@ -5,6 +5,7 @@
 {{- include "cluster.internal.kubeadm.files.cri" $ }}
 {{- include "cluster.internal.kubeadm.files.kubelet" $ }}
 {{- include "cluster.internal.kubeadm.files.proxy" $ }}
+{{- include "cluster.internal.kubeadm.files.teleport" $ }}
 {{- include "cluster.internal.kubeadm.files.custom" $ }}
 {{- end }}
 
@@ -71,6 +72,35 @@
   permissions: "0644"
   encoding: base64
   content: {{ tpl ($.Files.Get "files/etc/systemd/http-proxy.conf") $ | b64enc }}
+{{- if $.Values.internal.teleport.enabled }}
+- path: /etc/systemd/system/teleport.service.d/http-proxy.conf
+  permissions: "0644"
+  encoding: base64
+  content: {{ tpl ($.Files.Get "files/etc/systemd/http-proxy.conf") $ | b64enc }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+The secret `-teleport-join-token` is created by the teleport-operator in cluster namespace
+and is used to join the node to the teleport cluster.
+*/}}
+{{- define "cluster.internal.kubeadm.files.teleport" }}
+{{- if $.Values.internal.teleport.enabled }}
+- path: /etc/teleport-join-token
+  permissions: "0644"
+  contentFrom:
+    secret:
+      name: {{ include "cluster.resource.name" $ }}-teleport-join-token
+      key: joinToken
+- path: /opt/teleport-node-role.sh
+  permissions: "0755"
+  encoding: base64
+  content: {{ $.Files.Get "files/opt/teleport-node-role.sh" | b64enc }}
+- path: /etc/teleport.yaml
+  permissions: "0644"
+  encoding: base64
+  content: {{ tpl ($.Files.Get "files/etc/teleport.yaml") . | b64enc }}
 {{- end }}
 {{- end }}
 

--- a/helm/cluster/templates/clusterapi/_helpers_flatcar.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_flatcar.tpl
@@ -1,3 +1,7 @@
+{{- define "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units.default" }}
+{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units.teleport" $ }}
+{{- end }}
+
 {{- define "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" }}
 {{- range . }}
 - name: {{ .name }}
@@ -82,5 +86,27 @@
     name: {{ .group.name }}
     {{- end }}
   {{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units.teleport" }}
+{{- if $.Values.internal.teleport.enabled }}
+- name: teleport.service
+  enabled: true
+  contents: |
+    [Unit]
+    Description=Teleport Service
+    After=network.target
+
+    [Service]
+    Type=simple
+    Restart=on-failure
+    ExecStart=/opt/bin/teleport start --roles=node --config=/etc/teleport.yaml --pid-file=/run/teleport.pid
+    ExecReload=/bin/kill -HUP $MAINPID
+    PIDFile=/run/teleport.pid
+    LimitNOFILE=524288
+
+    [Install]
+    WantedBy=multi-user.target
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_flatcar.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_flatcar.tpl
@@ -3,6 +3,7 @@ containerLinuxConfig:
   additionalConfig: |
     systemd:
       units:
+      {{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units.default" $ | indent 6 }}
       {{- include "cluster.internal.controlPlane.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $ | indent 6 }}
     storage:
       filesystems:

--- a/helm/cluster/templates/clusterapi/workers/_helpers_flatcar.tpl
+++ b/helm/cluster/templates/clusterapi/workers/_helpers_flatcar.tpl
@@ -3,6 +3,7 @@ containerLinuxConfig:
   additionalConfig: |
     systemd:
       units:
+      {{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units.default" $ | indent 6 }}
       {{- include "cluster.internal.workers.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $ | indent 6 }}
     storage:
       directories:

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -904,6 +904,11 @@
                                 }
                             }
                         },
+                        "managementCluster": {
+                            "type": "string",
+                            "title": "Management cluster",
+                            "description": "Name of the Cluster API cluster managing this workload cluster."
+                        },
                         "name": {
                             "type": "string",
                             "title": "Cluster name",
@@ -1589,6 +1594,27 @@
                             }
                         }
                     ]
+                },
+                "teleport": {
+                    "type": "object",
+                    "title": "Teleport",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "title": "Enable teleport",
+                            "default": false
+                        },
+                        "proxyAddr": {
+                            "type": "string",
+                            "title": "Teleport proxy address",
+                            "default": "test.teleport.giantswarm.io:443"
+                        },
+                        "version": {
+                            "type": "string",
+                            "title": "Teleport version",
+                            "default": "13.3.8"
+                        }
+                    }
                 },
                 "workers": {
                     "type": "object",

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -81,6 +81,10 @@ internal:
     infrastructureCluster: {}
     machineHealthCheckResourceEnabled: true
     machinePoolResourcesEnabled: true
+  teleport:
+    enabled: false
+    proxyAddr: test.teleport.giantswarm.io:443
+    version: 13.3.8
   workers:
     kubeadmConfig:
       ignition:


### PR DESCRIPTION
### What does this PR do?

This PR adds Teleport support that was originally added in cluster-aws here https://github.com/giantswarm/cluster-aws/pull/334.

### What is the effect of this change to users?

Teleport can be optionally enabled.

### How does it look like?

`cluster` chart Helm values to enable Teleport:
```
internal:
  teleport:
    enabled: true
```

### Any background context you can provide?

- https://github.com/giantswarm/roadmap/issues/2742
- https://github.com/giantswarm/cluster-aws/pull/334

### What is needed from the reviewers?

Check if the Teleport has been ported properly from cluster-aws.

### Do the docs need to be updated?

We don't yet have proper docs for the `cluster` chart.

### Should this change be mentioned in the release notes?

We have yet to write proper release notes for the `cluster` chart. For now it's just about porting stuff over from `cluster-aws`, so we will add a summary before the first release.