### PR TITLE
Manage machinepools by cluster-autoscaler

### DIFF
--- a/helm/cluster/templates/clusterapi/workers/machinepool.yaml
+++ b/helm/cluster/templates/clusterapi/workers/machinepool.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
     machine-pool.giantswarm.io/name: {{ include "cluster.resource.name" $ }}-{{ $nodePoolName }}
+    cluster.x-k8s.io/replicas-managed-by: "external-autoscaler"
     {{- include "cluster.annotations.custom" $ | indent 4 }}
     {{- if $nodePoolConfig.annotations }}
     {{- range $key, $val := $nodePoolConfig.annotations }}


### PR DESCRIPTION
Setting the same annotation as we have in `cluster-aws`