### PR TITLE
Make schema less strict

### DIFF
--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_apiserver.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_apiserver.tpl
@@ -32,7 +32,7 @@ extraArgs:
   feature-gates: {{ include "cluster.internal.controlPlane.kubeadm.clusterConfiguration.apiServer.featureGates" $ }}
   {{- end }}
   kubelet-preferred-address-types: InternalIP
-  {{- if $.Values.global.controlPlane.oidc }}
+  {{- if $.Values.global.controlPlane.oidc.issuerUrl }}
   {{- if $.Values.global.controlPlane.oidc.caPem }}
   oidc-ca-file: /etc/ssl/certs/oidc.pem
   {{- end }}

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -692,54 +692,65 @@
                             }
                         },
                         "proxy": {
+                            "type": "object",
                             "title": "Proxy",
                             "description": "Whether/how outgoing traffic is routed through proxy servers.",
-                            "default": null,
-                            "oneOf": [
-                                {
-                                    "type": "null"
+                            "required": [
+                                "enabled"
+                            ],
+                            "additionalProperties": false,
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "title": "Enable"
                                 },
-                                {
+                                "httpProxy": {
+                                    "type": "string",
+                                    "title": "HTTP proxy",
+                                    "description": "To be passed to the HTTP_PROXY environment variable in all hosts."
+                                },
+                                "httpsProxy": {
+                                    "type": "string",
+                                    "title": "HTTPS proxy",
+                                    "description": "To be passed to the HTTPS_PROXY environment variable in all hosts."
+                                },
+                                "noProxy": {
                                     "type": "object",
+                                    "title": "No proxy",
                                     "additionalProperties": false,
                                     "properties": {
-                                        "enabled": {
-                                            "type": "boolean",
-                                            "title": "Enable"
-                                        },
-                                        "httpProxy": {
-                                            "type": "string",
-                                            "title": "HTTP proxy",
-                                            "description": "To be passed to the HTTP_PROXY environment variable in all hosts."
-                                        },
-                                        "httpsProxy": {
-                                            "type": "string",
-                                            "title": "HTTPS proxy",
-                                            "description": "To be passed to the HTTPS_PROXY environment variable in all hosts."
-                                        },
-                                        "noProxy": {
-                                            "type": "object",
-                                            "title": "No proxy",
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "addresses": {
-                                                    "type": "array",
-                                                    "title": "Addresses",
-                                                    "description": "To be passed to the NO_PROXY environment variable in all hosts.",
-                                                    "items": {
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "addressesTemplate": {
-                                                    "type": "string",
-                                                    "title": "Addresses template",
-                                                    "description": "Name of Helm template that renders a YAML array with NO_PROXY addresses"
-                                                }
+                                        "addresses": {
+                                            "type": "array",
+                                            "title": "Addresses",
+                                            "description": "To be passed to the NO_PROXY environment variable in all hosts.",
+                                            "items": {
+                                                "type": "string"
                                             }
+                                        },
+                                        "addressesTemplate": {
+                                            "type": "string",
+                                            "title": "Addresses template",
+                                            "description": "Name of Helm template that renders a YAML array with NO_PROXY addresses"
                                         }
                                     }
                                 }
-                            ]
+                            },
+                            "default": {
+                                "enabled": false
+                            },
+                            "if": {
+                                "properties": {
+                                    "enabled": {
+                                        "const": true
+                                    }
+                                }
+                            },
+                            "then": {
+                                "required": [
+                                    "httpProxy",
+                                    "httpsProxy"
+                                ]
+                            }
                         }
                     }
                 },

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -801,46 +801,32 @@
                             }
                         },
                         "oidc": {
+                            "type": "object",
                             "title": "OIDC authentication",
-                            "default": null,
-                            "oneOf": [
-                                {
-                                    "type": "object",
-                                    "required": [
-                                        "clientId",
-                                        "groupsClaim",
-                                        "issuerUrl",
-                                        "usernameClaim"
-                                    ],
-                                    "properties": {
-                                        "caPem": {
-                                            "type": "string",
-                                            "title": "Certificate authority",
-                                            "description": "Identity provider's CA certificate in PEM format."
-                                        },
-                                        "clientId": {
-                                            "type": "string",
-                                            "title": "Client ID"
-                                        },
-                                        "groupsClaim": {
-                                            "type": "string",
-                                            "title": "Groups claim"
-                                        },
-                                        "issuerUrl": {
-                                            "type": "string",
-                                            "title": "Issuer URL",
-                                            "description": "Exact issuer URL that will be included in identity tokens."
-                                        },
-                                        "usernameClaim": {
-                                            "type": "string",
-                                            "title": "Username claim"
-                                        }
-                                    }
+                            "properties": {
+                                "caPem": {
+                                    "type": "string",
+                                    "title": "Certificate authority",
+                                    "description": "Identity provider's CA certificate in PEM format."
                                 },
-                                {
-                                    "type": "null"
+                                "clientId": {
+                                    "type": "string",
+                                    "title": "Client ID"
+                                },
+                                "groupsClaim": {
+                                    "type": "string",
+                                    "title": "Groups claim"
+                                },
+                                "issuerUrl": {
+                                    "type": "string",
+                                    "title": "Issuer URL",
+                                    "description": "Exact issuer URL that will be included in identity tokens."
+                                },
+                                "usernameClaim": {
+                                    "type": "string",
+                                    "title": "Username claim"
                                 }
-                            ]
+                            }
                         },
                         "replicas": {
                             "type": "integer",

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -737,19 +737,6 @@
                             },
                             "default": {
                                 "enabled": false
-                            },
-                            "if": {
-                                "properties": {
-                                    "enabled": {
-                                        "const": true
-                                    }
-                                }
-                            },
-                            "then": {
-                                "required": [
-                                    "httpProxy",
-                                    "httpsProxy"
-                                ]
                             }
                         }
                     }

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -730,7 +730,7 @@
                                         "addressesTemplate": {
                                             "type": "string",
                                             "title": "Addresses template",
-                                            "description": "Name of Helm template that renders a YAML array with NO_PROXY addresses"
+                                            "description": "Name of Helm template that renders a YAML array with NO_PROXY addresses."
                                         }
                                     }
                                 }

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -18,6 +18,8 @@ global:
       services:
         cidrBlocks:
           - 172.31.0.0/16
+    proxy:
+      enabled: false
   controlPlane:
     machineHealthCheck:
       enabled: true

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -27,6 +27,7 @@ global:
       nodeStartupTimeout: 8m0s
       unhealthyNotReadyTimeout: 10m0s
       unhealthyUnknownTimeout: 10m0s
+    oidc: {}
     replicas: 3
   metadata:
     servicePriority: highest


### PR DESCRIPTION
### What does this PR do?

This PR changes schema validation so it is less strict when validating OIDC and proxy. This change is done because `schemalint` currently does fully support using JSON schema with `oneOf`, `if` and `then`.

### What is the effect of this change to users?

- Schema validation works in the CI.
- OIDC and proxy properties are not validated in the schema and it's easier to provide incorrect Helm values.

### How does it look like?

See files diff.
