### PR TITLE
Fixed containerd configuration for newer flatcar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Helm value for specifying the provider name.
 - Render `app: cluster-<provider>` label instead of `app: cluster` label.
 
+### Fixed
+
+- Fixed containerd configuration for newer flatcar versions. 
+
 ## [0.1.0] - 2023-12-19
 
 ### Added

--- a/helm/cluster/files/etc/containerd/config.toml
+++ b/helm/cluster/files/etc/containerd/config.toml
@@ -6,7 +6,7 @@ subreaper = true
 # set containerd's OOM score
 oom_score = -999
 disabled_plugins = []
-[plugins."containerd.runtime.v1.linux"]
+[plugins."io.containerd.runtime.v1.linux"]
 # shim binary name/path
 shim = "containerd-shim"
 # runtime binary name/path


### PR DESCRIPTION
### What does this PR do?

Fixed a small typo in containerd config that would cause it to break in newer flatcar versions (see https://github.com/giantswarm/cluster-aws/pull/421).

- [x] CHANGELOG.md has been updated (if it exists)
