### PR TITLE
Make schema compatible with cluster-aws

### DIFF
--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -51,8 +51,8 @@ global:
       nodeLabels:
         workload-type: robots
   components:
-    cri:
-      registries:
+    containerd:
+      containerRegistries:
         docker.io:
         - endpoint: registry-1.docker.io
           credentials:

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -1,9 +1,9 @@
 global:
+  managementCluster: giantmc
   metadata:
     name: awesome
     organization: giantswarm
     description: "Awesome Giant Swarm cluster"
-    managementCluster: giantmc
     labels:
       some-cluster-label: label-1
       another-cluster-label: label-2

--- a/helm/cluster/files/etc/containerd/config.toml
+++ b/helm/cluster/files/etc/containerd/config.toml
@@ -21,11 +21,11 @@ runtime_type = "io.containerd.runc.v2"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
 SystemdCgroup = true
 [plugins."io.containerd.grpc.v1.cri"]
-sandbox_image = "{{ $.Values.internal.components.cri.sandboxContainerImage.registry }}/{{ $.Values.internal.components.cri.sandboxContainerImage.name }}:{{ $.Values.internal.components.cri.sandboxContainerImage.tag }}"
+sandbox_image = "{{ $.Values.internal.components.containerd.sandboxContainerImage.registry }}/{{ $.Values.internal.components.containerd.sandboxContainerImage.name }}:{{ $.Values.internal.components.containerd.sandboxContainerImage.tag }}"
 
 [plugins."io.containerd.grpc.v1.cri".registry]
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-  {{- range $host, $config := $.Values.global.components.cri.registries }}
+  {{- range $host, $config := $.Values.global.components.containerd.containerRegistries }}
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{$host}}"]
       endpoint = [
         {{- range $value := $config -}}
@@ -34,7 +34,7 @@ sandbox_image = "{{ $.Values.internal.components.cri.sandboxContainerImage.regis
     ]
   {{- end }}
 [plugins."io.containerd.grpc.v1.cri".registry.configs]
-  {{ range $host, $config := $.Values.global.components.cri.registries -}}
+  {{ range $host, $config := $.Values.global.components.containerd.containerRegistries -}}
     {{ range $value := $config -}}
       {{ with $value.credentials -}}
       [plugins."io.containerd.grpc.v1.cri".registry.configs."{{$value.endpoint}}".auth]

--- a/helm/cluster/files/etc/teleport.yaml
+++ b/helm/cluster/files/etc/teleport.yaml
@@ -22,9 +22,9 @@ ssh_service:
     command: [/opt/teleport-node-role.sh]
     period: 1m0s
   labels:
-    mc: {{ .Values.global.metadata.managementCluster }}
+    mc: {{ .Values.global.managementCluster }}
     {{- $clusterName := include "cluster.resource.name" $ }}
-    {{- if ne .Values.managementCluster $clusterName }}
+    {{- if ne .Values.global.managementCluster $clusterName }}
     cluster: {{ include "cluster.resource.name" $ }}
     {{- end }}
     baseDomain: {{ .Values.global.connectivity.baseDomain }}

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -515,27 +515,24 @@
                 "controlPlane",
                 "metadata"
             ],
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
                 "components": {
                     "type": "object",
                     "title": "Components",
-                    "description": "Advanced configuration of machine and cluster components.",
-                    "required": [
-                        "cri"
-                    ],
+                    "description": "Advanced configuration of components that are running on all nodes.",
                     "additionalProperties": false,
                     "properties": {
-                        "cri": {
+                        "containerd": {
                             "type": "object",
-                            "title": "CRI (container runtime interface)",
-                            "description": "Configuration of container runtime interface.",
+                            "title": "Containerd",
+                            "description": "Configuration of containerd.",
                             "required": [
-                                "registries"
+                                "containerRegistries"
                             ],
                             "additionalProperties": false,
                             "properties": {
-                                "registries": {
+                                "containerRegistries": {
                                     "type": "object",
                                     "title": "Container registries",
                                     "description": "Endpoints and credentials configuration for container registries.",
@@ -1063,14 +1060,14 @@
                     "title": "Components",
                     "description": "Internal configuration of various components that form the Kubernetes cluster.",
                     "required": [
-                        "cri"
+                        "containerd"
                     ],
                     "additionalProperties": false,
                     "properties": {
-                        "cri": {
+                        "containerd": {
                             "type": "object",
-                            "title": "CRI (container runtime interface)",
-                            "description": "Configuration of container runtime interface.",
+                            "title": "Containerd",
+                            "description": "Configuration of containerd.",
                             "required": [
                                 "sandboxContainerImage"
                             ],

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -860,6 +860,11 @@
                         }
                     }
                 },
+                "managementCluster": {
+                    "type": "string",
+                    "title": "Management cluster",
+                    "description": "Name of the Cluster API cluster managing this workload cluster."
+                },
                 "metadata": {
                     "type": "object",
                     "title": "Metadata",
@@ -903,11 +908,6 @@
                                     "pattern": "^[a-zA-Z0-9\\._-]+$"
                                 }
                             }
-                        },
-                        "managementCluster": {
-                            "type": "string",
-                            "title": "Management cluster",
-                            "description": "Name of the Cluster API cluster managing this workload cluster."
                         },
                         "name": {
                             "type": "string",

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -2,8 +2,8 @@
 
 global:
   components:
-    cri:
-      registries:
+    containerd:
+      containerRegistries:
         docker.io:
           - endpoint: registry-1.docker.io
           - endpoint: giantswarm.azurecr.io
@@ -37,7 +37,7 @@ internal:
             storage: {}
             systemd: {}
   components:
-    cri:
+    containerd:
       sandboxContainerImage:
         name: giantswarm/pause
         registry: quay.io


### PR DESCRIPTION
### What does this PR do?

Updating global property names so they are the same as in cluster-aws.