### PR TITLE
Fix schema so we start using it in cluster-aws

### DIFF
--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -177,7 +177,7 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.strict` | **Strict** - It controls if AdditionalConfig should be strictly parsed. If so, warnings are treated as errors.|**Type:** `boolean`<br/>|
 | `providerIntegration.bastion.kubeadmConfig.preKubeadmCommands` | **Pre-kubeadm commands** - Extra commands to run before kubeadm runs.|**Type:** `array`<br/>|
 | `providerIntegration.bastion.kubeadmConfig.preKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
-| `providerIntegration.clusterLabelsTemplateName` | **Cluster labels template name** - The name of the template that renders provider-specific labels for the Cluster resource|**Type:** `string`<br/>|
+| `providerIntegration.clusterAnnotationsTemplateName` | **Cluster annotations template name** - The name of the template that renders provider-specific annotations for the Cluster resource|**Type:** `string`<br/>|
 | `providerIntegration.components` | **Components** - Internal configuration of various components that form the Kubernetes cluster.|**Type:** `object`<br/>|
 | `providerIntegration.components.containerd` | **Containerd** - Configuration of containerd.|**Type:** `object`<br/>|
 | `providerIntegration.components.containerd.sandboxContainerImage` | **Kubectl image**|**Type:** `object`<br/>|

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -300,10 +300,6 @@ Properties within the `.internal` top-level object
 | `internal.resourcesApi.bastionResourceEnabled` | **Bastion resource enabled** - Flag that indicates if the Bastion resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.|**Type:** `boolean`<br/>**Default:** `true`|
 | `internal.resourcesApi.clusterResourceEnabled` | **Cluster resource enabled** - Flag that indicates if the Cluster resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.|**Type:** `boolean`<br/>**Default:** `true`|
 | `internal.resourcesApi.controlPlaneResourceEnabled` | **Control plane resource enabled** - Flag that indicates if the control plane resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.|**Type:** `boolean`<br/>**Default:** `true`|
-| `internal.resourcesApi.infrastructureCluster` | **Infrastructure cluster** - Group, version and kind of provider-specific infrastructure cluster resource.|**Type:** `object`<br/>|
-| `internal.resourcesApi.infrastructureCluster.group` | **API group**|**Type:** `string`<br/>**Example:** `"infrastructure.cluster.x-k8s.io"`<br/>|
-| `internal.resourcesApi.infrastructureCluster.kind` | **API kind**|**Type:** `string`<br/>**Examples:** `"AWSCluster", "AzureCluster", "VCDCluster", "VSphereCluster"`<br/>|
-| `internal.resourcesApi.infrastructureCluster.version` | **API version**|**Type:** `string`<br/>**Examples:** `"v1alpha1", "v1beta1", "v1beta2", "v1", "v2"`<br/>|
 | `internal.resourcesApi.machineHealthCheckResourceEnabled` | **MachineHealthCheck resource enabled** - Flag that indicates if the MachineHealthCheck resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.|**Type:** `boolean`<br/>**Default:** `true`|
 | `internal.resourcesApi.machinePoolResourcesEnabled` | **Machine pool resources enabled** - Flag that indicates if the machine pool resources are enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.|**Type:** `boolean`<br/>**Default:** `true`|
 | `internal.teleport` | **Teleport**|**Type:** `object`<br/>|
@@ -403,6 +399,18 @@ Properties within the `.global.nodePools` object
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
 | `global.managementCluster` | **Management cluster** - Name of the Cluster API cluster managing this workload cluster.|**Type:** `string`<br/>|
+
+### Provider chart integration
+Properties within the `.providerChartIntegration` top-level object
+Provider-specific properties that must be set by cluster-$provider chart in order to render correct templates for the provider.
+
+| **Property** | **Description** | **More Details** |
+| :----------- | :-------------- | :--------------- |
+| `providerChartIntegration.resourcesApi` | **Resources API** - Group, version and kind configuration that is required and used by a specific Cluster API provider.|**Type:** `object`<br/>|
+| `providerChartIntegration.resourcesApi.infrastructureCluster` | **Infrastructure cluster** - Group, version and kind of provider-specific infrastructure cluster resource.|**Type:** `object`<br/>|
+| `providerChartIntegration.resourcesApi.infrastructureCluster.group` | **API group**|**Type:** `string`<br/>**Example:** `"infrastructure.cluster.x-k8s.io"`<br/>|
+| `providerChartIntegration.resourcesApi.infrastructureCluster.kind` | **API kind**|**Type:** `string`<br/>**Examples:** `"AWSCluster", "AzureCluster", "VCDCluster", "VSphereCluster"`<br/>|
+| `providerChartIntegration.resourcesApi.infrastructureCluster.version` | **API version**|**Type:** `string`<br/>**Examples:** `"v1alpha1", "v1beta1", "v1beta2", "v1", "v2"`<br/>|
 
 
 

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -329,7 +329,8 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.kubeadmConfig.preKubeadmCommands` | **Pre-kubeadm commands** - Extra commands to run before kubeadm runs.|**Type:** `array`<br/>|
 | `providerIntegration.kubeadmConfig.preKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
 | `providerIntegration.kubernetesVersion` | **Kubernetes version**|**Type:** `string`<br/>**Example:** `"1.24.7"`<br/>**Default:** `"1.24.10"`|
-| `providerIntegration.paused` | **Paused**|**Type:** `boolean`<br/>**Default:** `false`|
+| `providerIntegration.pauseProperties` | **Pause properties** - A map of property names and their values that will affect setting pause annotation|**Type:** `object`<br/>|
+| `providerIntegration.pauseProperties.*` |**None**|**Types:** `string, number, integer, boolean`<br/>|
 | `providerIntegration.resourcesApi` | **Resources API** - Group, version and kind configuration that is required and used by a specific Cluster API provider.|**Type:** `object`<br/>|
 | `providerIntegration.resourcesApi.bastion` | **Bastion** - Configuration of bastion resources API and names.|**Type:** `object`<br/>|
 | `providerIntegration.resourcesApi.bastion.infrastructureMachineTemplate` | **Infrastructure Machine template** - Group, version and kind of provider-specific infrastructure Machine template resource.|**Type:** `object`<br/>|
@@ -346,6 +347,7 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.resourcesApi.infrastructureCluster.version` | **API version**|**Type:** `string`<br/>**Examples:** `"v1alpha1", "v1beta1", "v1beta2", "v1", "v2"`<br/>|
 | `providerIntegration.resourcesApi.machineHealthCheckResourceEnabled` | **MachineHealthCheck resource enabled** - Flag that indicates if the MachineHealthCheck resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.|**Type:** `boolean`<br/>**Default:** `true`|
 | `providerIntegration.resourcesApi.machinePoolResourcesEnabled` | **Machine pool resources enabled** - Flag that indicates if the machine pool resources are enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.|**Type:** `boolean`<br/>**Default:** `true`|
+| `providerIntegration.resourcesApi.nodePoolKind` | **Node pool kind** - Specifies which resource kind is used for node pools.|**Type:** `string`<br/>|
 | `providerIntegration.teleport` | **Teleport**|**Type:** `object`<br/>|
 | `providerIntegration.teleport.enabled` | **Enable teleport**|**Type:** `boolean`<br/>**Default:** `false`|
 | `providerIntegration.teleport.proxyAddr` | **Teleport proxy address**|**Type:** `string`<br/>**Default:** `"test.teleport.giantswarm.io:443"`|

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -177,6 +177,7 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.strict` | **Strict** - It controls if AdditionalConfig should be strictly parsed. If so, warnings are treated as errors.|**Type:** `boolean`<br/>|
 | `providerIntegration.bastion.kubeadmConfig.preKubeadmCommands` | **Pre-kubeadm commands** - Extra commands to run before kubeadm runs.|**Type:** `array`<br/>|
 | `providerIntegration.bastion.kubeadmConfig.preKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
+| `providerIntegration.clusterLabelsTemplateName` | **Cluster labels template name** - The name of the template that renders provider-specific labels for the Cluster resource|**Type:** `string`<br/>|
 | `providerIntegration.components` | **Components** - Internal configuration of various components that form the Kubernetes cluster.|**Type:** `object`<br/>|
 | `providerIntegration.components.containerd` | **Containerd** - Configuration of containerd.|**Type:** `object`<br/>|
 | `providerIntegration.components.containerd.sandboxContainerImage` | **Kubectl image**|**Type:** `object`<br/>|
@@ -332,12 +333,6 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.pauseProperties` | **Pause properties** - A map of property names and their values that will affect setting pause annotation|**Type:** `object`<br/>|
 | `providerIntegration.pauseProperties.*` |**None**|**Types:** `string, number, integer, boolean`<br/>|
 | `providerIntegration.resourcesApi` | **Resources API** - Group, version and kind configuration that is required and used by a specific Cluster API provider.|**Type:** `object`<br/>|
-| `providerIntegration.resourcesApi.bastion` | **Bastion** - Configuration of bastion resources API and names.|**Type:** `object`<br/>|
-| `providerIntegration.resourcesApi.bastion.infrastructureMachineTemplate` | **Infrastructure Machine template** - Group, version and kind of provider-specific infrastructure Machine template resource.|**Type:** `object`<br/>|
-| `providerIntegration.resourcesApi.bastion.infrastructureMachineTemplate.group` | **API group**|**Type:** `string`<br/>**Example:** `"infrastructure.cluster.x-k8s.io"`<br/>|
-| `providerIntegration.resourcesApi.bastion.infrastructureMachineTemplate.kind` | **API kind**|**Type:** `string`<br/>**Examples:** `"AWSMachineTemplate", "AzureMachineTemplate"`<br/>|
-| `providerIntegration.resourcesApi.bastion.infrastructureMachineTemplate.version` | **API version**|**Type:** `string`<br/>**Examples:** `"v1alpha1", "v1beta1", "v1beta2", "v1", "v2"`<br/>|
-| `providerIntegration.resourcesApi.bastion.infrastructureMachineTemplateSpecTemplateName` | **Infrastructure Machine template spec template name** - The name of Helm template that renders Infrastructure Machine template spec.|**Type:** `string`<br/>|
 | `providerIntegration.resourcesApi.bastionResourceEnabled` | **Bastion resource enabled** - Flag that indicates if the Bastion resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.|**Type:** `boolean`<br/>**Default:** `true`|
 | `providerIntegration.resourcesApi.clusterResourceEnabled` | **Cluster resource enabled** - Flag that indicates if the Cluster resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.|**Type:** `boolean`<br/>**Default:** `true`|
 | `providerIntegration.resourcesApi.controlPlaneResourceEnabled` | **Control plane resource enabled** - Flag that indicates if the control plane resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.|**Type:** `boolean`<br/>**Default:** `true`|
@@ -347,7 +342,6 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.resourcesApi.infrastructureCluster.version` | **API version**|**Type:** `string`<br/>**Examples:** `"v1alpha1", "v1beta1", "v1beta2", "v1", "v2"`<br/>|
 | `providerIntegration.resourcesApi.machineHealthCheckResourceEnabled` | **MachineHealthCheck resource enabled** - Flag that indicates if the MachineHealthCheck resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.|**Type:** `boolean`<br/>**Default:** `true`|
 | `providerIntegration.resourcesApi.machinePoolResourcesEnabled` | **Machine pool resources enabled** - Flag that indicates if the machine pool resources are enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.|**Type:** `boolean`<br/>**Default:** `true`|
-| `providerIntegration.resourcesApi.nodePoolKind` | **Node pool kind** - Specifies which resource kind is used for node pools.|**Type:** `string`<br/>|
 | `providerIntegration.teleport` | **Teleport**|**Type:** `object`<br/>|
 | `providerIntegration.teleport.enabled` | **Enable teleport**|**Type:** `boolean`<br/>**Default:** `false`|
 | `providerIntegration.teleport.proxyAddr` | **Teleport proxy address**|**Type:** `string`<br/>**Default:** `"test.teleport.giantswarm.io:443"`|

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -88,279 +88,6 @@ Configuration of the control plane.
 | `global.controlPlane.oidc.usernameClaim` | **Username claim**|**Type:** `string`<br/>|
 | `global.controlPlane.replicas` | **Replicas** - The number of control plane nodes.|**Type:** `integer`<br/>**Default:** `3`|
 
-### Internal
-Properties within the `.internal` top-level object
-
-| **Property** | **Description** | **More Details** |
-| :----------- | :-------------- | :--------------- |
-| `internal.bastion` | **Internal bastion configuration**|**Type:** `object`<br/>|
-| `internal.bastion.kubeadmConfig` | **Kubeadm config** - Configuration of bastion nodes.|**Type:** `object`<br/>|
-| `internal.bastion.kubeadmConfig.ignition` | **Ignition** - Ignition-specific configuration.|**Type:** `object`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig` | **Container Linux configuration**|**Type:** `object`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig` | **Additional config** - Additional configuration to be merged with the Ignition. More info: https://coreos.github.io/ignition/operator-notes/#config-merging.|**Type:** `object`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage` | **Storage** - It describes the desired state of the system’s storage devices.|**Type:** `object`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories` | **Directories** - The list of directories to be created.|**Type:** `array`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*]` | **Directory** - The directory to be created.|**Type:** `object`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].filesystem` | **Filesystem** - The internal identifier of the filesystem in which to create the directory. This matches the last filesystem with the given identifier.|**Type:** `string`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].group` | **Group** - It specifies the group of the owner.|**Type:** `object`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].group.id` | **ID** - The group ID of the owner.|**Type:** `integer`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].group.name` | **Name** - The group name of the owner.|**Type:** `string`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].mode` | **Mode** - The directory’s permission mode.|**Type:** `integer`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].overwrite` | **Overwrite** - Whether to delete preexisting nodes at the path.|**Type:** `boolean`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].path` | **Path** - The absolute path to the directory.|**Type:** `string`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].user` | **User** - It specifies the directory’s owner.|**Type:** `object`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].user.id` | **ID** - The user ID of the owner.|**Type:** `integer`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].user.name` | **Name** - The user name of the owner.|**Type:** `string`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems` | **File systems** - The list of filesystems to be configured and/or used in the “files” section. Either “mount” or “path” needs to be specified.|**Type:** `array`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*]` | **File system** - The filesystem to be configured and/or used in the “files” section. Either “mount” or “path” needs to be specified.|**Type:** `object`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount` | **Mount** - It contains the set of mount and formatting options for the filesystem. A non-null entry indicates that the filesystem should be mounted before it is used by Ignition.|**Type:** `object`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.device` | **Device** - The absolute path to the device. Devices are typically referenced by the /dev/disk/by-* symlinks.|**Type:** `string`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.format` | **Format** - The filesystem format (ext4, btrfs, or xfs).|**Type:** `string`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.label` | **Label** - The label of the filesystem.|**Type:** `string`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.options` | **Options** - Any additional options to be passed to the format-specific mkfs utility.|**Type:** `array`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.options[*]` |An additional option to be passed to the format-specific mkfs utility.|**Type:** `string`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.uuid` | **UUID** - The uuid of the filesystem.|**Type:** `string`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.wipeFilesystem` | **Wipe filesystem** - Whether or not to wipe the device before filesystem creation, see Ignition’s documentation on filesystems for more information https://github.com/coreos/ignition/blob/main/docs/operator-notes.md#filesystem-reuse-semantics.|**Type:** `boolean`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].name` | **Name** - The identifier for the filesystem, internal to Ignition. This is only required if the filesystem needs to be referenced in the “files” section.|**Type:** `string`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].path` | **Path** - The mount-point of the filesystem. A non-null entry indicates that the filesystem has already been mounted by the system at the specified path. This is really only useful for “/sysroot”.|**Type:** `string`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd` | **systemd** - It describes the desired state of the systemd units.|**Type:** `object`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units` | **Units**|**Type:** `array`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*]` | **systemd unit**|**Type:** `object`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents` | **Contents** - The contents of the unit.|**Type:** `string`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins` | **Unit drop-ins** - The list of drop-ins for the unit|**Type:** `array`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins[*]` | **Unit drop-in**|**Type:** `object`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins[*].contents` | **Contents** - The contents of the drop-in.|**Type:** `string`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins[*].name` | **Name** - The name of the drop-in. This must be suffixed with “.conf”|**Type:** `string`<br/>**Value pattern:** `^.+\.conf$`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].enabled` | **Enabled?** - Whether or not the service shall be enabled. When true, the service is enabled. When false, the service is disabled. When omitted, the service is unmodified. In order for this to have any effect, the unit must have an install section.|**Type:** `boolean`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].mask` | **Masked?** - Whether or not the service shall be masked. When true, the service is masked by symlinking it to /dev/null.|**Type:** `boolean`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].name` | **Name** - The name of the unit. This must be suffixed with a valid unit type (e.g. “thing.service”).|**Type:** `string`<br/>|
-| `internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.strict` | **Strict** - It controls if AdditionalConfig should be strictly parsed. If so, warnings are treated as errors.|**Type:** `boolean`<br/>|
-| `internal.bastion.kubeadmConfig.preKubeadmCommands` | **Pre-kubeadm commands** - Extra commands to run before kubeadm runs.|**Type:** `array`<br/>|
-| `internal.bastion.kubeadmConfig.preKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
-| `internal.components` | **Components** - Internal configuration of various components that form the Kubernetes cluster.|**Type:** `object`<br/>|
-| `internal.components.containerd` | **Containerd** - Configuration of containerd.|**Type:** `object`<br/>|
-| `internal.components.containerd.sandboxContainerImage` | **Kubectl image**|**Type:** `object`<br/>|
-| `internal.components.containerd.sandboxContainerImage.name` | **Repository**|**Type:** `string`<br/>**Default:** `"giantswarm/pause"`|
-| `internal.components.containerd.sandboxContainerImage.registry` | **Registry**|**Type:** `string`<br/>**Default:** `"quay.io"`|
-| `internal.components.containerd.sandboxContainerImage.tag` | **Tag**|**Type:** `string`<br/>**Default:** `"3.9"`|
-| `internal.components.kubelet` | **Kubelet** - Kubelet configuration that is used on all nodes.||
-| `internal.components.systemd` | **systemd**||
-| `internal.connectivity` | **Connectivity** - Internal connectivity configuration.|**Type:** `object`<br/>|
-| `internal.connectivity.sshSsoPublicKey` | **SSH public key for single sign-on**|**Type:** `string`<br/>**Default:** `"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"`|
-| `internal.controlPlane` | **Internal control plane configuration**|**Type:** `object`<br/>|
-| `internal.controlPlane.kubeadmConfig` | **Kubeadm config** - Configuration of control plane nodes.|**Type:** `object`<br/>|
-| `internal.controlPlane.kubeadmConfig.clusterConfiguration` | **Cluster configuration** - Configuration of Kubernetes components.|**Type:** `object`<br/>|
-| `internal.controlPlane.kubeadmConfig.clusterConfiguration.apiServer` | **API server** - Configuration of API server.|**Type:** `object`<br/>**Default:** `{}`|
-| `internal.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.additionalAdmissionPlugins` | **Additional admission plugins** - A list of plugins to enable, in addition to the default ones that include DefaultStorageClass, DefaultTolerationSeconds, LimitRanger, MutatingAdmissionWebhook, NamespaceLifecycle, PersistentVolumeClaimResize, Priority, ResourceQuota, ServiceAccount and ValidatingAdmissionWebhook.|**Type:** `array`<br/>|
-| `internal.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.additionalAdmissionPlugins[*]` | **Additional admission plugin**|**Type:** `string`<br/>|
-| `internal.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.apiAudiences` | **API audiences** - Identifiers of the API. The service account token authenticator will validate that tokens used against the API are bound to at least one of these audiences. If the --service-account-issuer flag is configured and this flag is not, 'api-audiences' field defaults to a single element list containing the issuer URL.||
-| `internal.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.etcdPrefix` | **etcd prefix**|**Type:** `string`<br/>|
-| `internal.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.extraArgs` | **Extra args**|**Type:** `object`<br/>|
-| `internal.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.extraCertificateSANs` | **Extra certificate SANs** - The additional certificate SANs that are appended to the default SANs.|**Type:** `array`<br/>|
-| `internal.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.extraCertificateSANs[*]` | **Extra certificate SAN**|**Type:** `string`<br/>|
-| `internal.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates` | **Feature gates**|**Type:** `array`<br/>|
-| `internal.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates[*]` | **Feature gate**|**Type:** `object`<br/>|
-| `internal.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates[*].enabled` | **Enabled**|**Type:** `boolean`<br/>|
-| `internal.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates[*].name` | **Name**|**Type:** `string`<br/>|
-| `internal.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.serviceAccountIssuer` | **Service account issuer** - Configuration of the identifier of the service account token issuer. You must specify either URL or clusterDomainPrefix (only one, not both).||
-| `internal.controlPlane.kubeadmConfig.clusterConfiguration.etcd` | **etcd** - Configuration of etcd|**Type:** `object`<br/>|
-| `internal.controlPlane.kubeadmConfig.clusterConfiguration.etcd.experimental` | **Experimental**|**Type:** `object`<br/>|
-| `internal.controlPlane.kubeadmConfig.clusterConfiguration.etcd.experimental.peerSkipClientSanVerification` | **Peer skip client SAN verification** - Skip verification of SAN field in client certificate for peer connections.|**Type:** `boolean`<br/>|
-| `internal.controlPlane.kubeadmConfig.clusterConfiguration.etcd.extraArgs` | **Extra args**|**Type:** `object`<br/>|
-| `internal.controlPlane.kubeadmConfig.clusterConfiguration.etcd.initialCluster` | **Initial cluster** - Initial cluster configuration for bootstrapping.|**Type:** `string`<br/>|
-| `internal.controlPlane.kubeadmConfig.clusterConfiguration.etcd.initialClusterState` | **Initial cluster state**|**Type:** `string`<br/>|
-| `internal.controlPlane.kubeadmConfig.files` | **Files** - These are the files that are included on control plane nodes.|**Type:** `array`<br/>|
-| `internal.controlPlane.kubeadmConfig.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
-| `internal.controlPlane.kubeadmConfig.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|
-| `internal.controlPlane.kubeadmConfig.files[*].contentFrom.secret` | **Secret** - Kubernetes Secret resource with the file content.|**Type:** `object`<br/>|
-| `internal.controlPlane.kubeadmConfig.files[*].contentFrom.secret.key` | **Key** - Secret key where the file content is.|**Type:** `string`<br/>|
-| `internal.controlPlane.kubeadmConfig.files[*].contentFrom.secret.name` | **Name** - Name of the Secret resource.|**Type:** `string`<br/>|
-| `internal.controlPlane.kubeadmConfig.files[*].path` | **Path** - File path on the node.|**Type:** `string`<br/>|
-| `internal.controlPlane.kubeadmConfig.files[*].permissions` | **Permissions** - File permissions in form 0644|**Type:** `string`<br/>**Default:** `"0644"`|
-| `internal.controlPlane.kubeadmConfig.ignition` | **Ignition** - Ignition-specific configuration.|**Type:** `object`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig` | **Container Linux configuration**|**Type:** `object`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig` | **Additional config** - Additional configuration to be merged with the Ignition. More info: https://coreos.github.io/ignition/operator-notes/#config-merging.|**Type:** `object`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage` | **Storage** - It describes the desired state of the system’s storage devices.|**Type:** `object`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories` | **Directories** - The list of directories to be created.|**Type:** `array`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*]` | **Directory** - The directory to be created.|**Type:** `object`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].filesystem` | **Filesystem** - The internal identifier of the filesystem in which to create the directory. This matches the last filesystem with the given identifier.|**Type:** `string`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].group` | **Group** - It specifies the group of the owner.|**Type:** `object`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].group.id` | **ID** - The group ID of the owner.|**Type:** `integer`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].group.name` | **Name** - The group name of the owner.|**Type:** `string`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].mode` | **Mode** - The directory’s permission mode.|**Type:** `integer`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].overwrite` | **Overwrite** - Whether to delete preexisting nodes at the path.|**Type:** `boolean`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].path` | **Path** - The absolute path to the directory.|**Type:** `string`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].user` | **User** - It specifies the directory’s owner.|**Type:** `object`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].user.id` | **ID** - The user ID of the owner.|**Type:** `integer`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].user.name` | **Name** - The user name of the owner.|**Type:** `string`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems` | **File systems** - The list of filesystems to be configured and/or used in the “files” section. Either “mount” or “path” needs to be specified.|**Type:** `array`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*]` | **File system** - The filesystem to be configured and/or used in the “files” section. Either “mount” or “path” needs to be specified.|**Type:** `object`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount` | **Mount** - It contains the set of mount and formatting options for the filesystem. A non-null entry indicates that the filesystem should be mounted before it is used by Ignition.|**Type:** `object`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.device` | **Device** - The absolute path to the device. Devices are typically referenced by the /dev/disk/by-* symlinks.|**Type:** `string`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.format` | **Format** - The filesystem format (ext4, btrfs, or xfs).|**Type:** `string`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.label` | **Label** - The label of the filesystem.|**Type:** `string`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.options` | **Options** - Any additional options to be passed to the format-specific mkfs utility.|**Type:** `array`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.options[*]` |An additional option to be passed to the format-specific mkfs utility.|**Type:** `string`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.uuid` | **UUID** - The uuid of the filesystem.|**Type:** `string`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.wipeFilesystem` | **Wipe filesystem** - Whether or not to wipe the device before filesystem creation, see Ignition’s documentation on filesystems for more information https://github.com/coreos/ignition/blob/main/docs/operator-notes.md#filesystem-reuse-semantics.|**Type:** `boolean`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].name` | **Name** - The identifier for the filesystem, internal to Ignition. This is only required if the filesystem needs to be referenced in the “files” section.|**Type:** `string`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].path` | **Path** - The mount-point of the filesystem. A non-null entry indicates that the filesystem has already been mounted by the system at the specified path. This is really only useful for “/sysroot”.|**Type:** `string`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd` | **systemd** - It describes the desired state of the systemd units.|**Type:** `object`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units` | **Units**|**Type:** `array`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*]` | **systemd unit**|**Type:** `object`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents` | **Contents** - The contents of the unit.|**Type:** `string`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins` | **Unit drop-ins** - The list of drop-ins for the unit|**Type:** `array`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins[*]` | **Unit drop-in**|**Type:** `object`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins[*].contents` | **Contents** - The contents of the drop-in.|**Type:** `string`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins[*].name` | **Name** - The name of the drop-in. This must be suffixed with “.conf”|**Type:** `string`<br/>**Value pattern:** `^.+\.conf$`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].enabled` | **Enabled?** - Whether or not the service shall be enabled. When true, the service is enabled. When false, the service is disabled. When omitted, the service is unmodified. In order for this to have any effect, the unit must have an install section.|**Type:** `boolean`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].mask` | **Masked?** - Whether or not the service shall be masked. When true, the service is masked by symlinking it to /dev/null.|**Type:** `boolean`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].name` | **Name** - The name of the unit. This must be suffixed with a valid unit type (e.g. “thing.service”).|**Type:** `string`<br/>|
-| `internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.strict` | **Strict** - It controls if AdditionalConfig should be strictly parsed. If so, warnings are treated as errors.|**Type:** `boolean`<br/>|
-| `internal.controlPlane.kubeadmConfig.localAPIEndpoint` | **Local API endpoint**|**Type:** `object`<br/>|
-| `internal.controlPlane.kubeadmConfig.localAPIEndpoint.bindPort` | **Bind port** - Kubernetes API bind port used for API server pod.|**Type:** `integer`<br/>**Default:** `6443`|
-| `internal.controlPlane.kubeadmConfig.postKubeadmCommands` | **Post-kubeadm commands** - Extra commands to run after kubeadm runs.|**Type:** `array`<br/>|
-| `internal.controlPlane.kubeadmConfig.postKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
-| `internal.controlPlane.kubeadmConfig.preKubeadmCommands` | **Pre-kubeadm commands** - Extra commands to run before kubeadm runs.|**Type:** `array`<br/>|
-| `internal.controlPlane.kubeadmConfig.preKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
-| `internal.controlPlane.resources` | **Resources configuration** - GVK and other configuration for control plane resources.|**Type:** `object`<br/>|
-| `internal.controlPlane.resources.controlPlane` | **Control plane resource config**|**Type:** `object`<br/>**Default:** `{"api":{"group":"controlplane.cluster.x-k8s.io","kind":"KubeadmControlPlane","version":"v1beta1"}}`|
-| `internal.controlPlane.resources.controlPlane.api` | **Schema for Kubernetes API group, version and kind** - It can be used to specify which CustomResourceDefinition is used.|**Type:** `object`<br/>|
-| `internal.controlPlane.resources.controlPlane.api.group` | **API group**|**Type:** `string`<br/>**Examples:** `"cluster.x-k8s.io", "controlplane.cluster.x-k8s.io", "infrastructure.cluster.x-k8s.io"`<br/>|
-| `internal.controlPlane.resources.controlPlane.api.kind` | **API kind**|**Type:** `string`<br/>**Examples:** `"Cluster", "KubeadmControlPlane"`<br/>|
-| `internal.controlPlane.resources.controlPlane.api.version` | **API version**|**Type:** `string`<br/>**Examples:** `"v1alpha1", "v1alpha2", "v1beta1", "v1"`<br/>|
-| `internal.controlPlane.resources.infrastructureMachineTemplate` | **Infrastructure Machine template** - Group, version and kind of provider-specific infrastructure Machine template resource.|**Type:** `object`<br/>|
-| `internal.controlPlane.resources.infrastructureMachineTemplate.group` | **API group**|**Type:** `string`<br/>**Example:** `"infrastructure.cluster.x-k8s.io"`<br/>|
-| `internal.controlPlane.resources.infrastructureMachineTemplate.kind` | **API kind**|**Type:** `string`<br/>**Examples:** `"AWSMachineTemplate", "AzureMachineTemplate"`<br/>|
-| `internal.controlPlane.resources.infrastructureMachineTemplate.version` | **API version**|**Type:** `string`<br/>**Examples:** `"v1alpha1", "v1beta1", "v1beta2", "v1", "v2"`<br/>|
-| `internal.controlPlane.resources.infrastructureMachineTemplateSpecTemplateName` | **Infrastructure Machine template spec template name** - The name of Helm template that renders Infrastructure Machine template spec.|**Type:** `string`<br/>|
-| `internal.hashSalt` | **Hash salt** - If specified, this token is used as a salt to the hash suffix of some resource names. Can be used to force-recreate some resources.|**Type:** `string`<br/>|
-| `internal.kubeadmConfig` | **Kubeadm config** - Common kubeadm config for all nodes, including both control plane and workers.|**Type:** `object`<br/>|
-| `internal.kubeadmConfig.files` | **Files** - These are the files that are included on all the nodes.|**Type:** `array`<br/>|
-| `internal.kubeadmConfig.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
-| `internal.kubeadmConfig.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|
-| `internal.kubeadmConfig.files[*].contentFrom.secret` | **Secret** - Kubernetes Secret resource with the file content.|**Type:** `object`<br/>|
-| `internal.kubeadmConfig.files[*].contentFrom.secret.key` | **Key** - Secret key where the file content is.|**Type:** `string`<br/>|
-| `internal.kubeadmConfig.files[*].contentFrom.secret.name` | **Name** - Name of the Secret resource.|**Type:** `string`<br/>|
-| `internal.kubeadmConfig.files[*].path` | **Path** - File path on the node.|**Type:** `string`<br/>|
-| `internal.kubeadmConfig.files[*].permissions` | **Permissions** - File permissions in form 0644|**Type:** `string`<br/>**Default:** `"0644"`|
-| `internal.kubeadmConfig.ignition` | **Ignition** - Ignition-specific configuration.|**Type:** `object`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig` | **Container Linux configuration**|**Type:** `object`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig` | **Additional config** - Additional configuration to be merged with the Ignition. More info: https://coreos.github.io/ignition/operator-notes/#config-merging.|**Type:** `object`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage` | **Storage** - It describes the desired state of the system’s storage devices.|**Type:** `object`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories` | **Directories** - The list of directories to be created.|**Type:** `array`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*]` | **Directory** - The directory to be created.|**Type:** `object`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].filesystem` | **Filesystem** - The internal identifier of the filesystem in which to create the directory. This matches the last filesystem with the given identifier.|**Type:** `string`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].group` | **Group** - It specifies the group of the owner.|**Type:** `object`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].group.id` | **ID** - The group ID of the owner.|**Type:** `integer`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].group.name` | **Name** - The group name of the owner.|**Type:** `string`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].mode` | **Mode** - The directory’s permission mode.|**Type:** `integer`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].overwrite` | **Overwrite** - Whether to delete preexisting nodes at the path.|**Type:** `boolean`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].path` | **Path** - The absolute path to the directory.|**Type:** `string`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].user` | **User** - It specifies the directory’s owner.|**Type:** `object`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].user.id` | **ID** - The user ID of the owner.|**Type:** `integer`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].user.name` | **Name** - The user name of the owner.|**Type:** `string`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems` | **File systems** - The list of filesystems to be configured and/or used in the “files” section. Either “mount” or “path” needs to be specified.|**Type:** `array`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*]` | **File system** - The filesystem to be configured and/or used in the “files” section. Either “mount” or “path” needs to be specified.|**Type:** `object`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount` | **Mount** - It contains the set of mount and formatting options for the filesystem. A non-null entry indicates that the filesystem should be mounted before it is used by Ignition.|**Type:** `object`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.device` | **Device** - The absolute path to the device. Devices are typically referenced by the /dev/disk/by-* symlinks.|**Type:** `string`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.format` | **Format** - The filesystem format (ext4, btrfs, or xfs).|**Type:** `string`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.label` | **Label** - The label of the filesystem.|**Type:** `string`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.options` | **Options** - Any additional options to be passed to the format-specific mkfs utility.|**Type:** `array`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.options[*]` |An additional option to be passed to the format-specific mkfs utility.|**Type:** `string`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.uuid` | **UUID** - The uuid of the filesystem.|**Type:** `string`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.wipeFilesystem` | **Wipe filesystem** - Whether or not to wipe the device before filesystem creation, see Ignition’s documentation on filesystems for more information https://github.com/coreos/ignition/blob/main/docs/operator-notes.md#filesystem-reuse-semantics.|**Type:** `boolean`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].name` | **Name** - The identifier for the filesystem, internal to Ignition. This is only required if the filesystem needs to be referenced in the “files” section.|**Type:** `string`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].path` | **Path** - The mount-point of the filesystem. A non-null entry indicates that the filesystem has already been mounted by the system at the specified path. This is really only useful for “/sysroot”.|**Type:** `string`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd` | **systemd** - It describes the desired state of the systemd units.|**Type:** `object`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units` | **Units**|**Type:** `array`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*]` | **systemd unit**|**Type:** `object`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents` | **Contents** - The contents of the unit.|**Type:** `string`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins` | **Unit drop-ins** - The list of drop-ins for the unit|**Type:** `array`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins[*]` | **Unit drop-in**|**Type:** `object`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins[*].contents` | **Contents** - The contents of the drop-in.|**Type:** `string`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins[*].name` | **Name** - The name of the drop-in. This must be suffixed with “.conf”|**Type:** `string`<br/>**Value pattern:** `^.+\.conf$`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].enabled` | **Enabled?** - Whether or not the service shall be enabled. When true, the service is enabled. When false, the service is disabled. When omitted, the service is unmodified. In order for this to have any effect, the unit must have an install section.|**Type:** `boolean`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].mask` | **Masked?** - Whether or not the service shall be masked. When true, the service is masked by symlinking it to /dev/null.|**Type:** `boolean`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].name` | **Name** - The name of the unit. This must be suffixed with a valid unit type (e.g. “thing.service”).|**Type:** `string`<br/>|
-| `internal.kubeadmConfig.ignition.containerLinuxConfig.strict` | **Strict** - It controls if AdditionalConfig should be strictly parsed. If so, warnings are treated as errors.|**Type:** `boolean`<br/>|
-| `internal.kubeadmConfig.postKubeadmCommands` | **Post-kubeadm commands** - Extra commands to run after kubeadm runs.|**Type:** `array`<br/>|
-| `internal.kubeadmConfig.postKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
-| `internal.kubeadmConfig.preKubeadmCommands` | **Pre-kubeadm commands** - Extra commands to run before kubeadm runs.|**Type:** `array`<br/>|
-| `internal.kubeadmConfig.preKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
-| `internal.kubernetesVersion` | **Kubernetes version**|**Type:** `string`<br/>**Example:** `"1.24.7"`<br/>**Default:** `"1.24.10"`|
-| `internal.paused` | **Paused**|**Type:** `boolean`<br/>**Default:** `false`|
-| `internal.resourcesApi` | **Resources API** - Group, version and kind configuration that is required and used by a specific Cluster API provider.|**Type:** `object`<br/>|
-| `internal.resourcesApi.bastion` | **Bastion** - Configuration of bastion resources API and names.|**Type:** `object`<br/>|
-| `internal.resourcesApi.bastion.infrastructureMachineTemplate` | **Infrastructure Machine template** - Group, version and kind of provider-specific infrastructure Machine template resource.|**Type:** `object`<br/>|
-| `internal.resourcesApi.bastion.infrastructureMachineTemplate.group` | **API group**|**Type:** `string`<br/>**Example:** `"infrastructure.cluster.x-k8s.io"`<br/>|
-| `internal.resourcesApi.bastion.infrastructureMachineTemplate.kind` | **API kind**|**Type:** `string`<br/>**Examples:** `"AWSMachineTemplate", "AzureMachineTemplate"`<br/>|
-| `internal.resourcesApi.bastion.infrastructureMachineTemplate.version` | **API version**|**Type:** `string`<br/>**Examples:** `"v1alpha1", "v1beta1", "v1beta2", "v1", "v2"`<br/>|
-| `internal.resourcesApi.bastion.infrastructureMachineTemplateSpecTemplateName` | **Infrastructure Machine template spec template name** - The name of Helm template that renders Infrastructure Machine template spec.|**Type:** `string`<br/>|
-| `internal.resourcesApi.bastionResourceEnabled` | **Bastion resource enabled** - Flag that indicates if the Bastion resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.|**Type:** `boolean`<br/>**Default:** `true`|
-| `internal.resourcesApi.clusterResourceEnabled` | **Cluster resource enabled** - Flag that indicates if the Cluster resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.|**Type:** `boolean`<br/>**Default:** `true`|
-| `internal.resourcesApi.controlPlaneResourceEnabled` | **Control plane resource enabled** - Flag that indicates if the control plane resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.|**Type:** `boolean`<br/>**Default:** `true`|
-| `internal.resourcesApi.machineHealthCheckResourceEnabled` | **MachineHealthCheck resource enabled** - Flag that indicates if the MachineHealthCheck resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.|**Type:** `boolean`<br/>**Default:** `true`|
-| `internal.resourcesApi.machinePoolResourcesEnabled` | **Machine pool resources enabled** - Flag that indicates if the machine pool resources are enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.|**Type:** `boolean`<br/>**Default:** `true`|
-| `internal.teleport` | **Teleport**|**Type:** `object`<br/>|
-| `internal.teleport.enabled` | **Enable teleport**|**Type:** `boolean`<br/>**Default:** `false`|
-| `internal.teleport.proxyAddr` | **Teleport proxy address**|**Type:** `string`<br/>**Default:** `"test.teleport.giantswarm.io:443"`|
-| `internal.teleport.version` | **Teleport version**|**Type:** `string`<br/>**Default:** `"13.3.8"`|
-| `internal.workers` | **Internal workers configuration**|**Type:** `object`<br/>|
-| `internal.workers.kubeadmConfig` | **Kubeadm config** - Configuration of workers nodes.|**Type:** `object`<br/>|
-| `internal.workers.kubeadmConfig.files` | **Files** - These are the files that are included on worker nodes.|**Type:** `array`<br/>|
-| `internal.workers.kubeadmConfig.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
-| `internal.workers.kubeadmConfig.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|
-| `internal.workers.kubeadmConfig.files[*].contentFrom.secret` | **Secret** - Kubernetes Secret resource with the file content.|**Type:** `object`<br/>|
-| `internal.workers.kubeadmConfig.files[*].contentFrom.secret.key` | **Key** - Secret key where the file content is.|**Type:** `string`<br/>|
-| `internal.workers.kubeadmConfig.files[*].contentFrom.secret.name` | **Name** - Name of the Secret resource.|**Type:** `string`<br/>|
-| `internal.workers.kubeadmConfig.files[*].path` | **Path** - File path on the node.|**Type:** `string`<br/>|
-| `internal.workers.kubeadmConfig.files[*].permissions` | **Permissions** - File permissions in form 0644|**Type:** `string`<br/>**Default:** `"0644"`|
-| `internal.workers.kubeadmConfig.ignition` | **Ignition** - Ignition-specific configuration.|**Type:** `object`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig` | **Container Linux configuration**|**Type:** `object`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig` | **Additional config** - Additional configuration to be merged with the Ignition. More info: https://coreos.github.io/ignition/operator-notes/#config-merging.|**Type:** `object`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage` | **Storage** - It describes the desired state of the system’s storage devices.|**Type:** `object`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories` | **Directories** - The list of directories to be created.|**Type:** `array`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*]` | **Directory** - The directory to be created.|**Type:** `object`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].filesystem` | **Filesystem** - The internal identifier of the filesystem in which to create the directory. This matches the last filesystem with the given identifier.|**Type:** `string`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].group` | **Group** - It specifies the group of the owner.|**Type:** `object`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].group.id` | **ID** - The group ID of the owner.|**Type:** `integer`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].group.name` | **Name** - The group name of the owner.|**Type:** `string`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].mode` | **Mode** - The directory’s permission mode.|**Type:** `integer`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].overwrite` | **Overwrite** - Whether to delete preexisting nodes at the path.|**Type:** `boolean`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].path` | **Path** - The absolute path to the directory.|**Type:** `string`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].user` | **User** - It specifies the directory’s owner.|**Type:** `object`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].user.id` | **ID** - The user ID of the owner.|**Type:** `integer`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].user.name` | **Name** - The user name of the owner.|**Type:** `string`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems` | **File systems** - The list of filesystems to be configured and/or used in the “files” section. Either “mount” or “path” needs to be specified.|**Type:** `array`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*]` | **File system** - The filesystem to be configured and/or used in the “files” section. Either “mount” or “path” needs to be specified.|**Type:** `object`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount` | **Mount** - It contains the set of mount and formatting options for the filesystem. A non-null entry indicates that the filesystem should be mounted before it is used by Ignition.|**Type:** `object`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.device` | **Device** - The absolute path to the device. Devices are typically referenced by the /dev/disk/by-* symlinks.|**Type:** `string`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.format` | **Format** - The filesystem format (ext4, btrfs, or xfs).|**Type:** `string`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.label` | **Label** - The label of the filesystem.|**Type:** `string`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.options` | **Options** - Any additional options to be passed to the format-specific mkfs utility.|**Type:** `array`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.options[*]` |An additional option to be passed to the format-specific mkfs utility.|**Type:** `string`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.uuid` | **UUID** - The uuid of the filesystem.|**Type:** `string`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.wipeFilesystem` | **Wipe filesystem** - Whether or not to wipe the device before filesystem creation, see Ignition’s documentation on filesystems for more information https://github.com/coreos/ignition/blob/main/docs/operator-notes.md#filesystem-reuse-semantics.|**Type:** `boolean`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].name` | **Name** - The identifier for the filesystem, internal to Ignition. This is only required if the filesystem needs to be referenced in the “files” section.|**Type:** `string`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].path` | **Path** - The mount-point of the filesystem. A non-null entry indicates that the filesystem has already been mounted by the system at the specified path. This is really only useful for “/sysroot”.|**Type:** `string`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd` | **systemd** - It describes the desired state of the systemd units.|**Type:** `object`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units` | **Units**|**Type:** `array`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*]` | **systemd unit**|**Type:** `object`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents` | **Contents** - The contents of the unit.|**Type:** `string`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins` | **Unit drop-ins** - The list of drop-ins for the unit|**Type:** `array`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins[*]` | **Unit drop-in**|**Type:** `object`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins[*].contents` | **Contents** - The contents of the drop-in.|**Type:** `string`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins[*].name` | **Name** - The name of the drop-in. This must be suffixed with “.conf”|**Type:** `string`<br/>**Value pattern:** `^.+\.conf$`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].enabled` | **Enabled?** - Whether or not the service shall be enabled. When true, the service is enabled. When false, the service is disabled. When omitted, the service is unmodified. In order for this to have any effect, the unit must have an install section.|**Type:** `boolean`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].mask` | **Masked?** - Whether or not the service shall be masked. When true, the service is masked by symlinking it to /dev/null.|**Type:** `boolean`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].name` | **Name** - The name of the unit. This must be suffixed with a valid unit type (e.g. “thing.service”).|**Type:** `string`<br/>|
-| `internal.workers.kubeadmConfig.ignition.containerLinuxConfig.strict` | **Strict** - It controls if AdditionalConfig should be strictly parsed. If so, warnings are treated as errors.|**Type:** `boolean`<br/>|
-| `internal.workers.kubeadmConfig.postKubeadmCommands` | **Post-kubeadm commands** - Extra commands to run after kubeadm runs.|**Type:** `array`<br/>|
-| `internal.workers.kubeadmConfig.postKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
-| `internal.workers.kubeadmConfig.preKubeadmCommands` | **Pre-kubeadm commands** - Extra commands to run before kubeadm runs.|**Type:** `array`<br/>|
-| `internal.workers.kubeadmConfig.preKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
-
 ### Metadata
 Properties within the `.global.metadata` object
 
@@ -400,17 +127,283 @@ Properties within the `.global.nodePools` object
 | :----------- | :-------------- | :--------------- |
 | `global.managementCluster` | **Management cluster** - Name of the Cluster API cluster managing this workload cluster.|**Type:** `string`<br/>|
 
-### Provider chart integration
-Properties within the `.providerChartIntegration` top-level object
-Provider-specific properties that must be set by cluster-$provider chart in order to render correct templates for the provider.
+### Provider integration
+Properties within the `.providerIntegration` top-level object
+Provider-specific properties that can be set by cluster-$provider chart in order to render correct templates for the provider.
 
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
-| `providerChartIntegration.resourcesApi` | **Resources API** - Group, version and kind configuration that is required and used by a specific Cluster API provider.|**Type:** `object`<br/>|
-| `providerChartIntegration.resourcesApi.infrastructureCluster` | **Infrastructure cluster** - Group, version and kind of provider-specific infrastructure cluster resource.|**Type:** `object`<br/>|
-| `providerChartIntegration.resourcesApi.infrastructureCluster.group` | **API group**|**Type:** `string`<br/>**Example:** `"infrastructure.cluster.x-k8s.io"`<br/>|
-| `providerChartIntegration.resourcesApi.infrastructureCluster.kind` | **API kind**|**Type:** `string`<br/>**Examples:** `"AWSCluster", "AzureCluster", "VCDCluster", "VSphereCluster"`<br/>|
-| `providerChartIntegration.resourcesApi.infrastructureCluster.version` | **API version**|**Type:** `string`<br/>**Examples:** `"v1alpha1", "v1beta1", "v1beta2", "v1", "v2"`<br/>|
+| `providerIntegration.bastion` | **Internal bastion configuration**|**Type:** `object`<br/>|
+| `providerIntegration.bastion.kubeadmConfig` | **Kubeadm config** - Configuration of bastion nodes.|**Type:** `object`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition` | **Ignition** - Ignition-specific configuration.|**Type:** `object`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig` | **Container Linux configuration**|**Type:** `object`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig` | **Additional config** - Additional configuration to be merged with the Ignition. More info: https://coreos.github.io/ignition/operator-notes/#config-merging.|**Type:** `object`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage` | **Storage** - It describes the desired state of the system’s storage devices.|**Type:** `object`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories` | **Directories** - The list of directories to be created.|**Type:** `array`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*]` | **Directory** - The directory to be created.|**Type:** `object`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].filesystem` | **Filesystem** - The internal identifier of the filesystem in which to create the directory. This matches the last filesystem with the given identifier.|**Type:** `string`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].group` | **Group** - It specifies the group of the owner.|**Type:** `object`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].group.id` | **ID** - The group ID of the owner.|**Type:** `integer`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].group.name` | **Name** - The group name of the owner.|**Type:** `string`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].mode` | **Mode** - The directory’s permission mode.|**Type:** `integer`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].overwrite` | **Overwrite** - Whether to delete preexisting nodes at the path.|**Type:** `boolean`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].path` | **Path** - The absolute path to the directory.|**Type:** `string`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].user` | **User** - It specifies the directory’s owner.|**Type:** `object`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].user.id` | **ID** - The user ID of the owner.|**Type:** `integer`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].user.name` | **Name** - The user name of the owner.|**Type:** `string`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems` | **File systems** - The list of filesystems to be configured and/or used in the “files” section. Either “mount” or “path” needs to be specified.|**Type:** `array`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*]` | **File system** - The filesystem to be configured and/or used in the “files” section. Either “mount” or “path” needs to be specified.|**Type:** `object`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount` | **Mount** - It contains the set of mount and formatting options for the filesystem. A non-null entry indicates that the filesystem should be mounted before it is used by Ignition.|**Type:** `object`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.device` | **Device** - The absolute path to the device. Devices are typically referenced by the /dev/disk/by-* symlinks.|**Type:** `string`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.format` | **Format** - The filesystem format (ext4, btrfs, or xfs).|**Type:** `string`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.label` | **Label** - The label of the filesystem.|**Type:** `string`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.options` | **Options** - Any additional options to be passed to the format-specific mkfs utility.|**Type:** `array`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.options[*]` |An additional option to be passed to the format-specific mkfs utility.|**Type:** `string`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.uuid` | **UUID** - The uuid of the filesystem.|**Type:** `string`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.wipeFilesystem` | **Wipe filesystem** - Whether or not to wipe the device before filesystem creation, see Ignition’s documentation on filesystems for more information https://github.com/coreos/ignition/blob/main/docs/operator-notes.md#filesystem-reuse-semantics.|**Type:** `boolean`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].name` | **Name** - The identifier for the filesystem, internal to Ignition. This is only required if the filesystem needs to be referenced in the “files” section.|**Type:** `string`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].path` | **Path** - The mount-point of the filesystem. A non-null entry indicates that the filesystem has already been mounted by the system at the specified path. This is really only useful for “/sysroot”.|**Type:** `string`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd` | **systemd** - It describes the desired state of the systemd units.|**Type:** `object`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units` | **Units**|**Type:** `array`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*]` | **systemd unit**|**Type:** `object`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents` | **Contents** - The contents of the unit.|**Type:** `string`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins` | **Unit drop-ins** - The list of drop-ins for the unit|**Type:** `array`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins[*]` | **Unit drop-in**|**Type:** `object`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins[*].contents` | **Contents** - The contents of the drop-in.|**Type:** `string`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins[*].name` | **Name** - The name of the drop-in. This must be suffixed with “.conf”|**Type:** `string`<br/>**Value pattern:** `^.+\.conf$`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].enabled` | **Enabled?** - Whether or not the service shall be enabled. When true, the service is enabled. When false, the service is disabled. When omitted, the service is unmodified. In order for this to have any effect, the unit must have an install section.|**Type:** `boolean`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].mask` | **Masked?** - Whether or not the service shall be masked. When true, the service is masked by symlinking it to /dev/null.|**Type:** `boolean`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].name` | **Name** - The name of the unit. This must be suffixed with a valid unit type (e.g. “thing.service”).|**Type:** `string`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.strict` | **Strict** - It controls if AdditionalConfig should be strictly parsed. If so, warnings are treated as errors.|**Type:** `boolean`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.preKubeadmCommands` | **Pre-kubeadm commands** - Extra commands to run before kubeadm runs.|**Type:** `array`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.preKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
+| `providerIntegration.components` | **Components** - Internal configuration of various components that form the Kubernetes cluster.|**Type:** `object`<br/>|
+| `providerIntegration.components.containerd` | **Containerd** - Configuration of containerd.|**Type:** `object`<br/>|
+| `providerIntegration.components.containerd.sandboxContainerImage` | **Kubectl image**|**Type:** `object`<br/>|
+| `providerIntegration.components.containerd.sandboxContainerImage.name` | **Repository**|**Type:** `string`<br/>**Default:** `"giantswarm/pause"`|
+| `providerIntegration.components.containerd.sandboxContainerImage.registry` | **Registry**|**Type:** `string`<br/>**Default:** `"quay.io"`|
+| `providerIntegration.components.containerd.sandboxContainerImage.tag` | **Tag**|**Type:** `string`<br/>**Default:** `"3.9"`|
+| `providerIntegration.components.kubelet` | **Kubelet** - Kubelet configuration that is used on all nodes.||
+| `providerIntegration.components.systemd` | **systemd**||
+| `providerIntegration.connectivity` | **Connectivity** - Internal connectivity configuration.|**Type:** `object`<br/>|
+| `providerIntegration.connectivity.sshSsoPublicKey` | **SSH public key for single sign-on**|**Type:** `string`<br/>**Default:** `"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"`|
+| `providerIntegration.controlPlane` | **Internal control plane configuration**|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig` | **Kubeadm config** - Configuration of control plane nodes.|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration` | **Cluster configuration** - Configuration of Kubernetes components.|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer` | **API server** - Configuration of API server.|**Type:** `object`<br/>**Default:** `{}`|
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.additionalAdmissionPlugins` | **Additional admission plugins** - A list of plugins to enable, in addition to the default ones that include DefaultStorageClass, DefaultTolerationSeconds, LimitRanger, MutatingAdmissionWebhook, NamespaceLifecycle, PersistentVolumeClaimResize, Priority, ResourceQuota, ServiceAccount and ValidatingAdmissionWebhook.|**Type:** `array`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.additionalAdmissionPlugins[*]` | **Additional admission plugin**|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.apiAudiences` | **API audiences** - Identifiers of the API. The service account token authenticator will validate that tokens used against the API are bound to at least one of these audiences. If the --service-account-issuer flag is configured and this flag is not, 'api-audiences' field defaults to a single element list containing the issuer URL.||
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.etcdPrefix` | **etcd prefix**|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.extraArgs` | **Extra args**|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.extraCertificateSANs` | **Extra certificate SANs** - The additional certificate SANs that are appended to the default SANs.|**Type:** `array`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.extraCertificateSANs[*]` | **Extra certificate SAN**|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates` | **Feature gates**|**Type:** `array`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates[*]` | **Feature gate**|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates[*].enabled` | **Enabled**|**Type:** `boolean`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates[*].name` | **Name**|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.serviceAccountIssuer` | **Service account issuer** - Configuration of the identifier of the service account token issuer. You must specify either URL or clusterDomainPrefix (only one, not both).||
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.etcd` | **etcd** - Configuration of etcd|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.etcd.experimental` | **Experimental**|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.etcd.experimental.peerSkipClientSanVerification` | **Peer skip client SAN verification** - Skip verification of SAN field in client certificate for peer connections.|**Type:** `boolean`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.etcd.extraArgs` | **Extra args**|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.etcd.initialCluster` | **Initial cluster** - Initial cluster configuration for bootstrapping.|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.etcd.initialClusterState` | **Initial cluster state**|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.files` | **Files** - These are the files that are included on control plane nodes.|**Type:** `array`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.files[*].contentFrom.secret` | **Secret** - Kubernetes Secret resource with the file content.|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.files[*].contentFrom.secret.key` | **Key** - Secret key where the file content is.|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.files[*].contentFrom.secret.name` | **Name** - Name of the Secret resource.|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.files[*].path` | **Path** - File path on the node.|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.files[*].permissions` | **Permissions** - File permissions in form 0644|**Type:** `string`<br/>**Default:** `"0644"`|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition` | **Ignition** - Ignition-specific configuration.|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig` | **Container Linux configuration**|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig` | **Additional config** - Additional configuration to be merged with the Ignition. More info: https://coreos.github.io/ignition/operator-notes/#config-merging.|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage` | **Storage** - It describes the desired state of the system’s storage devices.|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories` | **Directories** - The list of directories to be created.|**Type:** `array`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*]` | **Directory** - The directory to be created.|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].filesystem` | **Filesystem** - The internal identifier of the filesystem in which to create the directory. This matches the last filesystem with the given identifier.|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].group` | **Group** - It specifies the group of the owner.|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].group.id` | **ID** - The group ID of the owner.|**Type:** `integer`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].group.name` | **Name** - The group name of the owner.|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].mode` | **Mode** - The directory’s permission mode.|**Type:** `integer`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].overwrite` | **Overwrite** - Whether to delete preexisting nodes at the path.|**Type:** `boolean`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].path` | **Path** - The absolute path to the directory.|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].user` | **User** - It specifies the directory’s owner.|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].user.id` | **ID** - The user ID of the owner.|**Type:** `integer`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].user.name` | **Name** - The user name of the owner.|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems` | **File systems** - The list of filesystems to be configured and/or used in the “files” section. Either “mount” or “path” needs to be specified.|**Type:** `array`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*]` | **File system** - The filesystem to be configured and/or used in the “files” section. Either “mount” or “path” needs to be specified.|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount` | **Mount** - It contains the set of mount and formatting options for the filesystem. A non-null entry indicates that the filesystem should be mounted before it is used by Ignition.|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.device` | **Device** - The absolute path to the device. Devices are typically referenced by the /dev/disk/by-* symlinks.|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.format` | **Format** - The filesystem format (ext4, btrfs, or xfs).|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.label` | **Label** - The label of the filesystem.|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.options` | **Options** - Any additional options to be passed to the format-specific mkfs utility.|**Type:** `array`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.options[*]` |An additional option to be passed to the format-specific mkfs utility.|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.uuid` | **UUID** - The uuid of the filesystem.|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.wipeFilesystem` | **Wipe filesystem** - Whether or not to wipe the device before filesystem creation, see Ignition’s documentation on filesystems for more information https://github.com/coreos/ignition/blob/main/docs/operator-notes.md#filesystem-reuse-semantics.|**Type:** `boolean`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].name` | **Name** - The identifier for the filesystem, internal to Ignition. This is only required if the filesystem needs to be referenced in the “files” section.|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].path` | **Path** - The mount-point of the filesystem. A non-null entry indicates that the filesystem has already been mounted by the system at the specified path. This is really only useful for “/sysroot”.|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd` | **systemd** - It describes the desired state of the systemd units.|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units` | **Units**|**Type:** `array`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*]` | **systemd unit**|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents` | **Contents** - The contents of the unit.|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins` | **Unit drop-ins** - The list of drop-ins for the unit|**Type:** `array`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins[*]` | **Unit drop-in**|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins[*].contents` | **Contents** - The contents of the drop-in.|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins[*].name` | **Name** - The name of the drop-in. This must be suffixed with “.conf”|**Type:** `string`<br/>**Value pattern:** `^.+\.conf$`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].enabled` | **Enabled?** - Whether or not the service shall be enabled. When true, the service is enabled. When false, the service is disabled. When omitted, the service is unmodified. In order for this to have any effect, the unit must have an install section.|**Type:** `boolean`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].mask` | **Masked?** - Whether or not the service shall be masked. When true, the service is masked by symlinking it to /dev/null.|**Type:** `boolean`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].name` | **Name** - The name of the unit. This must be suffixed with a valid unit type (e.g. “thing.service”).|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.strict` | **Strict** - It controls if AdditionalConfig should be strictly parsed. If so, warnings are treated as errors.|**Type:** `boolean`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.localAPIEndpoint` | **Local API endpoint**|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.localAPIEndpoint.bindPort` | **Bind port** - Kubernetes API bind port used for API server pod.|**Type:** `integer`<br/>**Default:** `6443`|
+| `providerIntegration.controlPlane.kubeadmConfig.postKubeadmCommands` | **Post-kubeadm commands** - Extra commands to run after kubeadm runs.|**Type:** `array`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.postKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.preKubeadmCommands` | **Pre-kubeadm commands** - Extra commands to run before kubeadm runs.|**Type:** `array`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.preKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.resources` | **Resources configuration** - GVK and other configuration for control plane resources.|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.resources.controlPlane` | **Control plane resource config**|**Type:** `object`<br/>**Default:** `{"api":{"group":"controlplane.cluster.x-k8s.io","kind":"KubeadmControlPlane","version":"v1beta1"}}`|
+| `providerIntegration.controlPlane.resources.controlPlane.api` | **Schema for Kubernetes API group, version and kind** - It can be used to specify which CustomResourceDefinition is used.|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.resources.controlPlane.api.group` | **API group**|**Type:** `string`<br/>**Examples:** `"cluster.x-k8s.io", "controlplane.cluster.x-k8s.io", "infrastructure.cluster.x-k8s.io"`<br/>|
+| `providerIntegration.controlPlane.resources.controlPlane.api.kind` | **API kind**|**Type:** `string`<br/>**Examples:** `"Cluster", "KubeadmControlPlane"`<br/>|
+| `providerIntegration.controlPlane.resources.controlPlane.api.version` | **API version**|**Type:** `string`<br/>**Examples:** `"v1alpha1", "v1alpha2", "v1beta1", "v1"`<br/>|
+| `providerIntegration.controlPlane.resources.infrastructureMachineTemplate` | **Infrastructure Machine template** - Group, version and kind of provider-specific infrastructure Machine template resource.|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.resources.infrastructureMachineTemplate.group` | **API group**|**Type:** `string`<br/>**Example:** `"infrastructure.cluster.x-k8s.io"`<br/>|
+| `providerIntegration.controlPlane.resources.infrastructureMachineTemplate.kind` | **API kind**|**Type:** `string`<br/>**Examples:** `"AWSMachineTemplate", "AzureMachineTemplate"`<br/>|
+| `providerIntegration.controlPlane.resources.infrastructureMachineTemplate.version` | **API version**|**Type:** `string`<br/>**Examples:** `"v1alpha1", "v1beta1", "v1beta2", "v1", "v2"`<br/>|
+| `providerIntegration.controlPlane.resources.infrastructureMachineTemplateSpecTemplateName` | **Infrastructure Machine template spec template name** - The name of Helm template that renders Infrastructure Machine template spec.|**Type:** `string`<br/>|
+| `providerIntegration.hashSalt` | **Hash salt** - If specified, this token is used as a salt to the hash suffix of some resource names. Can be used to force-recreate some resources.|**Type:** `string`<br/>|
+| `providerIntegration.kubeadmConfig` | **Kubeadm config** - Common kubeadm config for all nodes, including both control plane and workers.|**Type:** `object`<br/>|
+| `providerIntegration.kubeadmConfig.files` | **Files** - These are the files that are included on all the nodes.|**Type:** `array`<br/>|
+| `providerIntegration.kubeadmConfig.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
+| `providerIntegration.kubeadmConfig.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|
+| `providerIntegration.kubeadmConfig.files[*].contentFrom.secret` | **Secret** - Kubernetes Secret resource with the file content.|**Type:** `object`<br/>|
+| `providerIntegration.kubeadmConfig.files[*].contentFrom.secret.key` | **Key** - Secret key where the file content is.|**Type:** `string`<br/>|
+| `providerIntegration.kubeadmConfig.files[*].contentFrom.secret.name` | **Name** - Name of the Secret resource.|**Type:** `string`<br/>|
+| `providerIntegration.kubeadmConfig.files[*].path` | **Path** - File path on the node.|**Type:** `string`<br/>|
+| `providerIntegration.kubeadmConfig.files[*].permissions` | **Permissions** - File permissions in form 0644|**Type:** `string`<br/>**Default:** `"0644"`|
+| `providerIntegration.kubeadmConfig.ignition` | **Ignition** - Ignition-specific configuration.|**Type:** `object`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig` | **Container Linux configuration**|**Type:** `object`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig` | **Additional config** - Additional configuration to be merged with the Ignition. More info: https://coreos.github.io/ignition/operator-notes/#config-merging.|**Type:** `object`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage` | **Storage** - It describes the desired state of the system’s storage devices.|**Type:** `object`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories` | **Directories** - The list of directories to be created.|**Type:** `array`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*]` | **Directory** - The directory to be created.|**Type:** `object`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].filesystem` | **Filesystem** - The internal identifier of the filesystem in which to create the directory. This matches the last filesystem with the given identifier.|**Type:** `string`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].group` | **Group** - It specifies the group of the owner.|**Type:** `object`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].group.id` | **ID** - The group ID of the owner.|**Type:** `integer`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].group.name` | **Name** - The group name of the owner.|**Type:** `string`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].mode` | **Mode** - The directory’s permission mode.|**Type:** `integer`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].overwrite` | **Overwrite** - Whether to delete preexisting nodes at the path.|**Type:** `boolean`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].path` | **Path** - The absolute path to the directory.|**Type:** `string`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].user` | **User** - It specifies the directory’s owner.|**Type:** `object`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].user.id` | **ID** - The user ID of the owner.|**Type:** `integer`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].user.name` | **Name** - The user name of the owner.|**Type:** `string`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems` | **File systems** - The list of filesystems to be configured and/or used in the “files” section. Either “mount” or “path” needs to be specified.|**Type:** `array`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*]` | **File system** - The filesystem to be configured and/or used in the “files” section. Either “mount” or “path” needs to be specified.|**Type:** `object`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount` | **Mount** - It contains the set of mount and formatting options for the filesystem. A non-null entry indicates that the filesystem should be mounted before it is used by Ignition.|**Type:** `object`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.device` | **Device** - The absolute path to the device. Devices are typically referenced by the /dev/disk/by-* symlinks.|**Type:** `string`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.format` | **Format** - The filesystem format (ext4, btrfs, or xfs).|**Type:** `string`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.label` | **Label** - The label of the filesystem.|**Type:** `string`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.options` | **Options** - Any additional options to be passed to the format-specific mkfs utility.|**Type:** `array`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.options[*]` |An additional option to be passed to the format-specific mkfs utility.|**Type:** `string`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.uuid` | **UUID** - The uuid of the filesystem.|**Type:** `string`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.wipeFilesystem` | **Wipe filesystem** - Whether or not to wipe the device before filesystem creation, see Ignition’s documentation on filesystems for more information https://github.com/coreos/ignition/blob/main/docs/operator-notes.md#filesystem-reuse-semantics.|**Type:** `boolean`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].name` | **Name** - The identifier for the filesystem, internal to Ignition. This is only required if the filesystem needs to be referenced in the “files” section.|**Type:** `string`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].path` | **Path** - The mount-point of the filesystem. A non-null entry indicates that the filesystem has already been mounted by the system at the specified path. This is really only useful for “/sysroot”.|**Type:** `string`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd` | **systemd** - It describes the desired state of the systemd units.|**Type:** `object`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units` | **Units**|**Type:** `array`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*]` | **systemd unit**|**Type:** `object`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents` | **Contents** - The contents of the unit.|**Type:** `string`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins` | **Unit drop-ins** - The list of drop-ins for the unit|**Type:** `array`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins[*]` | **Unit drop-in**|**Type:** `object`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins[*].contents` | **Contents** - The contents of the drop-in.|**Type:** `string`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins[*].name` | **Name** - The name of the drop-in. This must be suffixed with “.conf”|**Type:** `string`<br/>**Value pattern:** `^.+\.conf$`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].enabled` | **Enabled?** - Whether or not the service shall be enabled. When true, the service is enabled. When false, the service is disabled. When omitted, the service is unmodified. In order for this to have any effect, the unit must have an install section.|**Type:** `boolean`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].mask` | **Masked?** - Whether or not the service shall be masked. When true, the service is masked by symlinking it to /dev/null.|**Type:** `boolean`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].name` | **Name** - The name of the unit. This must be suffixed with a valid unit type (e.g. “thing.service”).|**Type:** `string`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.strict` | **Strict** - It controls if AdditionalConfig should be strictly parsed. If so, warnings are treated as errors.|**Type:** `boolean`<br/>|
+| `providerIntegration.kubeadmConfig.postKubeadmCommands` | **Post-kubeadm commands** - Extra commands to run after kubeadm runs.|**Type:** `array`<br/>|
+| `providerIntegration.kubeadmConfig.postKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
+| `providerIntegration.kubeadmConfig.preKubeadmCommands` | **Pre-kubeadm commands** - Extra commands to run before kubeadm runs.|**Type:** `array`<br/>|
+| `providerIntegration.kubeadmConfig.preKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
+| `providerIntegration.kubernetesVersion` | **Kubernetes version**|**Type:** `string`<br/>**Example:** `"1.24.7"`<br/>**Default:** `"1.24.10"`|
+| `providerIntegration.paused` | **Paused**|**Type:** `boolean`<br/>**Default:** `false`|
+| `providerIntegration.resourcesApi` | **Resources API** - Group, version and kind configuration that is required and used by a specific Cluster API provider.|**Type:** `object`<br/>|
+| `providerIntegration.resourcesApi.bastion` | **Bastion** - Configuration of bastion resources API and names.|**Type:** `object`<br/>|
+| `providerIntegration.resourcesApi.bastion.infrastructureMachineTemplate` | **Infrastructure Machine template** - Group, version and kind of provider-specific infrastructure Machine template resource.|**Type:** `object`<br/>|
+| `providerIntegration.resourcesApi.bastion.infrastructureMachineTemplate.group` | **API group**|**Type:** `string`<br/>**Example:** `"infrastructure.cluster.x-k8s.io"`<br/>|
+| `providerIntegration.resourcesApi.bastion.infrastructureMachineTemplate.kind` | **API kind**|**Type:** `string`<br/>**Examples:** `"AWSMachineTemplate", "AzureMachineTemplate"`<br/>|
+| `providerIntegration.resourcesApi.bastion.infrastructureMachineTemplate.version` | **API version**|**Type:** `string`<br/>**Examples:** `"v1alpha1", "v1beta1", "v1beta2", "v1", "v2"`<br/>|
+| `providerIntegration.resourcesApi.bastion.infrastructureMachineTemplateSpecTemplateName` | **Infrastructure Machine template spec template name** - The name of Helm template that renders Infrastructure Machine template spec.|**Type:** `string`<br/>|
+| `providerIntegration.resourcesApi.bastionResourceEnabled` | **Bastion resource enabled** - Flag that indicates if the Bastion resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.|**Type:** `boolean`<br/>**Default:** `true`|
+| `providerIntegration.resourcesApi.clusterResourceEnabled` | **Cluster resource enabled** - Flag that indicates if the Cluster resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.|**Type:** `boolean`<br/>**Default:** `true`|
+| `providerIntegration.resourcesApi.controlPlaneResourceEnabled` | **Control plane resource enabled** - Flag that indicates if the control plane resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.|**Type:** `boolean`<br/>**Default:** `true`|
+| `providerIntegration.resourcesApi.infrastructureCluster` | **Infrastructure cluster** - Group, version and kind of provider-specific infrastructure cluster resource.|**Type:** `object`<br/>|
+| `providerIntegration.resourcesApi.infrastructureCluster.group` | **API group**|**Type:** `string`<br/>**Example:** `"infrastructure.cluster.x-k8s.io"`<br/>|
+| `providerIntegration.resourcesApi.infrastructureCluster.kind` | **API kind**|**Type:** `string`<br/>**Examples:** `"AWSCluster", "AzureCluster", "VCDCluster", "VSphereCluster"`<br/>|
+| `providerIntegration.resourcesApi.infrastructureCluster.version` | **API version**|**Type:** `string`<br/>**Examples:** `"v1alpha1", "v1beta1", "v1beta2", "v1", "v2"`<br/>|
+| `providerIntegration.resourcesApi.machineHealthCheckResourceEnabled` | **MachineHealthCheck resource enabled** - Flag that indicates if the MachineHealthCheck resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.|**Type:** `boolean`<br/>**Default:** `true`|
+| `providerIntegration.resourcesApi.machinePoolResourcesEnabled` | **Machine pool resources enabled** - Flag that indicates if the machine pool resources are enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.|**Type:** `boolean`<br/>**Default:** `true`|
+| `providerIntegration.teleport` | **Teleport**|**Type:** `object`<br/>|
+| `providerIntegration.teleport.enabled` | **Enable teleport**|**Type:** `boolean`<br/>**Default:** `false`|
+| `providerIntegration.teleport.proxyAddr` | **Teleport proxy address**|**Type:** `string`<br/>**Default:** `"test.teleport.giantswarm.io:443"`|
+| `providerIntegration.teleport.version` | **Teleport version**|**Type:** `string`<br/>**Default:** `"13.3.8"`|
+| `providerIntegration.workers` | **Internal workers configuration**|**Type:** `object`<br/>|
+| `providerIntegration.workers.kubeadmConfig` | **Kubeadm config** - Configuration of workers nodes.|**Type:** `object`<br/>|
+| `providerIntegration.workers.kubeadmConfig.files` | **Files** - These are the files that are included on worker nodes.|**Type:** `array`<br/>|
+| `providerIntegration.workers.kubeadmConfig.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
+| `providerIntegration.workers.kubeadmConfig.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|
+| `providerIntegration.workers.kubeadmConfig.files[*].contentFrom.secret` | **Secret** - Kubernetes Secret resource with the file content.|**Type:** `object`<br/>|
+| `providerIntegration.workers.kubeadmConfig.files[*].contentFrom.secret.key` | **Key** - Secret key where the file content is.|**Type:** `string`<br/>|
+| `providerIntegration.workers.kubeadmConfig.files[*].contentFrom.secret.name` | **Name** - Name of the Secret resource.|**Type:** `string`<br/>|
+| `providerIntegration.workers.kubeadmConfig.files[*].path` | **Path** - File path on the node.|**Type:** `string`<br/>|
+| `providerIntegration.workers.kubeadmConfig.files[*].permissions` | **Permissions** - File permissions in form 0644|**Type:** `string`<br/>**Default:** `"0644"`|
+| `providerIntegration.workers.kubeadmConfig.ignition` | **Ignition** - Ignition-specific configuration.|**Type:** `object`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig` | **Container Linux configuration**|**Type:** `object`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig` | **Additional config** - Additional configuration to be merged with the Ignition. More info: https://coreos.github.io/ignition/operator-notes/#config-merging.|**Type:** `object`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage` | **Storage** - It describes the desired state of the system’s storage devices.|**Type:** `object`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories` | **Directories** - The list of directories to be created.|**Type:** `array`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*]` | **Directory** - The directory to be created.|**Type:** `object`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].filesystem` | **Filesystem** - The internal identifier of the filesystem in which to create the directory. This matches the last filesystem with the given identifier.|**Type:** `string`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].group` | **Group** - It specifies the group of the owner.|**Type:** `object`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].group.id` | **ID** - The group ID of the owner.|**Type:** `integer`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].group.name` | **Name** - The group name of the owner.|**Type:** `string`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].mode` | **Mode** - The directory’s permission mode.|**Type:** `integer`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].overwrite` | **Overwrite** - Whether to delete preexisting nodes at the path.|**Type:** `boolean`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].path` | **Path** - The absolute path to the directory.|**Type:** `string`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].user` | **User** - It specifies the directory’s owner.|**Type:** `object`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].user.id` | **ID** - The user ID of the owner.|**Type:** `integer`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories[*].user.name` | **Name** - The user name of the owner.|**Type:** `string`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems` | **File systems** - The list of filesystems to be configured and/or used in the “files” section. Either “mount” or “path” needs to be specified.|**Type:** `array`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*]` | **File system** - The filesystem to be configured and/or used in the “files” section. Either “mount” or “path” needs to be specified.|**Type:** `object`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount` | **Mount** - It contains the set of mount and formatting options for the filesystem. A non-null entry indicates that the filesystem should be mounted before it is used by Ignition.|**Type:** `object`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.device` | **Device** - The absolute path to the device. Devices are typically referenced by the /dev/disk/by-* symlinks.|**Type:** `string`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.format` | **Format** - The filesystem format (ext4, btrfs, or xfs).|**Type:** `string`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.label` | **Label** - The label of the filesystem.|**Type:** `string`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.options` | **Options** - Any additional options to be passed to the format-specific mkfs utility.|**Type:** `array`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.options[*]` |An additional option to be passed to the format-specific mkfs utility.|**Type:** `string`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.uuid` | **UUID** - The uuid of the filesystem.|**Type:** `string`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].mount.wipeFilesystem` | **Wipe filesystem** - Whether or not to wipe the device before filesystem creation, see Ignition’s documentation on filesystems for more information https://github.com/coreos/ignition/blob/main/docs/operator-notes.md#filesystem-reuse-semantics.|**Type:** `boolean`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].name` | **Name** - The identifier for the filesystem, internal to Ignition. This is only required if the filesystem needs to be referenced in the “files” section.|**Type:** `string`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems[*].path` | **Path** - The mount-point of the filesystem. A non-null entry indicates that the filesystem has already been mounted by the system at the specified path. This is really only useful for “/sysroot”.|**Type:** `string`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd` | **systemd** - It describes the desired state of the systemd units.|**Type:** `object`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units` | **Units**|**Type:** `array`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*]` | **systemd unit**|**Type:** `object`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents` | **Contents** - The contents of the unit.|**Type:** `string`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins` | **Unit drop-ins** - The list of drop-ins for the unit|**Type:** `array`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins[*]` | **Unit drop-in**|**Type:** `object`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins[*].contents` | **Contents** - The contents of the drop-in.|**Type:** `string`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins[*].name` | **Name** - The name of the drop-in. This must be suffixed with “.conf”|**Type:** `string`<br/>**Value pattern:** `^.+\.conf$`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].enabled` | **Enabled?** - Whether or not the service shall be enabled. When true, the service is enabled. When false, the service is disabled. When omitted, the service is unmodified. In order for this to have any effect, the unit must have an install section.|**Type:** `boolean`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].mask` | **Masked?** - Whether or not the service shall be masked. When true, the service is masked by symlinking it to /dev/null.|**Type:** `boolean`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].name` | **Name** - The name of the unit. This must be suffixed with a valid unit type (e.g. “thing.service”).|**Type:** `string`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.strict` | **Strict** - It controls if AdditionalConfig should be strictly parsed. If so, warnings are treated as errors.|**Type:** `boolean`<br/>|
+| `providerIntegration.workers.kubeadmConfig.postKubeadmCommands` | **Post-kubeadm commands** - Extra commands to run after kubeadm runs.|**Type:** `array`<br/>|
+| `providerIntegration.workers.kubeadmConfig.postKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
+| `providerIntegration.workers.kubeadmConfig.preKubeadmCommands` | **Pre-kubeadm commands** - Extra commands to run before kubeadm runs.|**Type:** `array`<br/>|
+| `providerIntegration.workers.kubeadmConfig.preKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
 
 
 

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -100,6 +100,7 @@ Properties within the `.global.metadata` object
 | `global.metadata.labels.PATTERN` | **Label**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-zA-Z0-9/\._-]+$`<br/>**Value pattern:** `^[a-zA-Z0-9\._-]+$`<br/>|
 | `global.metadata.name` | **Cluster name** - Unique identifier, cannot be changed after creation.|**Type:** `string`<br/>|
 | `global.metadata.organization` | **Organization** - The name of organization that owns the cluster.|**Type:** `string`<br/>|
+| `global.metadata.preventDeletion` | **Prevent cluster deletion** - Setting this to true will set giantswarm.io/prevent-deletion label to true, which will block cluster deletion.|**Type:** `boolean`<br/>**Default:** `false`|
 | `global.metadata.servicePriority` | **Service priority** - The relative importance of this cluster.|**Type:** `string`<br/>**Default:** `"highest"`|
 
 ### Node pools

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -79,7 +79,7 @@ providerIntegration:
                     # Contents goes here
       preKubeadmCommands:
       - sleep infinity
-  clusterLabelsTemplateName: "cluster.test.providerIntegration.connectivity.labels"
+  clusterAnnotationsTemplateName: "cluster.test.providerIntegration.connectivity.annotations"
   controlPlane:
     kubeadmConfig:
       clusterConfiguration:

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -79,6 +79,7 @@ providerIntegration:
                     # Contents goes here
       preKubeadmCommands:
       - sleep infinity
+  clusterLabelsTemplateName: "cluster.test.providerIntegration.connectivity.labels"
   controlPlane:
     kubeadmConfig:
       clusterConfiguration:

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -12,6 +12,7 @@ global:
       robots-need-this-in-the-cluster: "eW91IGNhbm5vdCByZWFkIHRoaXMsIGJ1dCByb2JvdHMgY2FuCg=="
   connectivity:
     baseDomain: example.gigantic.io
+    vpcMode: private
     proxy:
       enabled: true
       httpProxy: http://proxy.giantswarm.io
@@ -273,7 +274,8 @@ providerIntegration:
     - echo "hello all nodes after kubeadm"
     - echo "all cluster nodes after kubeadm"
   kubernetesVersion: 1.24.10
-  paused: false
+  pauseProperties:
+    global.connectivity.vpcMode: private
   resourcesApi:
     clusterResourceEnabled: true
     controlPlaneResourceEnabled: true

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -4,6 +4,7 @@ global:
     name: awesome
     organization: giantswarm
     description: "Awesome Giant Swarm cluster"
+    preventDeletion: true
     labels:
       some-cluster-label: label-1
       another-cluster-label: label-2

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -59,7 +59,7 @@ global:
             username: giantswarm
             password: super_secret_password
         - endpoint: giantswarm.azurecr.io
-internal:
+providerIntegration:
   bastion:
     kubeadmConfig:
       ignition:
@@ -280,6 +280,10 @@ internal:
     machinePoolResourcesEnabled: true
     machineHealthCheckResourceEnabled: true
     bastionResourceEnabled: true
+    infrastructureCluster:
+      group: infrastructure.cluster.x-k8s.io
+      version: v1beta1
+      kind: AWSCluster
     nodePoolKind: MachinePool
     infrastructureMachinePool:
       group: infrastructure.cluster.x-k8s.io
@@ -349,9 +353,3 @@ internal:
       postKubeadmCommands:
       - echo "hello workers after kubeadm"
       - echo "cluster workers after kubeadm"
-providerChartIntegration:
-  resourcesApi:
-    infrastructureCluster:
-      group: infrastructure.cluster.x-k8s.io
-      version: v1beta1
-      kind: AWSCluster

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -281,10 +281,6 @@ internal:
     machineHealthCheckResourceEnabled: true
     bastionResourceEnabled: true
     nodePoolKind: MachinePool
-    infrastructureCluster:
-      group: infrastructure.cluster.x-k8s.io
-      version: v1beta1
-      kind: AWSCluster
     infrastructureMachinePool:
       group: infrastructure.cluster.x-k8s.io
       version: v1beta1
@@ -353,3 +349,9 @@ internal:
       postKubeadmCommands:
       - echo "hello workers after kubeadm"
       - echo "cluster workers after kubeadm"
+providerChartIntegration:
+  resourcesApi:
+    infrastructureCluster:
+      group: infrastructure.cluster.x-k8s.io
+      version: v1beta1
+      kind: AWSCluster

--- a/helm/cluster/files/etc/containerd/config.toml
+++ b/helm/cluster/files/etc/containerd/config.toml
@@ -21,7 +21,7 @@ runtime_type = "io.containerd.runc.v2"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
 SystemdCgroup = true
 [plugins."io.containerd.grpc.v1.cri"]
-sandbox_image = "{{ $.Values.internal.components.containerd.sandboxContainerImage.registry }}/{{ $.Values.internal.components.containerd.sandboxContainerImage.name }}:{{ $.Values.internal.components.containerd.sandboxContainerImage.tag }}"
+sandbox_image = "{{ $.Values.providerIntegration.components.containerd.sandboxContainerImage.registry }}/{{ $.Values.providerIntegration.components.containerd.sandboxContainerImage.name }}:{{ $.Values.providerIntegration.components.containerd.sandboxContainerImage.tag }}"
 
 [plugins."io.containerd.grpc.v1.cri".registry]
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors]

--- a/helm/cluster/files/etc/ssh/trusted-user-ca-keys.pem
+++ b/helm/cluster/files/etc/ssh/trusted-user-ca-keys.pem
@@ -1,1 +1,1 @@
-{{ .Values.internal.connectivity.sshSsoPublicKey }}
+{{ .Values.providerIntegration.connectivity.sshSsoPublicKey }}

--- a/helm/cluster/files/etc/systemd/timesyncd.conf
+++ b/helm/cluster/files/etc/systemd/timesyncd.conf
@@ -1,4 +1,4 @@
-{{- if $.Values.internal.kubeadmConfig.systemd.timesyncd }}
+{{- if $.Values.providerIntegration.kubeadmConfig.systemd.timesyncd }}
 [Time]
-NTP={{- join "," (compact $.Values.internal.kubeadmConfig.systemd.timesyncd.npt) }}
+NTP={{- join "," (compact $.Values.providerIntegration.kubeadmConfig.systemd.timesyncd.npt) }}
 {{- end }}

--- a/helm/cluster/files/etc/teleport.yaml
+++ b/helm/cluster/files/etc/teleport.yaml
@@ -4,7 +4,7 @@ teleport:
   join_params:
     token_name: /etc/teleport-join-token
     method: token
-  proxy_server: {{ .Values.internal.teleport.proxyAddr }}
+  proxy_server: {{ .Values.providerIntegration.teleport.proxyAddr }}
   log:
     output: stderr
 auth_service:

--- a/helm/cluster/files/opt/kubelet-config.sh
+++ b/helm/cluster/files/opt/kubelet-config.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-{{- if $.Values.internal.kubeadmConfig.kubelet.gracefulNodeShutdown.shutdownGracePeriod }}
-sed -i "s|shutdownGracePeriod: .*|shutdownGracePeriod: {{ $.Values.internal.kubeadmConfig.kubelet.gracefulNodeShutdown.shutdownGracePeriod }}|g" "/var/lib/kubelet/config.yaml"
+{{- if $.Values.providerIntegration.kubeadmConfig.kubelet.gracefulNodeShutdown.shutdownGracePeriod }}
+sed -i "s|shutdownGracePeriod: .*|shutdownGracePeriod: {{ $.Values.providerIntegration.kubeadmConfig.kubelet.gracefulNodeShutdown.shutdownGracePeriod }}|g" "/var/lib/kubelet/config.yaml"
 {{- end }}
-{{- if $.Values.internal.kubeadmConfig.kubelet.gracefulNodeShutdown.shutdownGracePeriodCriticalPods }}
-sed -i "s|shutdownGracePeriodCriticalPods: .*|shutdownGracePeriodCriticalPods: {{ $.Values.internal.kubeadmConfig.kubelet.gracefulNodeShutdown.shutdownGracePeriodCriticalPods }}|g" "/var/lib/kubelet/config.yaml"
+{{- if $.Values.providerIntegration.kubeadmConfig.kubelet.gracefulNodeShutdown.shutdownGracePeriodCriticalPods }}
+sed -i "s|shutdownGracePeriodCriticalPods: .*|shutdownGracePeriodCriticalPods: {{ $.Values.providerIntegration.kubeadmConfig.kubelet.gracefulNodeShutdown.shutdownGracePeriodCriticalPods }}|g" "/var/lib/kubelet/config.yaml"
 {{- end }}
 systemctl restart kubelet

--- a/helm/cluster/templates/_helpers.tpl
+++ b/helm/cluster/templates/_helpers.tpl
@@ -40,6 +40,12 @@ cluster.x-k8s.io/watch-filter: capi
 helm.sh/chart: {{ include "cluster.chart.nameAndVersion" $ | quote }}
 {{- end -}}
 
+{{- define "cluster.labels.preventDeletion" }}
+{{- if $.Values.global.metadata.preventDeletion }}
+giantswarm.io/prevent-deletion: "true"
+{{- end }}
+{{- end }}
+
 {{- define "cluster.labels.custom" }}
 {{- if .Values.global.metadata.labels }}
 {{- range $key, $val := .Values.global.metadata.labels }}

--- a/helm/cluster/templates/_helpers.tpl
+++ b/helm/cluster/templates/_helpers.tpl
@@ -59,7 +59,7 @@ helm.sh/chart: {{ include "cluster.chart.nameAndVersion" $ | quote }}
 {{/*
 Hash function based on data provided
 Expects two arguments (as a `dict`) E.g.
-  {{ include "hash" (dict "data" . "salt" .Values.internal.hasSalt) }}
+  {{ include "hash" (dict "data" . "salt" .Values.providerIntegration.hasSalt) }}
 Where `data` is the data to hash and `global` is the top level scope.
 */}}
 {{- define "cluster.data.hash" -}}

--- a/helm/cluster/templates/_helpers.tpl
+++ b/helm/cluster/templates/_helpers.tpl
@@ -68,3 +68,26 @@ Where `data` is the data to hash and `global` is the top level scope.
 {{- if .salt }}{{ $salt = .salt}}{{end}}
 {{- (printf "%s%s" $data $salt) | quote | sha1sum | trunc 8 }}
 {{- end -}}
+
+{{/* Function that gets a Helm value based on its path */}}
+{{- define "cluster.values.get" -}}
+{{- $propertyPath := .path }}
+{{- $pathParts := split "." $propertyPath }}
+{{- $propertyValue := .Values }}
+{{- range $pathPart := $pathParts }}
+{{- $propertyValue = get $propertyValue $pathPart }}
+{{- end }}
+{{ $propertyValue }}
+{{- end }}
+
+{{/* Function that checks if a Helm value from a path is equal to a specified value */}}
+{{- define "cluster.values.equal" -}}
+{{- $propertyPath := .path }}
+{{- $pathParts := split "." $propertyPath }}
+{{- $propertyValue := .Values }}
+{{- range $pathPart := $pathParts }}
+{{- $propertyValue = get $propertyValue $pathPart }}
+{{- end }}
+{{- $testValue := .testValue }}
+{{ eq $propertyValue $testValue }}
+{{- end }}

--- a/helm/cluster/templates/bastion/_helpers_flatcar.tpl
+++ b/helm/cluster/templates/bastion/_helpers_flatcar.tpl
@@ -2,9 +2,9 @@
 containerLinuxConfig:
   additionalConfig: |
     systemd:
-      {{- if (((((($.Values.internal.bastion).kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).systemd).units }}
+      {{- if (((((($.Values.providerIntegration.bastion).kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).systemd).units }}
       units:
-      {{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $.Values.internal.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units | indent 6 }}
+      {{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $.Values.providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units | indent 6 }}
       {{- else }}
       units: []
       {{- end }}

--- a/helm/cluster/templates/bastion/_helpers_prekubeadmcommands.tpl
+++ b/helm/cluster/templates/bastion/_helpers_prekubeadmcommands.tpl
@@ -1,7 +1,7 @@
 {{/*
     Template cluster.internal.bastion.kubeadm.preKubeadmCommands defines extra commands to run
     on bastion nodes before kubeadm runs. It includes prefedined commands and custom commands
-    specified in Helm values field .Values.internal.bastion.kubeadmConfig.preKubeadmCommands.
+    specified in Helm values field .Values.providerIntegration.bastion.kubeadmConfig.preKubeadmCommands.
 */}}
 {{- define "cluster.internal.bastion.kubeadm.preKubeadmCommands" }}
 {{- include "cluster.internal.kubeadm.preKubeadmCommands.flatcar" $ }}
@@ -10,8 +10,8 @@
 {{- end }}
 
 {{- define "cluster.internal.bastion.kubeadm.preKubeadmCommands.custom" }}
-{{- if $.Values.internal.bastion.kubeadmConfig }}
-{{- range $command := $.Values.internal.bastion.kubeadmConfig.preKubeadmCommands }}
+{{- if $.Values.providerIntegration.bastion.kubeadmConfig }}
+{{- range $command := $.Values.providerIntegration.bastion.kubeadmConfig.preKubeadmCommands }}
 - {{ $command }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/bastion/kubeadmconfigtemplate.yaml
+++ b/helm/cluster/templates/bastion/kubeadmconfigtemplate.yaml
@@ -1,4 +1,4 @@
-{{- if $.Values.internal.resourcesApi.bastionResourceEnabled }}
+{{- if $.Values.providerIntegration.resourcesApi.bastionResourceEnabled }}
 {{- if .Values.global.connectivity.bastion.enabled }}
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
@@ -10,7 +10,7 @@ metadata:
     cluster.x-k8s.io/role: bastion
     {{- include "cluster.labels.common" $ | nindent 4 }}
     {{- include "cluster.labels.custom" $ | indent 4 }}
-  name: {{ include "cluster.resource.name" $ }}-bastion-{{ include "cluster.data.hash" (dict "data" (include "cluster.internal.bastion.kubeadmconfigtemplate.spec" $) "salt" $.Values.internal.hashSalt) }}
+  name: {{ include "cluster.resource.name" $ }}-bastion-{{ include "cluster.data.hash" (dict "data" (include "cluster.internal.bastion.kubeadmconfigtemplate.spec" $) "salt" $.Values.providerIntegration.hashSalt) }}
   namespace: {{ $.Release.Namespace }}
 spec:
   template:

--- a/helm/cluster/templates/bastion/machinedeployment.yaml
+++ b/helm/cluster/templates/bastion/machinedeployment.yaml
@@ -1,4 +1,4 @@
-{{- if $.Values.internal.resourcesApi.bastionResourceEnabled }}
+{{- if $.Values.providerIntegration.resourcesApi.bastionResourceEnabled }}
 {{- if .Values.global.connectivity.bastion.enabled }}
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -38,12 +38,12 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: {{ include "cluster.resource.name" $ }}-bastion-{{ include "cluster.data.hash" (dict "data" (include "cluster.internal.bastion.kubeadmconfigtemplate.spec" $) "salt" $.Values.internal.hashSalt) }}
+          name: {{ include "cluster.resource.name" $ }}-bastion-{{ include "cluster.data.hash" (dict "data" (include "cluster.internal.bastion.kubeadmconfigtemplate.spec" $) "salt" $.Values.providerIntegration.hashSalt) }}
       clusterName: {{ include "cluster.resource.name" $ }}
       infrastructureRef:
-        apiVersion: {{ $.Values.internal.resourcesApi.bastion.infrastructureMachineTemplate.group }}/{{ $.Values.internal.resourcesApi.bastion.infrastructureMachineTemplate.version }}
-        kind: {{ $.Values.internal.resourcesApi.bastion.infrastructureMachineTemplate.kind }}
-        name: {{ include "cluster.resource.name" $ }}-bastion-{{ include "cluster.data.hash" (dict "data" (include $.Values.internal.resourcesApi.bastion.infrastructureMachineTemplateSpecTemplateName $) "salt" $.Values.internal.hashSalt) }}
-      version: {{ $.Values.internal.kubernetesVersion }}
+        apiVersion: {{ $.Values.providerIntegration.resourcesApi.bastion.infrastructureMachineTemplate.group }}/{{ $.Values.providerIntegration.resourcesApi.bastion.infrastructureMachineTemplate.version }}
+        kind: {{ $.Values.providerIntegration.resourcesApi.bastion.infrastructureMachineTemplate.kind }}
+        name: {{ include "cluster.resource.name" $ }}-bastion-{{ include "cluster.data.hash" (dict "data" (include $.Values.providerIntegration.resourcesApi.bastion.infrastructureMachineTemplateSpecTemplateName $) "salt" $.Values.providerIntegration.hashSalt) }}
+      version: {{ $.Values.providerIntegration.kubernetesVersion }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/_helpers.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers.tpl
@@ -35,7 +35,7 @@
 - another.noproxy.address.giantswarm.io
 {{- end }}
 
-{{- define "cluster.test.providerIntegration.connectivity.labels" }}
+{{- define "cluster.test.providerIntegration.connectivity.annotations" }}
 network-topology.giantswarm.io/mode: None
 network-topology.giantswarm.io/transit-gateway: abc-123
 network-topology.giantswarm.io/prefix-list: "foo,bar"

--- a/helm/cluster/templates/clusterapi/_helpers.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers.tpl
@@ -34,3 +34,9 @@
 - some.noproxy.address.giantswarm.io
 - another.noproxy.address.giantswarm.io
 {{- end }}
+
+{{- define "cluster.test.providerIntegration.connectivity.labels" }}
+network-topology.giantswarm.io/mode: None
+network-topology.giantswarm.io/transit-gateway: abc-123
+network-topology.giantswarm.io/prefix-list: "foo,bar"
+{{- end }}

--- a/helm/cluster/templates/clusterapi/_helpers_files.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_files.tpl
@@ -17,8 +17,8 @@
 {{- end }}
 
 {{- define "cluster.internal.kubeadm.files.systemd" }}
-{{- if and $.Values.internal.kubeadmConfig $.Values.internal.kubeadmConfig.systemd }}
-{{- if and $.Values.internal.kubeadmConfig $.Values.internal.kubeadmConfig.systemd.timesyncd }}
+{{- if and $.Values.providerIntegration.kubeadmConfig $.Values.providerIntegration.kubeadmConfig.systemd }}
+{{- if and $.Values.providerIntegration.kubeadmConfig $.Values.providerIntegration.kubeadmConfig.systemd.timesyncd }}
 - path: /etc/systemd/timesyncd.conf
   permissions: "0644"
   encoding: base64
@@ -48,12 +48,12 @@
 {{- end }}
 
 {{- define "cluster.internal.kubeadm.files.kubelet" }}
-{{- if and $.Values.internal.kubeadmConfig $.Values.internal.kubeadmConfig.kubelet }}
+{{- if and $.Values.providerIntegration.kubeadmConfig $.Values.providerIntegration.kubeadmConfig.kubelet }}
 - path: /opt/kubelet-config.sh
   permissions: "0700"
   encoding: base64
   content: {{ tpl ($.Files.Get "files/opt/kubelet-config.sh") . | b64enc }}
-{{- if $.Values.internal.kubeadmConfig.kubelet.gracefulNodeShutdown }}
+{{- if $.Values.providerIntegration.kubeadmConfig.kubelet.gracefulNodeShutdown }}
 - path: /etc/systemd/logind.conf.d/zzz-kubelet-graceful-shutdown.conf
   permissions: "0700"
   encoding: base64
@@ -72,7 +72,7 @@
   permissions: "0644"
   encoding: base64
   content: {{ tpl ($.Files.Get "files/etc/systemd/http-proxy.conf") $ | b64enc }}
-{{- if $.Values.internal.teleport.enabled }}
+{{- if $.Values.providerIntegration.teleport.enabled }}
 - path: /etc/systemd/system/teleport.service.d/http-proxy.conf
   permissions: "0644"
   encoding: base64
@@ -86,7 +86,7 @@ The secret `-teleport-join-token` is created by the teleport-operator in cluster
 and is used to join the node to the teleport cluster.
 */}}
 {{- define "cluster.internal.kubeadm.files.teleport" }}
-{{- if $.Values.internal.teleport.enabled }}
+{{- if $.Values.providerIntegration.teleport.enabled }}
 - path: /etc/teleport-join-token
   permissions: "0644"
   contentFrom:
@@ -105,7 +105,7 @@ and is used to join the node to the teleport cluster.
 {{- end }}
 
 {{- define "cluster.internal.kubeadm.files.custom" }}
-{{- if $.Values.internal.kubeadmConfig.files }}
-{{ toYaml $.Values.internal.kubeadmConfig.files }}
+{{- if $.Values.providerIntegration.kubeadmConfig.files }}
+{{ toYaml $.Values.providerIntegration.kubeadmConfig.files }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/_helpers_flatcar.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_flatcar.tpl
@@ -90,7 +90,7 @@
 {{- end }}
 
 {{- define "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units.teleport" }}
-{{- if $.Values.internal.teleport.enabled }}
+{{- if $.Values.providerIntegration.teleport.enabled }}
 - name: teleport.service
   enabled: true
   contents: |

--- a/helm/cluster/templates/clusterapi/_helpers_postkubeadmcommands.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_postkubeadmcommands.tpl
@@ -1,7 +1,7 @@
 {{/*
     Template cluster.internal.kubeadm.postKubeadmCommands defines common extra commands to run on all
     (control plane and workers) nodes after kubeadm runs. It includes prefedined commands and custom
-    commands specified in Helm values field .Values.internal.kubeadmConfig.postKubeadmCommands.
+    commands specified in Helm values field .Values.providerIntegration.kubeadmConfig.postKubeadmCommands.
 */}}
 {{- define "cluster.internal.kubeadm.postKubeadmCommands" }}
 {{- include "cluster.internal.kubeadm.postKubeadmCommands.kubelet" $ }}
@@ -13,8 +13,8 @@
 {{- end }}
 
 {{- define "cluster.internal.kubeadm.postKubeadmCommands.custom" }}
-{{- if $.Values.internal.kubeadmConfig }}
-{{- range $command := $.Values.internal.kubeadmConfig.postKubeadmCommands }}
+{{- if $.Values.providerIntegration.kubeadmConfig }}
+{{- range $command := $.Values.providerIntegration.kubeadmConfig.postKubeadmCommands }}
 - {{ $command }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/_helpers_prekubeadmcommands.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_prekubeadmcommands.tpl
@@ -1,7 +1,7 @@
 {{/*
     Template cluster.internal.kubeadm.preKubeadmCommands defines common extra commands to run on all
     (control plane and workers) nodes before kubeadm runs. It includes prefedined commands and
-    custom commands specified in Helm values field .Values.internal.kubeadmConfig.preKubeadmCommands.
+    custom commands specified in Helm values field .Values.providerIntegration.kubeadmConfig.preKubeadmCommands.
 */}}
 {{- define "cluster.internal.kubeadm.preKubeadmCommands" }}
 {{- include "cluster.internal.kubeadm.preKubeadmCommands.flatcar" $ }}
@@ -31,8 +31,8 @@
 {{- end }}
 
 {{- define "cluster.internal.kubeadm.preKubeadmCommands.custom" }}
-{{- if $.Values.internal.kubeadmConfig }}
-{{- range $command := $.Values.internal.kubeadmConfig.preKubeadmCommands }}
+{{- if $.Values.providerIntegration.kubeadmConfig }}
+{{- range $command := $.Values.providerIntegration.kubeadmConfig.preKubeadmCommands }}
 - {{ $command }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/cluster.yaml
+++ b/helm/cluster/templates/clusterapi/cluster.yaml
@@ -34,7 +34,13 @@ spec:
     kind: {{ .kind }}
     {{- end }}
     name: {{ include "cluster.resource.name" $ }}
-  {{- if .Values.providerIntegration.paused }}
+  {{- $paused := false }}
+  {{- range $propertyPath, $propertyPauseValue := .Values.providerIntegration.pauseProperties }}
+  {{- $propertyValue := (include "cluster.values.get" (dict "Values" $.Values "path" $propertyPath)) | trim }}
+  {{- $triggersPause := (include "cluster.values.equal" (dict "Values" $.Values "path" $propertyPath "testValue" $propertyPauseValue )) | trim }}
+  {{- $paused = or $paused (eq $triggersPause "true") }}
+  {{- end }}
+  {{- if $paused }}
   paused: true
-  {{- end -}}
+  {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/cluster.yaml
+++ b/helm/cluster/templates/clusterapi/cluster.yaml
@@ -6,13 +6,13 @@ metadata:
     {{- with $.Values.global.metadata.description }}
     cluster.giantswarm.io/description: "{{ . }}"
     {{- end }}
+    {{- include "cluster.annotations.custom" $ | indent 4 }}
   labels:
     {{- include "cluster.labels.common" $ | nindent 4 }}
     cluster-apps-operator.giantswarm.io/watching: ""
-    {{- if $.Values.global.metadata.labels }}
-    {{- range $key, $val := $.Values.global.metadata.labels }}
-    {{ $key }}: {{ $val | quote }}
-    {{- end }}
+    {{- include "cluster.labels.custom" $ | indent 4 }}
+    {{- if .Values.providerIntegration.clusterLabelsTemplateName }}
+    {{- include .Values.providerIntegration.clusterLabelsTemplateName . | indent 4 }}
     {{- end }}
   name: {{ include "cluster.resource.name" $ }}
   namespace: {{ .Release.Namespace }}

--- a/helm/cluster/templates/clusterapi/cluster.yaml
+++ b/helm/cluster/templates/clusterapi/cluster.yaml
@@ -11,8 +11,9 @@ metadata:
     {{- end }}
     {{- include "cluster.annotations.custom" $ | indent 4 }}
   labels:
-    {{- include "cluster.labels.common" $ | nindent 4 }}
     cluster-apps-operator.giantswarm.io/watching: ""
+    {{- include "cluster.labels.common" $ | nindent 4 }}
+    {{- include "cluster.labels.preventDeletion" $ | indent 4 }}
     {{- include "cluster.labels.custom" $ | indent 4 }}
   name: {{ include "cluster.resource.name" $ }}
   namespace: {{ .Release.Namespace }}

--- a/helm/cluster/templates/clusterapi/cluster.yaml
+++ b/helm/cluster/templates/clusterapi/cluster.yaml
@@ -6,14 +6,14 @@ metadata:
     {{- with $.Values.global.metadata.description }}
     cluster.giantswarm.io/description: "{{ . }}"
     {{- end }}
+    {{- if .Values.providerIntegration.clusterAnnotationsTemplateName }}
+    {{- include .Values.providerIntegration.clusterAnnotationsTemplateName $ | indent 4 }}
+    {{- end }}
     {{- include "cluster.annotations.custom" $ | indent 4 }}
   labels:
     {{- include "cluster.labels.common" $ | nindent 4 }}
     cluster-apps-operator.giantswarm.io/watching: ""
     {{- include "cluster.labels.custom" $ | indent 4 }}
-    {{- if .Values.providerIntegration.clusterLabelsTemplateName }}
-    {{- include .Values.providerIntegration.clusterLabelsTemplateName . | indent 4 }}
-    {{- end }}
   name: {{ include "cluster.resource.name" $ }}
   namespace: {{ .Release.Namespace }}
 spec:

--- a/helm/cluster/templates/clusterapi/cluster.yaml
+++ b/helm/cluster/templates/clusterapi/cluster.yaml
@@ -1,4 +1,4 @@
-{{- if $.Values.internal.resourcesApi.clusterResourceEnabled }}
+{{- if $.Values.providerIntegration.resourcesApi.clusterResourceEnabled }}
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
@@ -25,16 +25,16 @@ spec:
       cidrBlocks:
       {{- toYaml $.Values.global.connectivity.network.pods.cidrBlocks | nindent 8 }}
   controlPlaneRef:
-    apiVersion: {{ .Values.internal.controlPlane.resources.controlPlane.api.group }}/{{ .Values.internal.controlPlane.resources.controlPlane.api.version }}
-    kind: {{ .Values.internal.controlPlane.resources.controlPlane.api.kind }}
+    apiVersion: {{ .Values.providerIntegration.controlPlane.resources.controlPlane.api.group }}/{{ .Values.providerIntegration.controlPlane.resources.controlPlane.api.version }}
+    kind: {{ .Values.providerIntegration.controlPlane.resources.controlPlane.api.kind }}
     name: {{ include "cluster.resource.name" $ }}
   infrastructureRef:
-    {{- with .Values.providerChartIntegration.resourcesApi.infrastructureCluster }}
+    {{- with .Values.providerIntegration.resourcesApi.infrastructureCluster }}
     apiVersion: {{ .group }}/{{ .version }}
     kind: {{ .kind }}
     {{- end }}
     name: {{ include "cluster.resource.name" $ }}
-  {{- if .Values.internal.paused }}
+  {{- if .Values.providerIntegration.paused }}
   paused: true
   {{- end -}}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/cluster.yaml
+++ b/helm/cluster/templates/clusterapi/cluster.yaml
@@ -29,8 +29,10 @@ spec:
     kind: {{ .Values.internal.controlPlane.resources.controlPlane.api.kind }}
     name: {{ include "cluster.resource.name" $ }}
   infrastructureRef:
-    apiVersion: {{ .Values.internal.resourcesApi.infrastructureCluster.group }}/{{ .Values.internal.resourcesApi.infrastructureCluster.version }}
-    kind: {{ .Values.internal.resourcesApi.infrastructureCluster.kind }}
+    {{- with .Values.providerChartIntegration.resourcesApi.infrastructureCluster }}
+    apiVersion: {{ .group }}/{{ .version }}
+    kind: {{ .kind }}
+    {{- end }}
     name: {{ include "cluster.resource.name" $ }}
   {{- if .Values.internal.paused }}
   paused: true

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_apiserver.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_apiserver.tpl
@@ -4,8 +4,8 @@ certSANs:
 - 127.0.0.1
 - "api.{{ include "cluster.resource.name" $ }}.{{ required "The baseDomain value is required" $.Values.global.connectivity.baseDomain }}"
 - "apiserver.{{ include "cluster.resource.name" $ }}.{{ required "The baseDomain value is required" $.Values.global.connectivity.baseDomain }}"
-{{- if $.Values.internal.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.extraCertificateSANs }}
-{{ toYaml $.Values.internal.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.extraCertificateSANs }}
+{{- if $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.extraCertificateSANs }}
+{{ toYaml $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.extraCertificateSANs }}
 {{- end }}
 {{- /*
     Timeout for the API server to appear.
@@ -14,7 +14,7 @@ certSANs:
 */}}
 timeoutForControlPlane: 20min
 extraArgs:
-  {{- if .Values.internal.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.apiAudiences }}
+  {{- if .Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.apiAudiences }}
   api-audiences: {{ include "cluster.internal.controlPlane.kubeadm.clusterConfiguration.apiServer.apiAudiences" $ | trim | quote }}
   {{- end }}
   audit-log-maxage: "30"
@@ -25,10 +25,10 @@ extraArgs:
   cloud-provider: external
   enable-admission-plugins: {{ include "cluster.internal.controlPlane.kubeadm.clusterConfiguration.apiServer.enableAdmissionPlugins" $ }}
   encryption-provider-config: /etc/kubernetes/encryption/config.yaml
-  {{- if $.Values.internal.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.etcdPrefix }}
-  etcd-prefix: {{ $.Values.internal.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.etcdPrefix }}
+  {{- if $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.etcdPrefix }}
+  etcd-prefix: {{ $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.etcdPrefix }}
   {{- end }}
-  {{- if .Values.internal.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates }}
+  {{- if .Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates }}
   feature-gates: {{ include "cluster.internal.controlPlane.kubeadm.clusterConfiguration.apiServer.featureGates" $ }}
   {{- end }}
   kubelet-preferred-address-types: InternalIP
@@ -43,21 +43,21 @@ extraArgs:
   {{- end }}
   profiling: "false"
   runtime-config: api/all=true
-  {{- if .Values.internal.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.serviceAccountIssuer }}
+  {{- if .Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.serviceAccountIssuer }}
   service-account-issuer: "{{ include "cluster.internal.controlPlane.kubeadm.clusterConfiguration.apiServer.serviceAccountIssuer" $ }}"
   {{- end }}
   service-account-lookup: "true"
   tls-cipher-suites: {{ include "cluster.internal.controlPlane.kubeadm.clusterConfiguration.apiServer.tlsCipherSuites" $ }}
-  {{- range $argName, $argValue := ((($.Values.internal.controlPlane.kubeadmConfig).clusterConfiguration).apiServer).extraArgs }}
+  {{- range $argName, $argValue := ((($.Values.providerIntegration.controlPlane.kubeadmConfig).clusterConfiguration).apiServer).extraArgs }}
   {{ $argName }}: {{ if kindIs "string" $argValue }}{{ $argValue | quote }}{{ else }}{{ $argValue }}{{ end }}
   {{- end }}
 {{- end }}
 
 {{- define "cluster.internal.controlPlane.kubeadm.clusterConfiguration.apiServer.apiAudiences" }}
-{{- if kindIs "string" $.Values.internal.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.apiAudiences }}
-{{ $.Values.internal.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.apiAudiences | trim }}
-{{- else if $.Values.internal.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.apiAudiences.templateName }}
-{{ include $.Values.internal.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.apiAudiences.templateName $ | trim }}
+{{- if kindIs "string" $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.apiAudiences }}
+{{ $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.apiAudiences | trim }}
+{{- else if $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.apiAudiences.templateName }}
+{{ include $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.apiAudiences.templateName $ | trim }}
 {{- end }}
 {{- end }}
 
@@ -73,17 +73,17 @@ extraArgs:
   "ResourceQuota"
   "ServiceAccount"
   "ValidatingAdmissionWebhook" -}}
-{{- range $additionalAdmissionPlugin := $.Values.internal.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.additionalAdmissionPlugins }}
+{{- range $additionalAdmissionPlugin := $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.additionalAdmissionPlugins }}
 {{- $enabledAdmissionPlugins = append $enabledAdmissionPlugins $additionalAdmissionPlugin -}}
 {{- end }}
 {{- join "," (compact $enabledAdmissionPlugins) }}
 {{- end }}
 
 {{- define "cluster.internal.controlPlane.kubeadm.clusterConfiguration.apiServer.serviceAccountIssuer" }}
-{{- if .Values.internal.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.serviceAccountIssuer.clusterDomainPrefix -}}
-https://{{ .Values.internal.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.serviceAccountIssuer.clusterDomainPrefix }}.{{ include "cluster.resource.name" $ }}.{{ required "The baseDomain value is required" $.Values.global.connectivity.baseDomain }}
+{{- if .Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.serviceAccountIssuer.clusterDomainPrefix -}}
+https://{{ .Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.serviceAccountIssuer.clusterDomainPrefix }}.{{ include "cluster.resource.name" $ }}.{{ required "The baseDomain value is required" $.Values.global.connectivity.baseDomain }}
 {{- else -}}
-{{ .Values.internal.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.serviceAccountIssuer.url }}
+{{ .Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.serviceAccountIssuer.url }}
 {{- end }}
 {{- end }}
 
@@ -118,7 +118,7 @@ api-audiences-example.giantswarm.io
 
 {{- define "cluster.internal.controlPlane.kubeadm.clusterConfiguration.apiServer.featureGates" }}
 {{- $featureGates := list -}}
-{{- range $featureGate := $.Values.internal.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates }}
+{{- range $featureGate := $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates }}
 {{- $featureGates = append $featureGates (printf "%s=%t" $featureGate.name $featureGate.enabled) -}}
 {{- end }}
 {{- join "," (compact $featureGates) | quote }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_etcd.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_etcd.tpl
@@ -3,7 +3,7 @@ local:
   extraArgs:
     listen-metrics-urls: "http://0.0.0.0:2381"
     quota-backend-bytes: "8589934592"
-    {{- with $etcdConfig := (($.Values.internal.controlPlane.kubeadmConfig).clusterConfiguration).etcd }}
+    {{- with $etcdConfig := (($.Values.providerIntegration.controlPlane.kubeadmConfig).clusterConfiguration).etcd }}
     {{- if $etcdConfig.initialCluster }}
     initial-cluster: {{ $etcdConfig.initialCluster | quote }}
     {{- end }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_files.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_files.tpl
@@ -24,7 +24,7 @@
 {{- end }}
 
 {{- define "cluster.internal.controlPlane.kubeadm.files.custom" }}
-{{- if $.Values.internal.controlPlane.kubeadmConfig.files }}
-{{ toYaml $.Values.internal.controlPlane.kubeadmConfig.files }}
+{{- if $.Values.providerIntegration.controlPlane.kubeadmConfig.files }}
+{{ toYaml $.Values.providerIntegration.controlPlane.kubeadmConfig.files }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_flatcar.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_flatcar.tpl
@@ -13,28 +13,28 @@ containerLinuxConfig:
 {{- end }}
 
 {{- define "cluster.internal.controlPlane.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" }}
-{{- if ((((($.Values.internal.kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).systemd).units }}
-{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $.Values.internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units }}
+{{- if ((((($.Values.providerIntegration.kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).systemd).units }}
+{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $.Values.providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units }}
 {{- end }}
-{{- if (((((($.Values.internal.controlPlane).kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).systemd).units }}
-{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $.Values.internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units }}
+{{- if (((((($.Values.providerIntegration.controlPlane).kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).systemd).units }}
+{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $.Values.providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units }}
 {{- end }}
 {{- end }}
 
 {{- define "cluster.internal.controlPlane.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.filesystems" }}
-{{- if ((((($.Values.internal.kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).storage).filesystems }}
-{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.filesystems" $.Values.internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems }}
+{{- if ((((($.Values.providerIntegration.kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).storage).filesystems }}
+{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.filesystems" $.Values.providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems }}
 {{- end }}
-{{- if (((((($.Values.internal.controlPlane).kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).storage).filesystems }}
-{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.filesystems" $.Values.internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems }}
+{{- if (((((($.Values.providerIntegration.controlPlane).kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).storage).filesystems }}
+{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.filesystems" $.Values.providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems }}
 {{- end }}
 {{- end }}
 
 {{- define "cluster.internal.controlPlane.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.directories" }}
-{{- if ((((($.Values.internal.kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).storage).directories }}
-{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.directories" $.Values.internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories }}
+{{- if ((((($.Values.providerIntegration.kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).storage).directories }}
+{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.directories" $.Values.providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories }}
 {{- end }}
-{{- if (((((($.Values.internal.controlPlane).kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).storage).directories }}
-{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.directories" $.Values.internal.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories }}
+{{- if (((((($.Values.providerIntegration.controlPlane).kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).storage).directories }}
+{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.directories" $.Values.providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_initconfiguration.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_initconfiguration.tpl
@@ -4,7 +4,7 @@ skipPhases:
 - addon/coredns
 localAPIEndpoint:
   advertiseAddress: ""
-  bindPort: {{ $.Values.internal.controlPlane.kubeadmConfig.localAPIEndpoint.bindPort }}
+  bindPort: {{ $.Values.providerIntegration.controlPlane.kubeadmConfig.localAPIEndpoint.bindPort }}
 nodeRegistration:
   kubeletExtraArgs:
     cloud-provider: external

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_joinconfiguration.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_joinconfiguration.tpl
@@ -2,7 +2,7 @@
 discovery: {}
 controlPlane:
   localAPIEndpoint:
-    bindPort: {{ $.Values.internal.controlPlane.kubeadmConfig.localAPIEndpoint.bindPort }}
+    bindPort: {{ $.Values.providerIntegration.controlPlane.kubeadmConfig.localAPIEndpoint.bindPort }}
 nodeRegistration:
   kubeletExtraArgs:
     cloud-provider: external

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_postkubeadmcommands.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_postkubeadmcommands.tpl
@@ -1,7 +1,7 @@
 {{/*
     Template cluster.internal.controlPlane.kubeadm.postKubeadmCommands defines extra commands to run
     on control plane nodes after kubeadm runs. It includes prefedined commands and custom commands
-    specified in Helm values field .Values.internal.controlPlane.kubeadmConfig.postKubeadmCommands.
+    specified in Helm values field .Values.providerIntegration.controlPlane.kubeadmConfig.postKubeadmCommands.
 */}}
 {{- define "cluster.internal.controlPlane.kubeadm.postKubeadmCommands" }}
 {{- include "cluster.internal.kubeadm.postKubeadmCommands" $ }}
@@ -9,8 +9,8 @@
 {{- end }}
 
 {{- define "cluster.internal.controlPlane.kubeadm.postKubeadmCommands.custom" }}
-{{- if $.Values.internal.controlPlane.kubeadmConfig }}
-{{- range $command := $.Values.internal.controlPlane.kubeadmConfig.postKubeadmCommands }}
+{{- if $.Values.providerIntegration.controlPlane.kubeadmConfig }}
+{{- range $command := $.Values.providerIntegration.controlPlane.kubeadmConfig.postKubeadmCommands }}
 - {{ $command }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_prekubeadmcommands.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_prekubeadmcommands.tpl
@@ -1,7 +1,7 @@
 {{/*
     Template cluster.internal.controlPlane.kubeadm.preKubeadmCommands defines extra commands to run
     on control plane nodes before kubeadm runs. It includes prefedined commands and custom commands
-    specified in Helm values field .Values.internal.controlPlane.kubeadmConfig.preKubeadmCommands.
+    specified in Helm values field .Values.providerIntegration.controlPlane.kubeadmConfig.preKubeadmCommands.
 */}}
 {{- define "cluster.internal.controlPlane.kubeadm.preKubeadmCommands" }}
 {{- include "cluster.internal.kubeadm.preKubeadmCommands" $ }}
@@ -9,8 +9,8 @@
 {{- end }}
 
 {{- define "cluster.internal.controlPlane.kubeadm.preKubeadmCommands.custom" }}
-{{- if $.Values.internal.controlPlane.kubeadmConfig }}
-{{- range $command := $.Values.internal.controlPlane.kubeadmConfig.preKubeadmCommands }}
+{{- if $.Values.providerIntegration.controlPlane.kubeadmConfig }}
+{{- range $command := $.Values.providerIntegration.controlPlane.kubeadmConfig.preKubeadmCommands }}
 - {{ $command }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/controlplane/kubeadmcontrolplane.yaml
+++ b/helm/cluster/templates/clusterapi/controlplane/kubeadmcontrolplane.yaml
@@ -1,4 +1,4 @@
-{{- if $.Values.internal.resourcesApi.controlPlaneResourceEnabled }}
+{{- if $.Values.providerIntegration.resourcesApi.controlPlaneResourceEnabled }}
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
 metadata:
@@ -21,9 +21,9 @@ spec:
         {{- include "cluster.labels.common" $ | nindent 8 }}
         {{- include "cluster.labels.custom" $ | indent 8 }}
     infrastructureRef:
-      apiVersion: {{ $.Values.internal.controlPlane.resources.infrastructureMachineTemplate.group }}/{{ $.Values.internal.controlPlane.resources.infrastructureMachineTemplate.version }}
-      kind: {{ $.Values.internal.controlPlane.resources.infrastructureMachineTemplate.kind }}
-      name: {{ include "cluster.resource.name" $ }}-control-plane-{{ include "cluster.data.hash" (dict "data" (include $.Values.internal.controlPlane.resources.infrastructureMachineTemplateSpecTemplateName $) "salt" $.Values.internal.hashSalt) }}
+      apiVersion: {{ $.Values.providerIntegration.controlPlane.resources.infrastructureMachineTemplate.group }}/{{ $.Values.providerIntegration.controlPlane.resources.infrastructureMachineTemplate.version }}
+      kind: {{ $.Values.providerIntegration.controlPlane.resources.infrastructureMachineTemplate.kind }}
+      name: {{ include "cluster.resource.name" $ }}-control-plane-{{ include "cluster.data.hash" (dict "data" (include $.Values.providerIntegration.controlPlane.resources.infrastructureMachineTemplateSpecTemplateName $) "salt" $.Values.providerIntegration.hashSalt) }}
   kubeadmConfigSpec:
     format: ignition
     ignition:
@@ -56,5 +56,5 @@ spec:
     users:
     {{- include "cluster.internal.kubeadm.users" $ | indent 4 }}
   replicas: {{ .Values.global.controlPlane.replicas }}
-  version: v{{ trimPrefix "v" .Values.internal.kubernetesVersion }}
+  version: v{{ trimPrefix "v" .Values.providerIntegration.kubernetesVersion }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/controlplane/machinehealthcheck.yaml
+++ b/helm/cluster/templates/clusterapi/controlplane/machinehealthcheck.yaml
@@ -1,5 +1,5 @@
-{{- if $.Values.internal.resourcesApi.controlPlaneResourceEnabled }}
-{{- if $.Values.internal.resourcesApi.machineHealthCheckResourceEnabled }}
+{{- if $.Values.providerIntegration.resourcesApi.controlPlaneResourceEnabled }}
+{{- if $.Values.providerIntegration.resourcesApi.machineHealthCheckResourceEnabled }}
 {{- if $.Values.global.controlPlane.machineHealthCheck.enabled }}
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck

--- a/helm/cluster/templates/clusterapi/workers/_helpers_files.tpl
+++ b/helm/cluster/templates/clusterapi/workers/_helpers_files.tpl
@@ -4,7 +4,7 @@
 {{- end }}
 
 {{- define "cluster.internal.workers.kubeadm.files.custom" }}
-{{- if $.Values.internal.workers.kubeadmConfig.files }}
-{{ toYaml $.Values.internal.workers.kubeadmConfig.files }}
+{{- if $.Values.providerIntegration.workers.kubeadmConfig.files }}
+{{ toYaml $.Values.providerIntegration.workers.kubeadmConfig.files }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/workers/_helpers_flatcar.tpl
+++ b/helm/cluster/templates/clusterapi/workers/_helpers_flatcar.tpl
@@ -11,28 +11,28 @@ containerLinuxConfig:
 {{- end }}
 
 {{- define "cluster.internal.workers.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" }}
-{{- if ((((($.Values.internal.kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).systemd).units }}
-{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $.Values.internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units }}
+{{- if ((((($.Values.providerIntegration.kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).systemd).units }}
+{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $.Values.providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units }}
 {{- end }}
-{{- if (((((($.Values.internal.workers).kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).systemd).units }}
-{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $.Values.internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units }}
+{{- if (((((($.Values.providerIntegration.workers).kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).systemd).units }}
+{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $.Values.providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units }}
 {{- end }}
 {{- end }}
 
 {{- define "cluster.internal.workers.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.filesystems" }}
-{{- if ((((($.Values.internal.kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).storage).filesystems }}
-{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.filesystems" $.Values.internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems }}
+{{- if ((((($.Values.providerIntegration.kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).storage).filesystems }}
+{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.filesystems" $.Values.providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems }}
 {{- end }}
-{{- if (((((($.Values.internal.workers).kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).storage).filesystems }}
-{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.filesystems" $.Values.internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems }}
+{{- if (((((($.Values.providerIntegration.workers).kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).storage).filesystems }}
+{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.filesystems" $.Values.providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.filesystems }}
 {{- end }}
 {{- end }}
 
 {{- define "cluster.internal.workers.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.directories" }}
-{{- if ((((($.Values.internal.kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).storage).directories }}
-{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.directories" $.Values.internal.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories }}
+{{- if ((((($.Values.providerIntegration.kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).storage).directories }}
+{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.directories" $.Values.providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories }}
 {{- end }}
-{{- if (((((($.Values.internal.workers).kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).storage).directories }}
-{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.directories" $.Values.internal.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories }}
+{{- if (((((($.Values.providerIntegration.workers).kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).storage).directories }}
+{{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.directories" $.Values.providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.storage.directories }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/workers/_helpers_postkubeadmcommands.tpl
+++ b/helm/cluster/templates/clusterapi/workers/_helpers_postkubeadmcommands.tpl
@@ -1,7 +1,7 @@
 {{/*
     Template cluster.internal.controlPlane.kubeadm.postKubeadmCommands defines extra commands to run
     on worker nodes after kubeadm runs. It includes prefedined commands and custom commands
-    specified in Helm values field .Values.internal.workers.kubeadmConfig.postKubeadmCommands.
+    specified in Helm values field .Values.providerIntegration.workers.kubeadmConfig.postKubeadmCommands.
 */}}
 {{- define "cluster.internal.workers.kubeadm.postKubeadmCommands" }}
 {{- include "cluster.internal.kubeadm.postKubeadmCommands" . }}
@@ -9,8 +9,8 @@
 {{- end }}
 
 {{- define "cluster.internal.workers.kubeadm.postKubeadmCommands.custom" }}
-{{- if $.Values.internal.workers.kubeadmConfig }}
-{{- range $command := $.Values.internal.workers.kubeadmConfig.postKubeadmCommands }}
+{{- if $.Values.providerIntegration.workers.kubeadmConfig }}
+{{- range $command := $.Values.providerIntegration.workers.kubeadmConfig.postKubeadmCommands }}
 - {{ $command }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/workers/_helpers_prekubeadmcommands.tpl
+++ b/helm/cluster/templates/clusterapi/workers/_helpers_prekubeadmcommands.tpl
@@ -1,7 +1,7 @@
 {{/*
     Template cluster.internal.workers.kubeadm.preKubeadmCommands defines extra commands to run
     on worker nodes before kubeadm runs. It includes prefedined commands and custom commands
-    specified in Helm values field .Values.internal.workers.kubeadmConfig.preKubeadmCommands.
+    specified in Helm values field .Values.providerIntegration.workers.kubeadmConfig.preKubeadmCommands.
 */}}
 {{- define "cluster.internal.workers.kubeadm.preKubeadmCommands" }}
 {{- include "cluster.internal.kubeadm.preKubeadmCommands" $ }}
@@ -9,8 +9,8 @@
 {{- end }}
 
 {{- define "cluster.internal.workers.kubeadm.preKubeadmCommands.custom" }}
-{{- if $.Values.internal.workers.kubeadmConfig }}
-{{- range $command := $.Values.internal.workers.kubeadmConfig.preKubeadmCommands }}
+{{- if $.Values.providerIntegration.workers.kubeadmConfig }}
+{{- range $command := $.Values.providerIntegration.workers.kubeadmConfig.preKubeadmCommands }}
 - {{ $command }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/workers/kubeadmconfig.yaml
+++ b/helm/cluster/templates/clusterapi/workers/kubeadmconfig.yaml
@@ -1,5 +1,5 @@
-{{- if $.Values.internal.resourcesApi.machinePoolResourcesEnabled }}
-{{- if eq $.Values.internal.resourcesApi.nodePoolKind "MachinePool" }}
+{{- if $.Values.providerIntegration.resourcesApi.machinePoolResourcesEnabled }}
+{{- if eq $.Values.providerIntegration.resourcesApi.nodePoolKind "MachinePool" }}
 {{- range $nodePoolName, $nodePoolConfig := $.Values.global.nodePools }}
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfig

--- a/helm/cluster/templates/clusterapi/workers/machinepool.yaml
+++ b/helm/cluster/templates/clusterapi/workers/machinepool.yaml
@@ -1,5 +1,5 @@
-{{- if $.Values.internal.resourcesApi.machinePoolResourcesEnabled }}
-{{- if eq $.Values.internal.resourcesApi.nodePoolKind "MachinePool" }}
+{{- if $.Values.providerIntegration.resourcesApi.machinePoolResourcesEnabled }}
+{{- if eq $.Values.providerIntegration.resourcesApi.nodePoolKind "MachinePool" }}
 {{- range $nodePoolName, $nodePoolConfig := $.Values.global.nodePools }}
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
@@ -36,10 +36,10 @@ spec:
           name: {{ include "cluster.resource.name" $ }}-{{ $nodePoolName }}
       clusterName: {{ include "cluster.resource.name" $ }}
       infrastructureRef:
-        apiVersion: {{ $.Values.internal.resourcesApi.infrastructureMachinePool.group }}/{{ $.Values.internal.resourcesApi.infrastructureMachinePool.version }}
-        kind: {{ $.Values.internal.resourcesApi.infrastructureMachinePool.kind }}
+        apiVersion: {{ $.Values.providerIntegration.resourcesApi.infrastructureMachinePool.group }}/{{ $.Values.providerIntegration.resourcesApi.infrastructureMachinePool.version }}
+        kind: {{ $.Values.providerIntegration.resourcesApi.infrastructureMachinePool.kind }}
         name: {{ include "cluster.resource.name" $ }}-{{ $nodePoolName }}
-      version: {{ $.Values.internal.kubernetesVersion }}
+      version: {{ $.Values.providerIntegration.kubernetesVersion }}
 ---
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/containerd_config.yaml
+++ b/helm/cluster/templates/containerd_config.yaml
@@ -1,4 +1,4 @@
-{{- if or $.Values.internal.resourcesApi.controlPlaneResourceEnabled $.Values.internal.resourcesApi.machinePoolResourcesEnabled }}
+{{- if or $.Values.providerIntegration.resourcesApi.controlPlaneResourceEnabled $.Values.providerIntegration.resourcesApi.machinePoolResourcesEnabled }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1031,10 +1031,10 @@
                         }
                     }
                 },
-                "clusterLabelsTemplateName": {
+                "clusterAnnotationsTemplateName": {
                     "type": "string",
-                    "title": "Cluster labels template name",
-                    "description": "The name of the template that renders provider-specific labels for the Cluster resource"
+                    "title": "Cluster annotations template name",
+                    "description": "The name of the template that renders provider-specific annotations for the Cluster resource"
                 },
                 "components": {
                     "type": "object",

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1031,6 +1031,11 @@
                         }
                     }
                 },
+                "clusterLabelsTemplateName": {
+                    "type": "string",
+                    "title": "Cluster labels template name",
+                    "description": "The name of the template that renders provider-specific labels for the Cluster resource"
+                },
                 "components": {
                     "type": "object",
                     "title": "Components",

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -604,7 +604,6 @@
                         "baseDomain",
                         "network"
                     ],
-                    "additionalProperties": false,
                     "properties": {
                         "baseDomain": {
                             "type": "string",
@@ -633,7 +632,6 @@
                                 "pods",
                                 "services"
                             ],
-                            "additionalProperties": false,
                             "properties": {
                                 "pods": {
                                     "type": "object",
@@ -641,7 +639,6 @@
                                     "required": [
                                         "cidrBlocks"
                                     ],
-                                    "additionalProperties": false,
                                     "properties": {
                                         "cidrBlocks": {
                                             "type": "array",
@@ -668,7 +665,6 @@
                                     "required": [
                                         "cidrBlocks"
                                     ],
-                                    "additionalProperties": false,
                                     "properties": {
                                         "cidrBlocks": {
                                             "type": "array",
@@ -698,7 +694,6 @@
                             "required": [
                                 "enabled"
                             ],
-                            "additionalProperties": false,
                             "properties": {
                                 "enabled": {
                                     "type": "boolean",
@@ -717,7 +712,6 @@
                                 "noProxy": {
                                     "type": "object",
                                     "title": "No proxy",
-                                    "additionalProperties": false,
                                     "properties": {
                                         "addresses": {
                                             "type": "array",

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1006,7 +1006,6 @@
                 "components",
                 "controlPlane",
                 "kubernetesVersion",
-                "paused",
                 "resourcesApi"
             ],
             "additionalProperties": false,
@@ -1470,10 +1469,18 @@
                     ],
                     "default": "1.24.10"
                 },
-                "paused": {
-                    "type": "boolean",
-                    "title": "Paused",
-                    "default": false
+                "pauseProperties": {
+                    "type": "object",
+                    "title": "Pause properties",
+                    "description": "A map of property names and their values that will affect setting pause annotation",
+                    "additionalProperties": {
+                        "type": [
+                            "string",
+                            "number",
+                            "integer",
+                            "boolean"
+                        ]
+                    }
                 },
                 "resourcesApi": {
                     "type": "object",
@@ -1482,12 +1489,12 @@
                     "required": [
                         "clusterResourceEnabled",
                         "controlPlaneResourceEnabled",
-                        "infrastructureCluster",
                         "machinePoolResourcesEnabled",
                         "machineHealthCheckResourceEnabled",
-                        "bastionResourceEnabled"
+                        "bastionResourceEnabled",
+                        "infrastructureCluster",
+                        "nodePoolKind"
                     ],
-                    "additionalProperties": false,
                     "properties": {
                         "bastion": {
                             "type": "object",
@@ -1536,39 +1543,36 @@
                             "title": "Machine pool resources enabled",
                             "description": "Flag that indicates if the machine pool resources are enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.",
                             "default": true
+                        },
+                        "nodePoolKind": {
+                            "type": "string",
+                            "title": "Node pool kind",
+                            "description": "Specifies which resource kind is used for node pools.",
+                            "enum": [
+                                "MachineDeployment",
+                                "MachinePool"
+                            ]
                         }
                     },
-                    "oneOf": [
-                        {
-                            "required": [
-                                "infrastructureMachinePool",
-                                "nodePoolKind"
-                            ],
-                            "properties": {
-                                "infrastructureMachinePool": {
-                                    "$ref": "#/$defs/infrastructureMachinePool"
-                                },
-                                "nodePoolKind": {
-                                    "const": "MachinePool"
-                                }
-                            }
-                        },
-                        {
-                            "required": [
-                                "nodePoolKind"
-                            ],
-                            "properties": {
-                                "nodePoolKind": {
-                                    "const": "MachineDeployment"
-                                }
-                            },
-                            "not": {
-                                "required": [
-                                    "infrastructureMachinePool"
-                                ]
+                    "unevaluatedProperties": false,
+                    "if": {
+                        "type": "object",
+                        "properties": {
+                            "nodePoolKind": {
+                                "const": "MachinePool"
                             }
                         }
-                    ]
+                    },
+                    "then": {
+                        "required": [
+                            "infrastructureMachinePool"
+                        ],
+                        "properties": {
+                            "infrastructureMachinePool": {
+                                "$ref": "#/$defs/infrastructureMachinePool"
+                            }
+                        }
+                    }
                 },
                 "teleport": {
                     "type": "object",

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1479,7 +1479,6 @@
                     "title": "Resources API",
                     "description": "Group, version and kind configuration that is required and used by a specific Cluster API provider.",
                     "required": [
-                        "infrastructureCluster",
                         "clusterResourceEnabled",
                         "controlPlaneResourceEnabled",
                         "machinePoolResourcesEnabled",

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1565,6 +1565,9 @@
                             "if": {
                                 "type": "object",
                                 "properties": {
+                                    "machinePoolResourcesEnabled": {
+                                        "const": true
+                                    },
                                     "nodePoolKind": {
                                         "const": "MachinePool"
                                     }

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1497,25 +1497,9 @@
                         "machinePoolResourcesEnabled",
                         "machineHealthCheckResourceEnabled",
                         "bastionResourceEnabled",
-                        "infrastructureCluster",
-                        "nodePoolKind"
+                        "infrastructureCluster"
                     ],
                     "properties": {
-                        "bastion": {
-                            "type": "object",
-                            "title": "Bastion",
-                            "description": "Configuration of bastion resources API and names.",
-                            "properties": {
-                                "infrastructureMachineTemplate": {
-                                    "$ref": "#/$defs/infrastructureMachineTemplate"
-                                },
-                                "infrastructureMachineTemplateSpecTemplateName": {
-                                    "type": "string",
-                                    "title": "Infrastructure Machine template spec template name",
-                                    "description": "The name of Helm template that renders Infrastructure Machine template spec."
-                                }
-                            }
-                        },
                         "bastionResourceEnabled": {
                             "type": "boolean",
                             "title": "Bastion resource enabled",
@@ -1548,36 +1532,89 @@
                             "title": "Machine pool resources enabled",
                             "description": "Flag that indicates if the machine pool resources are enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.",
                             "default": true
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "if": {
+                                "type": "object",
+                                "properties": {
+                                    "machinePoolResourcesEnabled": {
+                                        "const": true
+                                    }
+                                }
+                            },
+                            "then": {
+                                "required": [
+                                    "nodePoolKind"
+                                ],
+                                "properties": {
+                                    "nodePoolKind": {
+                                        "type": "string",
+                                        "title": "Node pool kind",
+                                        "description": "Specifies which resource kind is used for node pools.",
+                                        "enum": [
+                                            "MachineDeployment",
+                                            "MachinePool"
+                                        ]
+                                    }
+                                }
+                            }
                         },
-                        "nodePoolKind": {
-                            "type": "string",
-                            "title": "Node pool kind",
-                            "description": "Specifies which resource kind is used for node pools.",
-                            "enum": [
-                                "MachineDeployment",
-                                "MachinePool"
-                            ]
-                        }
-                    },
-                    "unevaluatedProperties": false,
-                    "if": {
-                        "type": "object",
-                        "properties": {
-                            "nodePoolKind": {
-                                "const": "MachinePool"
+                        {
+                            "if": {
+                                "type": "object",
+                                "properties": {
+                                    "nodePoolKind": {
+                                        "const": "MachinePool"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "required": [
+                                    "infrastructureMachinePool"
+                                ],
+                                "properties": {
+                                    "infrastructureMachinePool": {
+                                        "$ref": "#/$defs/infrastructureMachinePool"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "if": {
+                                "type": "object",
+                                "properties": {
+                                    "bastionResourceEnabled": {
+                                        "const": true
+                                    }
+                                }
+                            },
+                            "then": {
+                                "required": [
+                                    "bastion"
+                                ],
+                                "properties": {
+                                    "bastion": {
+                                        "type": "object",
+                                        "title": "Bastion",
+                                        "description": "Configuration of bastion resources API and names.",
+                                        "properties": {
+                                            "infrastructureMachineTemplate": {
+                                                "$ref": "#/$defs/infrastructureMachineTemplate"
+                                            },
+                                            "infrastructureMachineTemplateSpecTemplateName": {
+                                                "type": "string",
+                                                "title": "Infrastructure Machine template spec template name",
+                                                "description": "The name of Helm template that renders Infrastructure Machine template spec."
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
-                    },
-                    "then": {
-                        "required": [
-                            "infrastructureMachinePool"
-                        ],
-                        "properties": {
-                            "infrastructureMachinePool": {
-                                "$ref": "#/$defs/infrastructureMachinePool"
-                            }
-                        }
-                    }
+                    ],
+                    "unevaluatedProperties": false
                 },
                 "teleport": {
                     "type": "object",

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -997,9 +997,10 @@
                 }
             }
         },
-        "internal": {
+        "providerIntegration": {
             "type": "object",
-            "title": "Internal",
+            "title": "Provider integration",
+            "description": "Provider-specific properties that can be set by cluster-$provider chart in order to render correct templates for the provider.",
             "required": [
                 "connectivity",
                 "components",
@@ -1481,10 +1482,12 @@
                     "required": [
                         "clusterResourceEnabled",
                         "controlPlaneResourceEnabled",
+                        "infrastructureCluster",
                         "machinePoolResourcesEnabled",
                         "machineHealthCheckResourceEnabled",
                         "bastionResourceEnabled"
                     ],
+                    "additionalProperties": false,
                     "properties": {
                         "bastion": {
                             "type": "object",
@@ -1518,6 +1521,9 @@
                             "title": "Control plane resource enabled",
                             "description": "Flag that indicates if the control plane resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.",
                             "default": true
+                        },
+                        "infrastructureCluster": {
+                            "$ref": "#/$defs/infrastructureCluster"
                         },
                         "machineHealthCheckResourceEnabled": {
                             "type": "boolean",
@@ -1617,28 +1623,6 @@
                                     "$ref": "#/$defs/preKubeadmCommands"
                                 }
                             }
-                        }
-                    }
-                }
-            }
-        },
-        "providerChartIntegration": {
-            "type": "object",
-            "title": "Provider chart integration",
-            "description": "Provider-specific properties that must be set by cluster-$provider chart in order to render correct templates for the provider.",
-            "additionalProperties": false,
-            "properties": {
-                "resourcesApi": {
-                    "type": "object",
-                    "title": "Resources API",
-                    "description": "Group, version and kind configuration that is required and used by a specific Cluster API provider.",
-                    "required": [
-                        "infrastructureCluster"
-                    ],
-                    "additionalProperties": false,
-                    "properties": {
-                        "infrastructureCluster": {
-                            "$ref": "#/$defs/infrastructureCluster"
                         }
                     }
                 }

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1520,9 +1520,6 @@
                             "description": "Flag that indicates if the control plane resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.",
                             "default": true
                         },
-                        "infrastructureCluster": {
-                            "$ref": "#/$defs/infrastructureCluster"
-                        },
                         "machineHealthCheckResourceEnabled": {
                             "type": "boolean",
                             "title": "MachineHealthCheck resource enabled",
@@ -1621,6 +1618,28 @@
                                     "$ref": "#/$defs/preKubeadmCommands"
                                 }
                             }
+                        }
+                    }
+                }
+            }
+        },
+        "providerChartIntegration": {
+            "type": "object",
+            "title": "Provider chart integration",
+            "description": "Provider-specific properties that must be set by cluster-$provider chart in order to render correct templates for the provider.",
+            "additionalProperties": false,
+            "properties": {
+                "resourcesApi": {
+                    "type": "object",
+                    "title": "Resources API",
+                    "description": "Group, version and kind configuration that is required and used by a specific Cluster API provider.",
+                    "required": [
+                        "infrastructureCluster"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                        "infrastructureCluster": {
+                            "$ref": "#/$defs/infrastructureCluster"
                         }
                     }
                 }

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -894,6 +894,12 @@
                             "description": "The name of organization that owns the cluster.",
                             "readOnly": true
                         },
+                        "preventDeletion": {
+                            "type": "boolean",
+                            "title": "Prevent cluster deletion",
+                            "description": "Setting this to true will set giantswarm.io/prevent-deletion label to true, which will block cluster deletion.",
+                            "default": false
+                        },
                         "servicePriority": {
                             "type": "string",
                             "title": "Service priority",

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -844,12 +844,10 @@
                     "type": "object",
                     "title": "Metadata",
                     "required": [
-                        "description",
                         "name",
                         "organization",
                         "servicePriority"
                     ],
-                    "additionalProperties": false,
                     "properties": {
                         "description": {
                             "type": "string",

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -30,6 +30,7 @@ global:
     oidc: {}
     replicas: 3
   metadata:
+    preventDeletion: false
     servicePriority: highest
 providerIntegration:
   bastion:

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -81,7 +81,6 @@ internal:
     bastionResourceEnabled: true
     clusterResourceEnabled: true
     controlPlaneResourceEnabled: true
-    infrastructureCluster: {}
     machineHealthCheckResourceEnabled: true
     machinePoolResourcesEnabled: true
   teleport:
@@ -95,3 +94,6 @@ internal:
           additionalConfig:
             storage: {}
             systemd: {}
+providerChartIntegration:
+  resourcesApi:
+    infrastructureCluster: {}

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -31,7 +31,7 @@ global:
     replicas: 3
   metadata:
     servicePriority: highest
-internal:
+providerIntegration:
   bastion:
     kubeadmConfig:
       ignition:
@@ -81,6 +81,7 @@ internal:
     bastionResourceEnabled: true
     clusterResourceEnabled: true
     controlPlaneResourceEnabled: true
+    infrastructureCluster: {}
     machineHealthCheckResourceEnabled: true
     machinePoolResourcesEnabled: true
   teleport:
@@ -94,6 +95,3 @@ internal:
           additionalConfig:
             storage: {}
             systemd: {}
-providerChartIntegration:
-  resourcesApi:
-    infrastructureCluster: {}

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -75,8 +75,6 @@ providerIntegration:
           systemd: {}
   kubernetesVersion: 1.24.10
   resourcesApi:
-    bastion:
-      infrastructureMachineTemplate: {}
     bastionResourceEnabled: true
     clusterResourceEnabled: true
     controlPlaneResourceEnabled: true

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -74,7 +74,6 @@ providerIntegration:
           storage: {}
           systemd: {}
   kubernetesVersion: 1.24.10
-  paused: false
   resourcesApi:
     bastion:
       infrastructureMachineTemplate: {}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3047

### What does this PR do?

This PR fixes schema and adds missing properties that are needed in order to start using the `cluster` chart in `cluster-aws` and render Cluster resource from it (only Cluster resource for now).

Changes:
- Renamed `Values.internal` to `Values.providerIntegeration`.
- Added `Values.clusterAnnotationsTemplateName` property that is used to set the name of the template that is rendering provider-specific annotations on the Cluster resource.
- Added `Values.pauseProperties` property where you can specify a list of properties and their corresponding values that will trigger setting `spec.paused` to `true` in the Cluster resource. 

### What is the effect of this change to users?

`cluster` chart can be used in `cluster-aws` for rendering `Cluster` resource.

### Any background context you can provide?

- https://github.com/giantswarm/roadmap/issues/2739
- https://github.com/giantswarm/roadmap/issues/3047

