### PR TITLE
Fix typo in app label deprecation notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix a typo in app label deprecation notice.
+
 ## [0.1.1] - 2023-12-21
 
 ### Added

--- a/helm/cluster/templates/_helpers.tpl
+++ b/helm/cluster/templates/_helpers.tpl
@@ -29,8 +29,8 @@ Common labels
 */}}
 {{- define "cluster.labels.common" -}}
 # deprecated: "app: cluster-{{ .Values.providerIntegration.provider }}" label is deprecated and it will be removed after upgrading
-# to Kubernetes 1.25. We still need it here because existing ClusterResourceSet selectors.
-# need this label on the Cluster resource
+# to Kubernetes 1.25. We still need it here because existing ClusterResourceSet selectors
+# need this label on the Cluster resource.
 app: "cluster-{{ .Values.providerIntegration.provider }}"
 app.kubernetes.io/name: {{ include "cluster.chart.name" $ | quote }}
 app.kubernetes.io/version: {{ .Chart.Version | quote }}


### PR DESCRIPTION
### What does this PR do?

Fixes a typo in app label deprecation notice.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
