### PR TITLE
Allow configuring cluster api server port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `global.controlPlane.apiServerPort` value, configuring the Load Balancer port for the API
+
 ## [0.2.0] - 2024-01-17
 
 ### Added

--- a/Makefile.development.mk
+++ b/Makefile.development.mk
@@ -3,7 +3,7 @@
 ##@ Generate
 
 ensure-schema-gen:
-	@helm schema-gen --help &>/dev/null || helm plugin install https://github.com/mihaisee/helm-schema-gen.git
+	@helm schema-gen --help >/dev/null || helm plugin install https://github.com/mihaisee/helm-schema-gen.git
 
 ##@ Build
 

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -66,7 +66,7 @@ Configuration of the control plane.
 
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
-| `global.controlPlane.apiServerPort` | **The public facing API server Load Balancer port.**|**Type:** `integer`<br/>**Default:** `6443`|
+| `global.controlPlane.apiServerPort` | **API server port** - The public facing API server Load Balancer port.|**Type:** `integer`<br/>**Default:** `6443`|
 | `global.controlPlane.customNodeTaints` | **Custom node taints**|**Type:** `array`<br/>|
 | `global.controlPlane.customNodeTaints[*]` |**None**|**Type:** `object`<br/>|
 | `global.controlPlane.customNodeTaints[*].effect` | **Effect**|**Type:** `string`<br/>|

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -66,7 +66,7 @@ Configuration of the control plane.
 
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
-| `global.controlPlane.apiServerPort` | **The public facing API server Load Balancer port.**|**Type:** `integer`<br/>|
+| `global.controlPlane.apiServerPort` | **The public facing API server Load Balancer port.**|**Type:** `integer`<br/>**Default:** `6443`|
 | `global.controlPlane.customNodeTaints` | **Custom node taints**|**Type:** `array`<br/>|
 | `global.controlPlane.customNodeTaints[*]` |**None**|**Type:** `object`<br/>|
 | `global.controlPlane.customNodeTaints[*].effect` | **Effect**|**Type:** `string`<br/>|

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -66,6 +66,7 @@ Configuration of the control plane.
 
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
+| `global.controlPlane.apiServerPort` | **The public facing API server Load Balancer port.**|**Type:** `integer`<br/>|
 | `global.controlPlane.customNodeTaints` | **Custom node taints**|**Type:** `array`<br/>|
 | `global.controlPlane.customNodeTaints[*]` |**None**|**Type:** `object`<br/>|
 | `global.controlPlane.customNodeTaints[*].effect` | **Effect**|**Type:** `string`<br/>|

--- a/helm/cluster/templates/clusterapi/cluster.yaml
+++ b/helm/cluster/templates/clusterapi/cluster.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   clusterNetwork:
-    apiServerPort: {{ .Values.providerIntegration.controlPlane.apiServerPort }}
+    apiServerPort: {{ .Values.global.controlPlane.apiServerPort }}
     services:
       cidrBlocks:
       {{- toYaml $.Values.global.connectivity.network.services.cidrBlocks | nindent 8 }}

--- a/helm/cluster/templates/clusterapi/cluster.yaml
+++ b/helm/cluster/templates/clusterapi/cluster.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   clusterNetwork:
+    apiServerPort: {{ .Values.providerIntegration.controlPlane.apiServerPort }}
     services:
       cidrBlocks:
       {{- toYaml $.Values.global.connectivity.network.services.cidrBlocks | nindent 8 }}

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1291,7 +1291,8 @@
                             "type": "integer"
 =======
                             "type": "integer",
-                            "title": "The public facing API server Load Balancer port.",
+                            "title": "API server port",
+                            "description": "The public facing API server Load Balancer port.",
                             "default": 6443
                         },
                         "customNodeTaints": {

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -139,8 +139,14 @@
                             "properties": {
                                 "storage": {
                                     "type": "object",
+<<<<<<< HEAD
                                     "title": "Storage",
                                     "description": "It describes the desired state of the system\u2019s storage devices.",
+||||||| parent of bbfacaf (Revert "run make generate-schema")
+=======
+                                    "title": "Storage",
+                                    "description": "It describes the desired state of the system’s storage devices.",
+>>>>>>> bbfacaf (Revert "run make generate-schema")
                                     "properties": {
                                         "directories": {
                                             "type": "array",
@@ -154,6 +160,7 @@
                                                     "path"
                                                 ],
                                                 "properties": {
+<<<<<<< HEAD
                                                     "filesystem": {
                                                         "type": "string",
                                                         "title": "Filesystem",
@@ -280,11 +287,143 @@
                                                         "type": "string",
                                                         "title": "Path",
                                                         "description": "The mount-point of the filesystem. A non-null entry indicates that the filesystem has already been mounted by the system at the specified path. This is really only useful for \u201c/sysroot\u201d."
+||||||| parent of bbfacaf (Revert "run make generate-schema")
+                                                    "endpoint": {
+                                                        "type": "string"
+=======
+                                                    "filesystem": {
+                                                        "type": "string",
+                                                        "title": "Filesystem",
+                                                        "description": "The internal identifier of the filesystem in which to create the directory. This matches the last filesystem with the given identifier."
+                                                    },
+                                                    "group": {
+                                                        "type": "object",
+                                                        "title": "Group",
+                                                        "description": "It specifies the group of the owner.",
+                                                        "properties": {
+                                                            "id": {
+                                                                "type": "integer",
+                                                                "title": "ID",
+                                                                "description": "The group ID of the owner."
+                                                            },
+                                                            "name": {
+                                                                "type": "string",
+                                                                "title": "Name",
+                                                                "description": "The group name of the owner."
+                                                            }
+                                                        }
+                                                    },
+                                                    "mode": {
+                                                        "type": "integer",
+                                                        "title": "Mode",
+                                                        "description": "The directory’s permission mode."
+                                                    },
+                                                    "overwrite": {
+                                                        "type": "boolean",
+                                                        "title": "Overwrite",
+                                                        "description": "Whether to delete preexisting nodes at the path."
+                                                    },
+                                                    "path": {
+                                                        "type": "string",
+                                                        "title": "Path",
+                                                        "description": "The absolute path to the directory."
+                                                    },
+                                                    "user": {
+                                                        "type": "object",
+                                                        "title": "User",
+                                                        "description": "It specifies the directory’s owner.",
+                                                        "properties": {
+                                                            "id": {
+                                                                "type": "integer",
+                                                                "title": "ID",
+                                                                "description": "The user ID of the owner."
+                                                            },
+                                                            "name": {
+                                                                "type": "string",
+                                                                "title": "Name",
+                                                                "description": "The user name of the owner."
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "filesystems": {
+                                            "type": "array",
+                                            "title": "File systems",
+                                            "description": "The list of filesystems to be configured and/or used in the “files” section. Either “mount” or “path” needs to be specified.",
+                                            "items": {
+                                                "type": "object",
+                                                "title": "File system",
+                                                "description": "The filesystem to be configured and/or used in the “files” section. Either “mount” or “path” needs to be specified.",
+                                                "properties": {
+                                                    "mount": {
+                                                        "type": "object",
+                                                        "title": "Mount",
+                                                        "description": "It contains the set of mount and formatting options for the filesystem. A non-null entry indicates that the filesystem should be mounted before it is used by Ignition.",
+                                                        "required": [
+                                                            "device",
+                                                            "format"
+                                                        ],
+                                                        "properties": {
+                                                            "device": {
+                                                                "type": "string",
+                                                                "title": "Device",
+                                                                "description": "The absolute path to the device. Devices are typically referenced by the /dev/disk/by-* symlinks."
+                                                            },
+                                                            "format": {
+                                                                "type": "string",
+                                                                "title": "Format",
+                                                                "description": "The filesystem format (ext4, btrfs, or xfs).",
+                                                                "enum": [
+                                                                    "ext4",
+                                                                    "btrfs",
+                                                                    "xfs"
+                                                                ]
+                                                            },
+                                                            "label": {
+                                                                "type": "string",
+                                                                "title": "Label",
+                                                                "description": "The label of the filesystem."
+                                                            },
+                                                            "options": {
+                                                                "type": "array",
+                                                                "title": "Options",
+                                                                "description": "Any additional options to be passed to the format-specific mkfs utility.",
+                                                                "items": {
+                                                                    "type": "string",
+                                                                    "description": "An additional option to be passed to the format-specific mkfs utility.",
+                                                                    "name": "Option"
+                                                                }
+                                                            },
+                                                            "uuid": {
+                                                                "type": "string",
+                                                                "title": "UUID",
+                                                                "description": "The uuid of the filesystem."
+                                                            },
+                                                            "wipeFilesystem": {
+                                                                "type": "boolean",
+                                                                "title": "Wipe filesystem",
+                                                                "description": "Whether or not to wipe the device before filesystem creation, see Ignition’s documentation on filesystems for more information https://github.com/coreos/ignition/blob/main/docs/operator-notes.md#filesystem-reuse-semantics."
+                                                            }
+                                                        }
+                                                    },
+                                                    "name": {
+                                                        "type": "string",
+                                                        "title": "Name",
+                                                        "description": "The identifier for the filesystem, internal to Ignition. This is only required if the filesystem needs to be referenced in the “files” section."
+                                                    },
+                                                    "path": {
+                                                        "type": "string",
+                                                        "title": "Path",
+                                                        "description": "The mount-point of the filesystem. A non-null entry indicates that the filesystem has already been mounted by the system at the specified path. This is really only useful for “/sysroot”."
+>>>>>>> bbfacaf (Revert "run make generate-schema")
                                                     }
                                                 }
                                             }
                                         }
                                     }
+<<<<<<< HEAD
                                 },
                                 "systemd": {
                                     "type": "object",
@@ -653,6 +792,315 @@
                                             }
                                         ]
                                     }
+||||||| parent of bbfacaf (Revert "run make generate-schema")
+=======
+                                },
+                                "systemd": {
+                                    "type": "object",
+                                    "title": "systemd",
+                                    "description": "It describes the desired state of the systemd units.",
+                                    "properties": {
+                                        "units": {
+                                            "type": "array",
+                                            "title": "Units",
+                                            "items": {
+                                                "$ref": "#/$defs/systemdUnit"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "strict": {
+                            "type": "boolean",
+                            "title": "Strict",
+                            "description": "It controls if AdditionalConfig should be strictly parsed. If so, warnings are treated as errors."
+                        }
+                    }
+                }
+            }
+        },
+        "infrastructureCluster": {
+            "type": "object",
+            "title": "Infrastructure cluster",
+            "description": "Group, version and kind of provider-specific infrastructure cluster resource.",
+            "required": [
+                "group",
+                "version",
+                "kind"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "group": {
+                    "type": "string",
+                    "title": "API group",
+                    "examples": [
+                        "infrastructure.cluster.x-k8s.io"
+                    ]
+                },
+                "kind": {
+                    "type": "string",
+                    "title": "API kind",
+                    "examples": [
+                        "AWSCluster",
+                        "AzureCluster",
+                        "VCDCluster",
+                        "VSphereCluster"
+                    ]
+                },
+                "version": {
+                    "type": "string",
+                    "title": "API version",
+                    "examples": [
+                        "v1alpha1",
+                        "v1beta1",
+                        "v1beta2",
+                        "v1",
+                        "v2"
+                    ]
+                }
+            }
+        },
+        "infrastructureMachinePool": {
+            "type": "object",
+            "title": "Infrastructure MachinePool",
+            "description": "Group, version and kind of provider-specific infrastructure MachinePool resource.",
+            "required": [
+                "group",
+                "version",
+                "kind"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "group": {
+                    "type": "string",
+                    "title": "API group",
+                    "examples": [
+                        "infrastructure.cluster.x-k8s.io"
+                    ]
+                },
+                "kind": {
+                    "type": "string",
+                    "title": "API kind",
+                    "examples": [
+                        "AWSMachinePool",
+                        "AzureMachinePool"
+                    ]
+                },
+                "version": {
+                    "type": "string",
+                    "title": "API version",
+                    "examples": [
+                        "v1alpha1",
+                        "v1beta1",
+                        "v1beta2",
+                        "v1",
+                        "v2"
+                    ]
+                }
+            }
+        },
+        "infrastructureMachineTemplate": {
+            "type": "object",
+            "title": "Infrastructure Machine template",
+            "description": "Group, version and kind of provider-specific infrastructure Machine template resource.",
+            "required": [
+                "group",
+                "version",
+                "kind"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "group": {
+                    "type": "string",
+                    "title": "API group",
+                    "examples": [
+                        "infrastructure.cluster.x-k8s.io"
+                    ]
+                },
+                "kind": {
+                    "type": "string",
+                    "title": "API kind",
+                    "examples": [
+                        "AWSMachineTemplate",
+                        "AzureMachineTemplate"
+                    ]
+                },
+                "version": {
+                    "type": "string",
+                    "title": "API version",
+                    "examples": [
+                        "v1alpha1",
+                        "v1beta1",
+                        "v1beta2",
+                        "v1",
+                        "v2"
+                    ]
+                }
+            }
+        },
+        "postKubeadmCommands": {
+            "type": "array",
+            "title": "Post-kubeadm commands",
+            "description": "Extra commands to run after kubeadm runs.",
+            "items": {
+                "type": "string"
+            }
+        },
+        "preKubeadmCommands": {
+            "type": "array",
+            "title": "Pre-kubeadm commands",
+            "description": "Extra commands to run before kubeadm runs.",
+            "items": {
+                "type": "string"
+            }
+        },
+        "systemdUnit": {
+            "type": "object",
+            "title": "systemd unit",
+            "required": [
+                "name"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "contents": {
+                    "type": "string",
+                    "title": "Contents",
+                    "description": "The contents of the unit."
+                },
+                "dropins": {
+                    "type": "array",
+                    "title": "Unit drop-ins",
+                    "description": "The list of drop-ins for the unit",
+                    "items": {
+                        "type": "object",
+                        "title": "Unit drop-in",
+                        "required": [
+                            "name"
+                        ],
+                        "properties": {
+                            "contents": {
+                                "type": "string",
+                                "title": "Contents",
+                                "description": "The contents of the drop-in."
+                            },
+                            "name": {
+                                "type": "string",
+                                "title": "Name",
+                                "description": "The name of the drop-in. This must be suffixed with “.conf”",
+                                "pattern": "^.+\\.conf$"
+                            }
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean",
+                    "title": "Enabled?",
+                    "description": "Whether or not the service shall be enabled. When true, the service is enabled. When false, the service is disabled. When omitted, the service is unmodified. In order for this to have any effect, the unit must have an install section."
+                },
+                "mask": {
+                    "type": "boolean",
+                    "title": "Masked?",
+                    "description": "Whether or not the service shall be masked. When true, the service is masked by symlinking it to /dev/null."
+                },
+                "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The name of the unit. This must be suffixed with a valid unit type (e.g. “thing.service”)."
+                }
+            }
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "global": {
+            "type": "object",
+            "title": "Global properties",
+            "description": "Properties that are available to all charts and subcharts.",
+            "required": [
+                "components",
+                "connectivity",
+                "controlPlane",
+                "metadata"
+            ],
+            "additionalProperties": true,
+            "properties": {
+                "components": {
+                    "type": "object",
+                    "title": "Components",
+                    "description": "Advanced configuration of components that are running on all nodes.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "containerd": {
+                            "type": "object",
+                            "title": "Containerd",
+                            "description": "Configuration of containerd.",
+                            "required": [
+                                "containerRegistries"
+                            ],
+                            "additionalProperties": false,
+                            "properties": {
+                                "containerRegistries": {
+                                    "type": "object",
+                                    "title": "Container registries",
+                                    "description": "Endpoints and credentials configuration for container registries.",
+                                    "additionalProperties": {
+                                        "type": "array",
+                                        "title": "Registries",
+                                        "description": "Container registries and mirrors",
+                                        "items": {
+                                            "type": "object",
+                                            "title": "Registry",
+                                            "required": [
+                                                "endpoint"
+                                            ],
+                                            "properties": {
+                                                "credentials": {
+                                                    "type": "object",
+                                                    "title": "Credentials",
+                                                    "properties": {
+                                                        "auth": {
+                                                            "type": "string",
+                                                            "title": "Auth",
+                                                            "description": "Base64-encoded string from the concatenation of the username, a colon, and the password."
+                                                        },
+                                                        "identitytoken": {
+                                                            "type": "string",
+                                                            "title": "Identity token",
+                                                            "description": "Used to authenticate the user and obtain an access token for the registry."
+                                                        },
+                                                        "password": {
+                                                            "type": "string",
+                                                            "title": "Password",
+                                                            "description": "Used to authenticate for the registry with username/password."
+                                                        },
+                                                        "username": {
+                                                            "type": "string",
+                                                            "title": "Username",
+                                                            "description": "Used to authenticate for the registry with username/password."
+                                                        }
+                                                    }
+                                                },
+                                                "endpoint": {
+                                                    "type": "string",
+                                                    "title": "Endpoint",
+                                                    "description": "Endpoint for the container registry."
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "default": {
+                                        "docker.io": [
+                                            {
+                                                "endpoint": "registry-1.docker.io"
+                                            },
+                                            {
+                                                "endpoint": "giantswarm.azurecr.io"
+                                            }
+                                        ]
+                                    }
+>>>>>>> bbfacaf (Revert "run make generate-schema")
                                 }
                             }
                         }
@@ -758,6 +1206,7 @@
                             ],
                             "properties": {
                                 "enabled": {
+<<<<<<< HEAD
                                     "type": "boolean",
                                     "title": "Enable"
                                 },
@@ -775,6 +1224,41 @@
                                     "type": "string",
                                     "title": "No proxy",
                                     "description": "Comma-separated addresses to be passed to the NO_PROXY environment variable in all hosts."
+||||||| parent of bbfacaf (Revert "run make generate-schema")
+                                    "type": "boolean"
+=======
+                                    "type": "boolean",
+                                    "title": "Enable"
+                                },
+                                "httpProxy": {
+                                    "type": "string",
+                                    "title": "HTTP proxy",
+                                    "description": "To be passed to the HTTP_PROXY environment variable in all hosts."
+                                },
+                                "httpsProxy": {
+                                    "type": "string",
+                                    "title": "HTTPS proxy",
+                                    "description": "To be passed to the HTTPS_PROXY environment variable in all hosts."
+                                },
+                                "noProxy": {
+                                    "type": "object",
+                                    "title": "No proxy",
+                                    "properties": {
+                                        "addresses": {
+                                            "type": "array",
+                                            "title": "Addresses",
+                                            "description": "To be passed to the NO_PROXY environment variable in all hosts.",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "addressesTemplate": {
+                                            "type": "string",
+                                            "title": "Addresses template",
+                                            "description": "Name of Helm template that renders a YAML array with NO_PROXY addresses."
+                                        }
+                                    }
+>>>>>>> bbfacaf (Revert "run make generate-schema")
                                 }
                             },
                             "default": {
@@ -793,6 +1277,7 @@
                     ],
                     "properties": {
                         "apiServerPort": {
+<<<<<<< HEAD
                             "type": "integer",
                             "title": "API server port",
                             "description": "The public facing API server Load Balancer port.",
@@ -802,6 +1287,16 @@
                         },
                         "customNodeTaints": {
                             "$ref": "#/$defs/customNodeTaints"
+||||||| parent of bbfacaf (Revert "run make generate-schema")
+                            "type": "integer"
+=======
+                            "type": "integer",
+                            "title": "The public facing API server Load Balancer port.",
+                            "default": 6443
+                        },
+                        "customNodeTaints": {
+                            "$ref": "#/$defs/customNodeTaints"
+>>>>>>> bbfacaf (Revert "run make generate-schema")
                         },
                         "machineHealthCheck": {
                             "type": "object",
@@ -905,6 +1400,7 @@
                         "servicePriority"
                     ],
                     "properties": {
+<<<<<<< HEAD
                         "description": {
                             "type": "string",
                             "title": "Cluster description",
@@ -951,6 +1447,54 @@
                             "description": "The name of organization that owns the cluster.",
                             "readOnly": true
                         },
+||||||| parent of bbfacaf (Revert "run make generate-schema")
+=======
+                        "description": {
+                            "type": "string",
+                            "title": "Cluster description",
+                            "description": "User-friendly description of the cluster's purpose."
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "title": "Annotations",
+                            "description": "These annotations are added to all Kubernetes resources defining this cluster.",
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^([a-zA-Z0-9\\.-]{1,253}/)?[a-zA-Z0-9\\._-]{1,63}$": {
+                                    "type": "string",
+                                    "title": "Annotation",
+                                    "minLength": 1
+                                }
+                            }
+                        },
+                        "labels": {
+                            "type": "object",
+                            "title": "Labels",
+                            "description": "These labels are added to all Kubernetes resources defining this cluster.",
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9/\\._-]+$": {
+                                    "type": "string",
+                                    "title": "Label",
+                                    "maxLength": 63,
+                                    "minLength": 0,
+                                    "pattern": "^[a-zA-Z0-9\\._-]+$"
+                                }
+                            }
+                        },
+                        "name": {
+                            "type": "string",
+                            "title": "Cluster name",
+                            "description": "Unique identifier, cannot be changed after creation.",
+                            "readOnly": true
+                        },
+                        "organization": {
+                            "type": "string",
+                            "title": "Organization",
+                            "description": "The name of organization that owns the cluster.",
+                            "readOnly": true
+                        },
+>>>>>>> bbfacaf (Revert "run make generate-schema")
                         "preventDeletion": {
                             "type": "boolean",
                             "title": "Prevent cluster deletion",
@@ -958,6 +1502,7 @@
                             "default": false
                         },
                         "servicePriority": {
+<<<<<<< HEAD
                             "type": "string",
                             "title": "Service priority",
                             "description": "The relative importance of this cluster.",
@@ -1080,6 +1625,107 @@
                             "title": "CGroups v1",
                             "description": "Force use of CGroups v1 for whole cluster.",
                             "default": false
+||||||| parent of bbfacaf (Revert "run make generate-schema")
+                            "type": "string"
+=======
+                            "type": "string",
+                            "title": "Service priority",
+                            "description": "The relative importance of this cluster.",
+                            "$comment": "Defined in https://github.com/giantswarm/rfc/tree/main/classify-cluster-priority",
+                            "enum": [
+                                "highest",
+                                "medium",
+                                "lowest"
+                            ],
+                            "default": "highest"
+                        }
+                    }
+                },
+                "nodePools": {
+                    "type": "object",
+                    "title": "Node pools",
+                    "patternProperties": {
+                        "^[a-z0-9]{5,10}$": {
+                            "type": "object",
+                            "title": "Node pool",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "title": "Annotations",
+                                    "description": "These annotations are added to all Kubernetes resources defining this node pool.",
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                        "^([a-zA-Z0-9\\.-]{1,253}/)?[a-zA-Z0-9\\._-]{1,63}$": {
+                                            "type": "string",
+                                            "title": "Annotation",
+                                            "minLength": 1
+                                        }
+                                    }
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "title": "Labels",
+                                    "description": "These labels are added to all Kubernetes resources defining this node pool.",
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                        "^[a-zA-Z0-9/\\._-]+$": {
+                                            "type": "string",
+                                            "title": "Label",
+                                            "maxLength": 63,
+                                            "minLength": 0,
+                                            "pattern": "^[a-zA-Z0-9\\._-]+$"
+                                        }
+                                    }
+                                },
+                                "nodeLabels": {
+                                    "type": "object",
+                                    "title": "Node labels",
+                                    "description": "Labels that are passed to kubelet argument 'node-labels'.",
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    }
+                                },
+                                "nodeTaints": {
+                                    "type": "array",
+                                    "title": "Custom node taints",
+                                    "items": {
+                                        "type": "object",
+                                        "required": [
+                                            "effect",
+                                            "key",
+                                            "value"
+                                        ],
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "effect": {
+                                                "type": "string",
+                                                "title": "Effect",
+                                                "enum": [
+                                                    "NoSchedule",
+                                                    "PreferNoSchedule",
+                                                    "NoExecute"
+                                                ]
+                                            },
+                                            "key": {
+                                                "type": "string",
+                                                "title": "Key"
+                                            },
+                                            "value": {
+                                                "type": "string",
+                                                "title": "Value"
+                                            }
+                                        }
+                                    }
+                                },
+                                "replicas": {
+                                    "type": "integer",
+                                    "title": "Replicas",
+                                    "description": "The number of node pool nodes.",
+                                    "maximum": 1000,
+                                    "minimum": 0
+                                }
+                            }
+>>>>>>> bbfacaf (Revert "run make generate-schema")
                         }
                     }
                 }
@@ -1152,6 +1798,7 @@
                                         "tag"
                                     ],
                                     "properties": {
+<<<<<<< HEAD
                                         "name": {
                                             "type": "string",
                                             "title": "Repository",
@@ -1183,17 +1830,112 @@
                                     "additionalProperties": false,
                                     "properties": {
                                         "timesyncd": {
+||||||| parent of bbfacaf (Revert "run make generate-schema")
+                                        "containerLinuxConfig": {
+=======
+                                        "name": {
+                                            "type": "string",
+                                            "title": "Repository",
+                                            "default": "giantswarm/pause"
+                                        },
+                                        "registry": {
+                                            "type": "string",
+                                            "title": "Registry",
+                                            "default": "quay.io"
+                                        },
+                                        "tag": {
+                                            "type": "string",
+                                            "title": "Tag",
+                                            "default": "3.9"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "kubelet": {
+                            "title": "Kubelet",
+                            "description": "Kubelet configuration that is used on all nodes.",
+                            "default": null,
+                            "oneOf": [
+                                {
+                                    "type": "null"
+                                },
+                                {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "gracefulNodeShutdown": {
+>>>>>>> bbfacaf (Revert "run make generate-schema")
                                             "type": "object",
+<<<<<<< HEAD
                                             "title": "timesyncd",
                                             "description": "systemd-timesyncd is a system service that may be used to synchronize the local system clock with a remote Network Time Protocol (NTP) server.",
                                             "additionalProperties": false,
+||||||| parent of bbfacaf (Revert "run make generate-schema")
+=======
+                                            "title": "Graceful node shut down",
+                                            "description": "It enables kubelet to gracefully evict pods during a node shutdown. It is enabled by default in Kubernetes 1.21.",
+                                            "additionalProperties": false,
+>>>>>>> bbfacaf (Revert "run make generate-schema")
                                             "properties": {
+<<<<<<< HEAD
                                                 "ntp": {
                                                     "type": "array",
                                                     "title": "NTP",
                                                     "description": "A list of NTP server host names or IP addresses.",
                                                     "items": {
                                                         "type": "string"
+||||||| parent of bbfacaf (Revert "run make generate-schema")
+                                                "additionalConfig": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "storage": {
+                                                            "type": "object"
+                                                        },
+                                                        "systemd": {
+                                                            "type": "object"
+                                                        }
+=======
+                                                "shutdownGracePeriod": {
+                                                    "type": "string",
+                                                    "title": "Shutdown grace period",
+                                                    "description": "Specifies the total duration that the node should delay the shutdown by. This is the total grace period for pod termination for both regular and critical pods."
+                                                },
+                                                "shutdownGracePeriodCriticalPods": {
+                                                    "type": "string",
+                                                    "title": "Shutdown grace period for critical pods",
+                                                    "description": "Specifies the duration used to terminate critical pods during a node shutdown. This should be less than shutdownGracePeriod."
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "systemd": {
+                            "title": "systemd",
+                            "default": null,
+                            "oneOf": [
+                                {
+                                    "type": "null"
+                                },
+                                {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "timesyncd": {
+                                            "type": "object",
+                                            "title": "timesyncd",
+                                            "description": "systemd-timesyncd is a system service that may be used to synchronize the local system clock with a remote Network Time Protocol (NTP) server.",
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "npt": {
+                                                    "type": "array",
+                                                    "title": "NTP",
+                                                    "description": "A list of NTP server host names or IP addresses.",
+                                                    "items": {
+                                                        "type": "string"
+>>>>>>> bbfacaf (Revert "run make generate-schema")
                                                     }
                                                 }
                                             }
@@ -1206,9 +1948,19 @@
                 },
                 "connectivity": {
                     "type": "object",
+<<<<<<< HEAD
                     "title": "Connectivity",
                     "description": "Internal connectivity configuration.",
                     "additionalProperties": false,
+||||||| parent of bbfacaf (Revert "run make generate-schema")
+=======
+                    "title": "Connectivity",
+                    "description": "Internal connectivity configuration.",
+                    "required": [
+                        "sshSsoPublicKey"
+                    ],
+                    "additionalProperties": false,
+>>>>>>> bbfacaf (Revert "run make generate-schema")
                     "properties": {
                         "proxy": {
                             "type": "object",
@@ -1269,6 +2021,7 @@
                                     "additionalProperties": false,
                                     "properties": {
                                         "apiServer": {
+<<<<<<< HEAD
                                             "type": "object",
                                             "title": "API server",
                                             "description": "Configuration of API server.",
@@ -1399,6 +2152,139 @@
                                                 }
                                             },
                                             "default": {}
+||||||| parent of bbfacaf (Revert "run make generate-schema")
+                                            "type": "object"
+=======
+                                            "type": "object",
+                                            "title": "API server",
+                                            "description": "Configuration of API server.",
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "additionalAdmissionPlugins": {
+                                                    "type": "array",
+                                                    "title": "Additional admission plugins",
+                                                    "description": "A list of plugins to enable, in addition to the default ones that include DefaultStorageClass, DefaultTolerationSeconds, LimitRanger, MutatingAdmissionWebhook, NamespaceLifecycle, PersistentVolumeClaimResize, Priority, ResourceQuota, ServiceAccount and ValidatingAdmissionWebhook.",
+                                                    "items": {
+                                                        "type": "string",
+                                                        "title": "Additional admission plugin"
+                                                    }
+                                                },
+                                                "apiAudiences": {
+                                                    "title": "API audiences",
+                                                    "description": "Identifiers of the API. The service account token authenticator will validate that tokens used against the API are bound to at least one of these audiences. If the --service-account-issuer flag is configured and this flag is not, 'api-audiences' field defaults to a single element list containing the issuer URL.",
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "null"
+                                                        },
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "required": [
+                                                                "templateName"
+                                                            ],
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "templateName": {
+                                                                    "type": "string",
+                                                                    "title": "Template name",
+                                                                    "description": "The name of the Helm template which renders the 'api-audiences' value"
+                                                                }
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                "etcdPrefix": {
+                                                    "type": "string",
+                                                    "title": "etcd prefix"
+                                                },
+                                                "extraArgs": {
+                                                    "type": "object",
+                                                    "title": "Extra args"
+                                                },
+                                                "extraCertificateSANs": {
+                                                    "type": "array",
+                                                    "title": "Extra certificate SANs",
+                                                    "description": "The additional certificate SANs that are appended to the default SANs.",
+                                                    "items": {
+                                                        "type": "string",
+                                                        "title": "Extra certificate SAN"
+                                                    }
+                                                },
+                                                "featureGates": {
+                                                    "type": "array",
+                                                    "title": "Feature gates",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "title": "Feature gate",
+                                                        "required": [
+                                                            "name",
+                                                            "enabled"
+                                                        ],
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "enabled": {
+                                                                "type": "boolean",
+                                                                "title": "Enabled"
+                                                            },
+                                                            "name": {
+                                                                "type": "string",
+                                                                "title": "Name"
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "serviceAccountIssuer": {
+                                                    "title": "Service account issuer",
+                                                    "description": "Configuration of the identifier of the service account token issuer. You must specify either URL or clusterDomainPrefix (only one, not both).",
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "null"
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "clusterDomainPrefix": {
+                                                                    "type": "string",
+                                                                    "title": "Cluster domain prefix",
+                                                                    "description": "Prefix that is prepended to the cluster domain name, so that resulting URL is used as the identifier of the service account token issuer."
+                                                                },
+                                                                "url": {
+                                                                    "type": "string",
+                                                                    "title": "URL",
+                                                                    "description": "This URL is used as the identifier of the service account token issuer."
+                                                                }
+                                                            },
+                                                            "oneOf": [
+                                                                {
+                                                                    "required": [
+                                                                        "url"
+                                                                    ],
+                                                                    "not": {
+                                                                        "required": [
+                                                                            "clusterDomainPrefix"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "required": [
+                                                                        "clusterDomainPrefix"
+                                                                    ],
+                                                                    "not": {
+                                                                        "required": [
+                                                                            "url"
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "default": {}
+>>>>>>> bbfacaf (Revert "run make generate-schema")
                                         },
                                         "etcd": {
                                             "type": "object",
@@ -1535,6 +2421,7 @@
                             }
                         },
                         "ignition": {
+<<<<<<< HEAD
                             "$ref": "#/$defs/ignition"
                         },
                         "postKubeadmCommands": {
@@ -1691,6 +2578,182 @@
                                                 "type": "string",
                                                 "title": "Infrastructure Machine template spec template name",
                                                 "description": "The name of Helm template that renders Infrastructure Machine template spec."
+||||||| parent of bbfacaf (Revert "run make generate-schema")
+                            "type": "object",
+                            "properties": {
+                                "containerLinuxConfig": {
+                                    "type": "object",
+                                    "properties": {
+                                        "additionalConfig": {
+                                            "type": "object",
+                                            "properties": {
+                                                "storage": {
+                                                    "type": "object"
+                                                },
+                                                "systemd": {
+                                                    "type": "object"
+                                                }
+=======
+                            "$ref": "#/$defs/ignition"
+                        },
+                        "postKubeadmCommands": {
+                            "$ref": "#/$defs/postKubeadmCommands"
+                        },
+                        "preKubeadmCommands": {
+                            "$ref": "#/$defs/preKubeadmCommands"
+                        }
+                    }
+                },
+                "kubernetesVersion": {
+                    "type": "string",
+                    "title": "Kubernetes version",
+                    "examples": [
+                        "1.24.7"
+                    ],
+                    "default": "1.24.10"
+                },
+                "pauseProperties": {
+                    "type": "object",
+                    "title": "Pause properties",
+                    "description": "A map of property names and their values that will affect setting pause annotation",
+                    "additionalProperties": {
+                        "type": [
+                            "string",
+                            "number",
+                            "integer",
+                            "boolean"
+                        ]
+                    }
+                },
+                "provider": {
+                    "type": "string",
+                    "title": "Provider",
+                    "description": "The name of the Cluster API provider. The name here must match the name of the provider in cluster-<provider> app name."
+                },
+                "resourcesApi": {
+                    "type": "object",
+                    "title": "Resources API",
+                    "description": "Group, version and kind configuration that is required and used by a specific Cluster API provider.",
+                    "required": [
+                        "clusterResourceEnabled",
+                        "controlPlaneResourceEnabled",
+                        "machinePoolResourcesEnabled",
+                        "machineHealthCheckResourceEnabled",
+                        "bastionResourceEnabled",
+                        "infrastructureCluster"
+                    ],
+                    "properties": {
+                        "bastionResourceEnabled": {
+                            "type": "boolean",
+                            "title": "Bastion resource enabled",
+                            "description": "Flag that indicates if the Bastion resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.",
+                            "default": true
+                        },
+                        "clusterResourceEnabled": {
+                            "type": "boolean",
+                            "title": "Cluster resource enabled",
+                            "description": "Flag that indicates if the Cluster resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.",
+                            "default": true
+                        },
+                        "controlPlaneResourceEnabled": {
+                            "type": "boolean",
+                            "title": "Control plane resource enabled",
+                            "description": "Flag that indicates if the control plane resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.",
+                            "default": true
+                        },
+                        "infrastructureCluster": {
+                            "$ref": "#/$defs/infrastructureCluster"
+                        },
+                        "machineHealthCheckResourceEnabled": {
+                            "type": "boolean",
+                            "title": "MachineHealthCheck resource enabled",
+                            "description": "Flag that indicates if the MachineHealthCheck resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.",
+                            "default": true
+                        },
+                        "machinePoolResourcesEnabled": {
+                            "type": "boolean",
+                            "title": "Machine pool resources enabled",
+                            "description": "Flag that indicates if the machine pool resources are enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.",
+                            "default": true
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "if": {
+                                "type": "object",
+                                "properties": {
+                                    "machinePoolResourcesEnabled": {
+                                        "const": true
+                                    }
+                                }
+                            },
+                            "then": {
+                                "required": [
+                                    "nodePoolKind"
+                                ],
+                                "properties": {
+                                    "nodePoolKind": {
+                                        "type": "string",
+                                        "title": "Node pool kind",
+                                        "description": "Specifies which resource kind is used for node pools.",
+                                        "enum": [
+                                            "MachineDeployment",
+                                            "MachinePool"
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "if": {
+                                "type": "object",
+                                "properties": {
+                                    "machinePoolResourcesEnabled": {
+                                        "const": true
+                                    },
+                                    "nodePoolKind": {
+                                        "const": "MachinePool"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "required": [
+                                    "infrastructureMachinePool"
+                                ],
+                                "properties": {
+                                    "infrastructureMachinePool": {
+                                        "$ref": "#/$defs/infrastructureMachinePool"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "if": {
+                                "type": "object",
+                                "properties": {
+                                    "bastionResourceEnabled": {
+                                        "const": true
+                                    }
+                                }
+                            },
+                            "then": {
+                                "required": [
+                                    "bastion"
+                                ],
+                                "properties": {
+                                    "bastion": {
+                                        "type": "object",
+                                        "title": "Bastion",
+                                        "description": "Configuration of bastion resources API and names.",
+                                        "properties": {
+                                            "infrastructureMachineTemplate": {
+                                                "$ref": "#/$defs/infrastructureMachineTemplate"
+                                            },
+                                            "infrastructureMachineTemplateSpecTemplateName": {
+                                                "type": "string",
+                                                "title": "Infrastructure Machine template spec template name",
+                                                "description": "The name of Helm template that renders Infrastructure Machine template spec."
+>>>>>>> bbfacaf (Revert "run make generate-schema")
                                             }
                                         }
                                     }
@@ -1705,19 +2768,43 @@
                     "title": "Teleport",
                     "properties": {
                         "enabled": {
+<<<<<<< HEAD
                             "type": "boolean",
                             "title": "Enable teleport",
                             "default": true
+||||||| parent of bbfacaf (Revert "run make generate-schema")
+                            "type": "boolean"
+=======
+                            "type": "boolean",
+                            "title": "Enable teleport",
+                            "default": false
+>>>>>>> bbfacaf (Revert "run make generate-schema")
                         },
                         "proxyAddr": {
+<<<<<<< HEAD
                             "type": "string",
                             "title": "Teleport proxy address",
                             "default": "teleport.giantswarm.io:443"
+||||||| parent of bbfacaf (Revert "run make generate-schema")
+                            "type": "string"
+=======
+                            "type": "string",
+                            "title": "Teleport proxy address",
+                            "default": "test.teleport.giantswarm.io:443"
+>>>>>>> bbfacaf (Revert "run make generate-schema")
                         },
                         "version": {
+<<<<<<< HEAD
                             "type": "string",
                             "title": "Teleport version",
                             "default": "14.1.3"
+||||||| parent of bbfacaf (Revert "run make generate-schema")
+                            "type": "string"
+=======
+                            "type": "string",
+                            "title": "Teleport version",
+                            "default": "13.3.8"
+>>>>>>> bbfacaf (Revert "run make generate-schema")
                         }
                     }
                 },

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -139,14 +139,8 @@
                             "properties": {
                                 "storage": {
                                     "type": "object",
-<<<<<<< HEAD
                                     "title": "Storage",
                                     "description": "It describes the desired state of the system\u2019s storage devices.",
-||||||| parent of bbfacaf (Revert "run make generate-schema")
-=======
-                                    "title": "Storage",
-                                    "description": "It describes the desired state of the system’s storage devices.",
->>>>>>> bbfacaf (Revert "run make generate-schema")
                                     "properties": {
                                         "directories": {
                                             "type": "array",
@@ -160,7 +154,6 @@
                                                     "path"
                                                 ],
                                                 "properties": {
-<<<<<<< HEAD
                                                     "filesystem": {
                                                         "type": "string",
                                                         "title": "Filesystem",
@@ -287,143 +280,11 @@
                                                         "type": "string",
                                                         "title": "Path",
                                                         "description": "The mount-point of the filesystem. A non-null entry indicates that the filesystem has already been mounted by the system at the specified path. This is really only useful for \u201c/sysroot\u201d."
-||||||| parent of bbfacaf (Revert "run make generate-schema")
-                                                    "endpoint": {
-                                                        "type": "string"
-=======
-                                                    "filesystem": {
-                                                        "type": "string",
-                                                        "title": "Filesystem",
-                                                        "description": "The internal identifier of the filesystem in which to create the directory. This matches the last filesystem with the given identifier."
-                                                    },
-                                                    "group": {
-                                                        "type": "object",
-                                                        "title": "Group",
-                                                        "description": "It specifies the group of the owner.",
-                                                        "properties": {
-                                                            "id": {
-                                                                "type": "integer",
-                                                                "title": "ID",
-                                                                "description": "The group ID of the owner."
-                                                            },
-                                                            "name": {
-                                                                "type": "string",
-                                                                "title": "Name",
-                                                                "description": "The group name of the owner."
-                                                            }
-                                                        }
-                                                    },
-                                                    "mode": {
-                                                        "type": "integer",
-                                                        "title": "Mode",
-                                                        "description": "The directory’s permission mode."
-                                                    },
-                                                    "overwrite": {
-                                                        "type": "boolean",
-                                                        "title": "Overwrite",
-                                                        "description": "Whether to delete preexisting nodes at the path."
-                                                    },
-                                                    "path": {
-                                                        "type": "string",
-                                                        "title": "Path",
-                                                        "description": "The absolute path to the directory."
-                                                    },
-                                                    "user": {
-                                                        "type": "object",
-                                                        "title": "User",
-                                                        "description": "It specifies the directory’s owner.",
-                                                        "properties": {
-                                                            "id": {
-                                                                "type": "integer",
-                                                                "title": "ID",
-                                                                "description": "The user ID of the owner."
-                                                            },
-                                                            "name": {
-                                                                "type": "string",
-                                                                "title": "Name",
-                                                                "description": "The user name of the owner."
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "filesystems": {
-                                            "type": "array",
-                                            "title": "File systems",
-                                            "description": "The list of filesystems to be configured and/or used in the “files” section. Either “mount” or “path” needs to be specified.",
-                                            "items": {
-                                                "type": "object",
-                                                "title": "File system",
-                                                "description": "The filesystem to be configured and/or used in the “files” section. Either “mount” or “path” needs to be specified.",
-                                                "properties": {
-                                                    "mount": {
-                                                        "type": "object",
-                                                        "title": "Mount",
-                                                        "description": "It contains the set of mount and formatting options for the filesystem. A non-null entry indicates that the filesystem should be mounted before it is used by Ignition.",
-                                                        "required": [
-                                                            "device",
-                                                            "format"
-                                                        ],
-                                                        "properties": {
-                                                            "device": {
-                                                                "type": "string",
-                                                                "title": "Device",
-                                                                "description": "The absolute path to the device. Devices are typically referenced by the /dev/disk/by-* symlinks."
-                                                            },
-                                                            "format": {
-                                                                "type": "string",
-                                                                "title": "Format",
-                                                                "description": "The filesystem format (ext4, btrfs, or xfs).",
-                                                                "enum": [
-                                                                    "ext4",
-                                                                    "btrfs",
-                                                                    "xfs"
-                                                                ]
-                                                            },
-                                                            "label": {
-                                                                "type": "string",
-                                                                "title": "Label",
-                                                                "description": "The label of the filesystem."
-                                                            },
-                                                            "options": {
-                                                                "type": "array",
-                                                                "title": "Options",
-                                                                "description": "Any additional options to be passed to the format-specific mkfs utility.",
-                                                                "items": {
-                                                                    "type": "string",
-                                                                    "description": "An additional option to be passed to the format-specific mkfs utility.",
-                                                                    "name": "Option"
-                                                                }
-                                                            },
-                                                            "uuid": {
-                                                                "type": "string",
-                                                                "title": "UUID",
-                                                                "description": "The uuid of the filesystem."
-                                                            },
-                                                            "wipeFilesystem": {
-                                                                "type": "boolean",
-                                                                "title": "Wipe filesystem",
-                                                                "description": "Whether or not to wipe the device before filesystem creation, see Ignition’s documentation on filesystems for more information https://github.com/coreos/ignition/blob/main/docs/operator-notes.md#filesystem-reuse-semantics."
-                                                            }
-                                                        }
-                                                    },
-                                                    "name": {
-                                                        "type": "string",
-                                                        "title": "Name",
-                                                        "description": "The identifier for the filesystem, internal to Ignition. This is only required if the filesystem needs to be referenced in the “files” section."
-                                                    },
-                                                    "path": {
-                                                        "type": "string",
-                                                        "title": "Path",
-                                                        "description": "The mount-point of the filesystem. A non-null entry indicates that the filesystem has already been mounted by the system at the specified path. This is really only useful for “/sysroot”."
->>>>>>> bbfacaf (Revert "run make generate-schema")
                                                     }
                                                 }
                                             }
                                         }
                                     }
-<<<<<<< HEAD
                                 },
                                 "systemd": {
                                     "type": "object",
@@ -792,315 +653,6 @@
                                             }
                                         ]
                                     }
-||||||| parent of bbfacaf (Revert "run make generate-schema")
-=======
-                                },
-                                "systemd": {
-                                    "type": "object",
-                                    "title": "systemd",
-                                    "description": "It describes the desired state of the systemd units.",
-                                    "properties": {
-                                        "units": {
-                                            "type": "array",
-                                            "title": "Units",
-                                            "items": {
-                                                "$ref": "#/$defs/systemdUnit"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "strict": {
-                            "type": "boolean",
-                            "title": "Strict",
-                            "description": "It controls if AdditionalConfig should be strictly parsed. If so, warnings are treated as errors."
-                        }
-                    }
-                }
-            }
-        },
-        "infrastructureCluster": {
-            "type": "object",
-            "title": "Infrastructure cluster",
-            "description": "Group, version and kind of provider-specific infrastructure cluster resource.",
-            "required": [
-                "group",
-                "version",
-                "kind"
-            ],
-            "additionalProperties": false,
-            "properties": {
-                "group": {
-                    "type": "string",
-                    "title": "API group",
-                    "examples": [
-                        "infrastructure.cluster.x-k8s.io"
-                    ]
-                },
-                "kind": {
-                    "type": "string",
-                    "title": "API kind",
-                    "examples": [
-                        "AWSCluster",
-                        "AzureCluster",
-                        "VCDCluster",
-                        "VSphereCluster"
-                    ]
-                },
-                "version": {
-                    "type": "string",
-                    "title": "API version",
-                    "examples": [
-                        "v1alpha1",
-                        "v1beta1",
-                        "v1beta2",
-                        "v1",
-                        "v2"
-                    ]
-                }
-            }
-        },
-        "infrastructureMachinePool": {
-            "type": "object",
-            "title": "Infrastructure MachinePool",
-            "description": "Group, version and kind of provider-specific infrastructure MachinePool resource.",
-            "required": [
-                "group",
-                "version",
-                "kind"
-            ],
-            "additionalProperties": false,
-            "properties": {
-                "group": {
-                    "type": "string",
-                    "title": "API group",
-                    "examples": [
-                        "infrastructure.cluster.x-k8s.io"
-                    ]
-                },
-                "kind": {
-                    "type": "string",
-                    "title": "API kind",
-                    "examples": [
-                        "AWSMachinePool",
-                        "AzureMachinePool"
-                    ]
-                },
-                "version": {
-                    "type": "string",
-                    "title": "API version",
-                    "examples": [
-                        "v1alpha1",
-                        "v1beta1",
-                        "v1beta2",
-                        "v1",
-                        "v2"
-                    ]
-                }
-            }
-        },
-        "infrastructureMachineTemplate": {
-            "type": "object",
-            "title": "Infrastructure Machine template",
-            "description": "Group, version and kind of provider-specific infrastructure Machine template resource.",
-            "required": [
-                "group",
-                "version",
-                "kind"
-            ],
-            "additionalProperties": false,
-            "properties": {
-                "group": {
-                    "type": "string",
-                    "title": "API group",
-                    "examples": [
-                        "infrastructure.cluster.x-k8s.io"
-                    ]
-                },
-                "kind": {
-                    "type": "string",
-                    "title": "API kind",
-                    "examples": [
-                        "AWSMachineTemplate",
-                        "AzureMachineTemplate"
-                    ]
-                },
-                "version": {
-                    "type": "string",
-                    "title": "API version",
-                    "examples": [
-                        "v1alpha1",
-                        "v1beta1",
-                        "v1beta2",
-                        "v1",
-                        "v2"
-                    ]
-                }
-            }
-        },
-        "postKubeadmCommands": {
-            "type": "array",
-            "title": "Post-kubeadm commands",
-            "description": "Extra commands to run after kubeadm runs.",
-            "items": {
-                "type": "string"
-            }
-        },
-        "preKubeadmCommands": {
-            "type": "array",
-            "title": "Pre-kubeadm commands",
-            "description": "Extra commands to run before kubeadm runs.",
-            "items": {
-                "type": "string"
-            }
-        },
-        "systemdUnit": {
-            "type": "object",
-            "title": "systemd unit",
-            "required": [
-                "name"
-            ],
-            "additionalProperties": false,
-            "properties": {
-                "contents": {
-                    "type": "string",
-                    "title": "Contents",
-                    "description": "The contents of the unit."
-                },
-                "dropins": {
-                    "type": "array",
-                    "title": "Unit drop-ins",
-                    "description": "The list of drop-ins for the unit",
-                    "items": {
-                        "type": "object",
-                        "title": "Unit drop-in",
-                        "required": [
-                            "name"
-                        ],
-                        "properties": {
-                            "contents": {
-                                "type": "string",
-                                "title": "Contents",
-                                "description": "The contents of the drop-in."
-                            },
-                            "name": {
-                                "type": "string",
-                                "title": "Name",
-                                "description": "The name of the drop-in. This must be suffixed with “.conf”",
-                                "pattern": "^.+\\.conf$"
-                            }
-                        }
-                    }
-                },
-                "enabled": {
-                    "type": "boolean",
-                    "title": "Enabled?",
-                    "description": "Whether or not the service shall be enabled. When true, the service is enabled. When false, the service is disabled. When omitted, the service is unmodified. In order for this to have any effect, the unit must have an install section."
-                },
-                "mask": {
-                    "type": "boolean",
-                    "title": "Masked?",
-                    "description": "Whether or not the service shall be masked. When true, the service is masked by symlinking it to /dev/null."
-                },
-                "name": {
-                    "type": "string",
-                    "title": "Name",
-                    "description": "The name of the unit. This must be suffixed with a valid unit type (e.g. “thing.service”)."
-                }
-            }
-        }
-    },
-    "type": "object",
-    "additionalProperties": false,
-    "properties": {
-        "global": {
-            "type": "object",
-            "title": "Global properties",
-            "description": "Properties that are available to all charts and subcharts.",
-            "required": [
-                "components",
-                "connectivity",
-                "controlPlane",
-                "metadata"
-            ],
-            "additionalProperties": true,
-            "properties": {
-                "components": {
-                    "type": "object",
-                    "title": "Components",
-                    "description": "Advanced configuration of components that are running on all nodes.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "containerd": {
-                            "type": "object",
-                            "title": "Containerd",
-                            "description": "Configuration of containerd.",
-                            "required": [
-                                "containerRegistries"
-                            ],
-                            "additionalProperties": false,
-                            "properties": {
-                                "containerRegistries": {
-                                    "type": "object",
-                                    "title": "Container registries",
-                                    "description": "Endpoints and credentials configuration for container registries.",
-                                    "additionalProperties": {
-                                        "type": "array",
-                                        "title": "Registries",
-                                        "description": "Container registries and mirrors",
-                                        "items": {
-                                            "type": "object",
-                                            "title": "Registry",
-                                            "required": [
-                                                "endpoint"
-                                            ],
-                                            "properties": {
-                                                "credentials": {
-                                                    "type": "object",
-                                                    "title": "Credentials",
-                                                    "properties": {
-                                                        "auth": {
-                                                            "type": "string",
-                                                            "title": "Auth",
-                                                            "description": "Base64-encoded string from the concatenation of the username, a colon, and the password."
-                                                        },
-                                                        "identitytoken": {
-                                                            "type": "string",
-                                                            "title": "Identity token",
-                                                            "description": "Used to authenticate the user and obtain an access token for the registry."
-                                                        },
-                                                        "password": {
-                                                            "type": "string",
-                                                            "title": "Password",
-                                                            "description": "Used to authenticate for the registry with username/password."
-                                                        },
-                                                        "username": {
-                                                            "type": "string",
-                                                            "title": "Username",
-                                                            "description": "Used to authenticate for the registry with username/password."
-                                                        }
-                                                    }
-                                                },
-                                                "endpoint": {
-                                                    "type": "string",
-                                                    "title": "Endpoint",
-                                                    "description": "Endpoint for the container registry."
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "default": {
-                                        "docker.io": [
-                                            {
-                                                "endpoint": "registry-1.docker.io"
-                                            },
-                                            {
-                                                "endpoint": "giantswarm.azurecr.io"
-                                            }
-                                        ]
-                                    }
->>>>>>> bbfacaf (Revert "run make generate-schema")
                                 }
                             }
                         }
@@ -1206,7 +758,6 @@
                             ],
                             "properties": {
                                 "enabled": {
-<<<<<<< HEAD
                                     "type": "boolean",
                                     "title": "Enable"
                                 },
@@ -1224,41 +775,6 @@
                                     "type": "string",
                                     "title": "No proxy",
                                     "description": "Comma-separated addresses to be passed to the NO_PROXY environment variable in all hosts."
-||||||| parent of bbfacaf (Revert "run make generate-schema")
-                                    "type": "boolean"
-=======
-                                    "type": "boolean",
-                                    "title": "Enable"
-                                },
-                                "httpProxy": {
-                                    "type": "string",
-                                    "title": "HTTP proxy",
-                                    "description": "To be passed to the HTTP_PROXY environment variable in all hosts."
-                                },
-                                "httpsProxy": {
-                                    "type": "string",
-                                    "title": "HTTPS proxy",
-                                    "description": "To be passed to the HTTPS_PROXY environment variable in all hosts."
-                                },
-                                "noProxy": {
-                                    "type": "object",
-                                    "title": "No proxy",
-                                    "properties": {
-                                        "addresses": {
-                                            "type": "array",
-                                            "title": "Addresses",
-                                            "description": "To be passed to the NO_PROXY environment variable in all hosts.",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "addressesTemplate": {
-                                            "type": "string",
-                                            "title": "Addresses template",
-                                            "description": "Name of Helm template that renders a YAML array with NO_PROXY addresses."
-                                        }
-                                    }
->>>>>>> bbfacaf (Revert "run make generate-schema")
                                 }
                             },
                             "default": {
@@ -1277,7 +793,6 @@
                     ],
                     "properties": {
                         "apiServerPort": {
-<<<<<<< HEAD
                             "type": "integer",
                             "title": "API server port",
                             "description": "The public facing API server Load Balancer port.",
@@ -1287,19 +802,6 @@
                         },
                         "customNodeTaints": {
                             "$ref": "#/$defs/customNodeTaints"
-||||||| parent of bbfacaf (Revert "run make generate-schema")
-                            "type": "integer"
-=======
-                            "type": "integer",
-                            "title": "API server port",
-                            "description": "The public facing API server Load Balancer port.",
-                            "default": 6443,
-                            "minimum": 0,
-                            "maximum": 65535
-                        },
-                        "customNodeTaints": {
-                            "$ref": "#/$defs/customNodeTaints"
->>>>>>> bbfacaf (Revert "run make generate-schema")
                         },
                         "machineHealthCheck": {
                             "type": "object",
@@ -1403,55 +905,6 @@
                         "servicePriority"
                     ],
                     "properties": {
-<<<<<<< HEAD
-                        "description": {
-                            "type": "string",
-                            "title": "Cluster description",
-                            "description": "User-friendly description of the cluster's purpose."
-                        },
-                        "annotations": {
-                            "type": "object",
-                            "title": "Annotations",
-                            "description": "These annotations are added to all Kubernetes resources defining this cluster.",
-                            "additionalProperties": false,
-                            "patternProperties": {
-                                "^([a-zA-Z0-9\\.-]{1,253}/)?[a-zA-Z0-9\\._-]{1,63}$": {
-                                    "type": "string",
-                                    "title": "Annotation",
-                                    "minLength": 1
-                                }
-                            }
-                        },
-                        "labels": {
-                            "type": "object",
-                            "title": "Labels",
-                            "description": "These labels are added to all Kubernetes resources defining this cluster.",
-                            "additionalProperties": false,
-                            "patternProperties": {
-                                "^[a-zA-Z0-9/\\._-]+$": {
-                                    "type": "string",
-                                    "title": "Label",
-                                    "maxLength": 63,
-                                    "minLength": 0,
-                                    "pattern": "^[a-zA-Z0-9\\._-]+$"
-                                }
-                            }
-                        },
-                        "name": {
-
-                            "type": "string",
-                            "title": "Cluster name",
-                            "description": "Unique identifier, cannot be changed after creation.",
-                            "readOnly": true
-                        },
-                        "organization": {
-                            "type": "string",
-                            "title": "Organization",
-                            "description": "The name of organization that owns the cluster.",
-                            "readOnly": true
-                        },
-||||||| parent of bbfacaf (Revert "run make generate-schema")
-=======
                         "description": {
                             "type": "string",
                             "title": "Cluster description",
@@ -1497,7 +950,6 @@
                             "description": "The name of organization that owns the cluster.",
                             "readOnly": true
                         },
->>>>>>> bbfacaf (Revert "run make generate-schema")
                         "preventDeletion": {
                             "type": "boolean",
                             "title": "Prevent cluster deletion",
@@ -1505,7 +957,6 @@
                             "default": false
                         },
                         "servicePriority": {
-<<<<<<< HEAD
                             "type": "string",
                             "title": "Service priority",
                             "description": "The relative importance of this cluster.",
@@ -1628,107 +1079,6 @@
                             "title": "CGroups v1",
                             "description": "Force use of CGroups v1 for whole cluster.",
                             "default": false
-||||||| parent of bbfacaf (Revert "run make generate-schema")
-                            "type": "string"
-=======
-                            "type": "string",
-                            "title": "Service priority",
-                            "description": "The relative importance of this cluster.",
-                            "$comment": "Defined in https://github.com/giantswarm/rfc/tree/main/classify-cluster-priority",
-                            "enum": [
-                                "highest",
-                                "medium",
-                                "lowest"
-                            ],
-                            "default": "highest"
-                        }
-                    }
-                },
-                "nodePools": {
-                    "type": "object",
-                    "title": "Node pools",
-                    "patternProperties": {
-                        "^[a-z0-9]{5,10}$": {
-                            "type": "object",
-                            "title": "Node pool",
-                            "properties": {
-                                "annotations": {
-                                    "type": "object",
-                                    "title": "Annotations",
-                                    "description": "These annotations are added to all Kubernetes resources defining this node pool.",
-                                    "additionalProperties": false,
-                                    "patternProperties": {
-                                        "^([a-zA-Z0-9\\.-]{1,253}/)?[a-zA-Z0-9\\._-]{1,63}$": {
-                                            "type": "string",
-                                            "title": "Annotation",
-                                            "minLength": 1
-                                        }
-                                    }
-                                },
-                                "labels": {
-                                    "type": "object",
-                                    "title": "Labels",
-                                    "description": "These labels are added to all Kubernetes resources defining this node pool.",
-                                    "additionalProperties": false,
-                                    "patternProperties": {
-                                        "^[a-zA-Z0-9/\\._-]+$": {
-                                            "type": "string",
-                                            "title": "Label",
-                                            "maxLength": 63,
-                                            "minLength": 0,
-                                            "pattern": "^[a-zA-Z0-9\\._-]+$"
-                                        }
-                                    }
-                                },
-                                "nodeLabels": {
-                                    "type": "object",
-                                    "title": "Node labels",
-                                    "description": "Labels that are passed to kubelet argument 'node-labels'.",
-                                    "additionalProperties": {
-                                        "type": "string"
-                                    }
-                                },
-                                "nodeTaints": {
-                                    "type": "array",
-                                    "title": "Custom node taints",
-                                    "items": {
-                                        "type": "object",
-                                        "required": [
-                                            "effect",
-                                            "key",
-                                            "value"
-                                        ],
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "effect": {
-                                                "type": "string",
-                                                "title": "Effect",
-                                                "enum": [
-                                                    "NoSchedule",
-                                                    "PreferNoSchedule",
-                                                    "NoExecute"
-                                                ]
-                                            },
-                                            "key": {
-                                                "type": "string",
-                                                "title": "Key"
-                                            },
-                                            "value": {
-                                                "type": "string",
-                                                "title": "Value"
-                                            }
-                                        }
-                                    }
-                                },
-                                "replicas": {
-                                    "type": "integer",
-                                    "title": "Replicas",
-                                    "description": "The number of node pool nodes.",
-                                    "maximum": 1000,
-                                    "minimum": 0
-                                }
-                            }
->>>>>>> bbfacaf (Revert "run make generate-schema")
                         }
                     }
                 }
@@ -1801,7 +1151,6 @@
                                         "tag"
                                     ],
                                     "properties": {
-<<<<<<< HEAD
                                         "name": {
                                             "type": "string",
                                             "title": "Repository",
@@ -1833,112 +1182,17 @@
                                     "additionalProperties": false,
                                     "properties": {
                                         "timesyncd": {
-||||||| parent of bbfacaf (Revert "run make generate-schema")
-                                        "containerLinuxConfig": {
-=======
-                                        "name": {
-                                            "type": "string",
-                                            "title": "Repository",
-                                            "default": "giantswarm/pause"
-                                        },
-                                        "registry": {
-                                            "type": "string",
-                                            "title": "Registry",
-                                            "default": "quay.io"
-                                        },
-                                        "tag": {
-                                            "type": "string",
-                                            "title": "Tag",
-                                            "default": "3.9"
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "kubelet": {
-                            "title": "Kubelet",
-                            "description": "Kubelet configuration that is used on all nodes.",
-                            "default": null,
-                            "oneOf": [
-                                {
-                                    "type": "null"
-                                },
-                                {
-                                    "type": "object",
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "gracefulNodeShutdown": {
->>>>>>> bbfacaf (Revert "run make generate-schema")
                                             "type": "object",
-<<<<<<< HEAD
                                             "title": "timesyncd",
                                             "description": "systemd-timesyncd is a system service that may be used to synchronize the local system clock with a remote Network Time Protocol (NTP) server.",
                                             "additionalProperties": false,
-||||||| parent of bbfacaf (Revert "run make generate-schema")
-=======
-                                            "title": "Graceful node shut down",
-                                            "description": "It enables kubelet to gracefully evict pods during a node shutdown. It is enabled by default in Kubernetes 1.21.",
-                                            "additionalProperties": false,
->>>>>>> bbfacaf (Revert "run make generate-schema")
                                             "properties": {
-<<<<<<< HEAD
                                                 "ntp": {
                                                     "type": "array",
                                                     "title": "NTP",
                                                     "description": "A list of NTP server host names or IP addresses.",
                                                     "items": {
                                                         "type": "string"
-||||||| parent of bbfacaf (Revert "run make generate-schema")
-                                                "additionalConfig": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "storage": {
-                                                            "type": "object"
-                                                        },
-                                                        "systemd": {
-                                                            "type": "object"
-                                                        }
-=======
-                                                "shutdownGracePeriod": {
-                                                    "type": "string",
-                                                    "title": "Shutdown grace period",
-                                                    "description": "Specifies the total duration that the node should delay the shutdown by. This is the total grace period for pod termination for both regular and critical pods."
-                                                },
-                                                "shutdownGracePeriodCriticalPods": {
-                                                    "type": "string",
-                                                    "title": "Shutdown grace period for critical pods",
-                                                    "description": "Specifies the duration used to terminate critical pods during a node shutdown. This should be less than shutdownGracePeriod."
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "systemd": {
-                            "title": "systemd",
-                            "default": null,
-                            "oneOf": [
-                                {
-                                    "type": "null"
-                                },
-                                {
-                                    "type": "object",
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "timesyncd": {
-                                            "type": "object",
-                                            "title": "timesyncd",
-                                            "description": "systemd-timesyncd is a system service that may be used to synchronize the local system clock with a remote Network Time Protocol (NTP) server.",
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "npt": {
-                                                    "type": "array",
-                                                    "title": "NTP",
-                                                    "description": "A list of NTP server host names or IP addresses.",
-                                                    "items": {
-                                                        "type": "string"
->>>>>>> bbfacaf (Revert "run make generate-schema")
                                                     }
                                                 }
                                             }
@@ -1951,19 +1205,9 @@
                 },
                 "connectivity": {
                     "type": "object",
-<<<<<<< HEAD
                     "title": "Connectivity",
                     "description": "Internal connectivity configuration.",
                     "additionalProperties": false,
-||||||| parent of bbfacaf (Revert "run make generate-schema")
-=======
-                    "title": "Connectivity",
-                    "description": "Internal connectivity configuration.",
-                    "required": [
-                        "sshSsoPublicKey"
-                    ],
-                    "additionalProperties": false,
->>>>>>> bbfacaf (Revert "run make generate-schema")
                     "properties": {
                         "proxy": {
                             "type": "object",
@@ -2024,140 +1268,6 @@
                                     "additionalProperties": false,
                                     "properties": {
                                         "apiServer": {
-<<<<<<< HEAD
-                                            "type": "object",
-                                            "title": "API server",
-                                            "description": "Configuration of API server.",
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "additionalAdmissionPlugins": {
-                                                    "type": "array",
-                                                    "title": "Additional admission plugins",
-
-                                                    "description": "A list of plugins to enable, in addition to the default ones that include DefaultStorageClass, DefaultTolerationSeconds, LimitRanger, MutatingAdmissionWebhook, NamespaceLifecycle, PersistentVolumeClaimResize, Priority, ResourceQuota, ServiceAccount and ValidatingAdmissionWebhook.",
-                                                    "items": {
-                                                        "type": "string",
-                                                        "title": "Additional admission plugin"
-                                                    }
-                                                },
-                                                "apiAudiences": {
-                                                    "title": "API audiences",
-                                                    "description": "Identifiers of the API. The service account token authenticator will validate that tokens used against the API are bound to at least one of these audiences. If the --service-account-issuer flag is configured and this flag is not, 'api-audiences' field defaults to a single element list containing the issuer URL.",
-                                                    "oneOf": [
-                                                        {
-                                                            "type": "null"
-                                                        },
-                                                        {
-                                                            "type": "string"
-                                                        },
-                                                        {
-                                                            "type": "object",
-                                                            "required": [
-                                                                "templateName"
-                                                            ],
-                                                            "additionalProperties": false,
-                                                            "properties": {
-                                                                "templateName": {
-                                                                    "type": "string",
-                                                                    "title": "Template name",
-                                                                    "description": "The name of the Helm template which renders the 'api-audiences' value"
-                                                                }
-                                                            }
-                                                        }
-                                                    ]
-                                                },
-                                                "etcdPrefix": {
-                                                    "type": "string",
-                                                    "title": "etcd prefix"
-                                                },
-                                                "extraArgs": {
-                                                    "type": "object",
-                                                    "title": "Extra args"
-                                                },
-                                                "extraCertificateSANs": {
-                                                    "type": "array",
-                                                    "title": "Extra certificate SANs",
-                                                    "description": "The additional certificate SANs that are appended to the default SANs.",
-                                                    "items": {
-                                                        "type": "string",
-                                                        "title": "Extra certificate SAN"
-                                                    }
-                                                },
-                                                "featureGates": {
-                                                    "type": "array",
-                                                    "title": "Feature gates",
-                                                    "items": {
-                                                        "type": "object",
-                                                        "title": "Feature gate",
-                                                        "required": [
-                                                            "name",
-                                                            "enabled"
-                                                        ],
-                                                        "additionalProperties": false,
-                                                        "properties": {
-                                                            "enabled": {
-                                                                "type": "boolean",
-                                                                "title": "Enabled"
-                                                            },
-                                                            "name": {
-                                                                "type": "string",
-                                                                "title": "Name"
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                "serviceAccountIssuer": {
-                                                    "title": "Service account issuer",
-                                                    "description": "Configuration of the identifier of the service account token issuer. You must specify either URL or clusterDomainPrefix (only one, not both).",
-                                                    "oneOf": [
-                                                        {
-                                                            "type": "null"
-                                                        },
-                                                        {
-                                                            "type": "object",
-                                                            "additionalProperties": false,
-                                                            "properties": {
-                                                                "clusterDomainPrefix": {
-                                                                    "type": "string",
-                                                                    "title": "Cluster domain prefix",
-                                                                    "description": "Prefix that is prepended to the cluster domain name, so that resulting URL is used as the identifier of the service account token issuer."
-                                                                },
-                                                                "url": {
-                                                                    "type": "string",
-                                                                    "title": "URL",
-                                                                    "description": "This URL is used as the identifier of the service account token issuer."
-                                                                }
-                                                            },
-                                                            "oneOf": [
-                                                                {
-                                                                    "required": [
-                                                                        "url"
-                                                                    ],
-                                                                    "not": {
-                                                                        "required": [
-                                                                            "clusterDomainPrefix"
-                                                                        ]
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "required": [
-                                                                        "clusterDomainPrefix"
-                                                                    ],
-                                                                    "not": {
-                                                                        "required": [
-                                                                            "url"
-                                                                        ]
-                                                                    }
-                                                                }
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            },
-                                            "default": {}
-||||||| parent of bbfacaf (Revert "run make generate-schema")
-                                            "type": "object"
-=======
                                             "type": "object",
                                             "title": "API server",
                                             "description": "Configuration of API server.",
@@ -2287,7 +1397,6 @@
                                                 }
                                             },
                                             "default": {}
->>>>>>> bbfacaf (Revert "run make generate-schema")
                                         },
                                         "etcd": {
                                             "type": "object",
@@ -2424,7 +1533,6 @@
                             }
                         },
                         "ignition": {
-<<<<<<< HEAD
                             "$ref": "#/$defs/ignition"
                         },
                         "postKubeadmCommands": {
@@ -2581,182 +1689,6 @@
                                                 "type": "string",
                                                 "title": "Infrastructure Machine template spec template name",
                                                 "description": "The name of Helm template that renders Infrastructure Machine template spec."
-||||||| parent of bbfacaf (Revert "run make generate-schema")
-                            "type": "object",
-                            "properties": {
-                                "containerLinuxConfig": {
-                                    "type": "object",
-                                    "properties": {
-                                        "additionalConfig": {
-                                            "type": "object",
-                                            "properties": {
-                                                "storage": {
-                                                    "type": "object"
-                                                },
-                                                "systemd": {
-                                                    "type": "object"
-                                                }
-=======
-                            "$ref": "#/$defs/ignition"
-                        },
-                        "postKubeadmCommands": {
-                            "$ref": "#/$defs/postKubeadmCommands"
-                        },
-                        "preKubeadmCommands": {
-                            "$ref": "#/$defs/preKubeadmCommands"
-                        }
-                    }
-                },
-                "kubernetesVersion": {
-                    "type": "string",
-                    "title": "Kubernetes version",
-                    "examples": [
-                        "1.24.7"
-                    ],
-                    "default": "1.24.10"
-                },
-                "pauseProperties": {
-                    "type": "object",
-                    "title": "Pause properties",
-                    "description": "A map of property names and their values that will affect setting pause annotation",
-                    "additionalProperties": {
-                        "type": [
-                            "string",
-                            "number",
-                            "integer",
-                            "boolean"
-                        ]
-                    }
-                },
-                "provider": {
-                    "type": "string",
-                    "title": "Provider",
-                    "description": "The name of the Cluster API provider. The name here must match the name of the provider in cluster-<provider> app name."
-                },
-                "resourcesApi": {
-                    "type": "object",
-                    "title": "Resources API",
-                    "description": "Group, version and kind configuration that is required and used by a specific Cluster API provider.",
-                    "required": [
-                        "clusterResourceEnabled",
-                        "controlPlaneResourceEnabled",
-                        "machinePoolResourcesEnabled",
-                        "machineHealthCheckResourceEnabled",
-                        "bastionResourceEnabled",
-                        "infrastructureCluster"
-                    ],
-                    "properties": {
-                        "bastionResourceEnabled": {
-                            "type": "boolean",
-                            "title": "Bastion resource enabled",
-                            "description": "Flag that indicates if the Bastion resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.",
-                            "default": true
-                        },
-                        "clusterResourceEnabled": {
-                            "type": "boolean",
-                            "title": "Cluster resource enabled",
-                            "description": "Flag that indicates if the Cluster resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.",
-                            "default": true
-                        },
-                        "controlPlaneResourceEnabled": {
-                            "type": "boolean",
-                            "title": "Control plane resource enabled",
-                            "description": "Flag that indicates if the control plane resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.",
-                            "default": true
-                        },
-                        "infrastructureCluster": {
-                            "$ref": "#/$defs/infrastructureCluster"
-                        },
-                        "machineHealthCheckResourceEnabled": {
-                            "type": "boolean",
-                            "title": "MachineHealthCheck resource enabled",
-                            "description": "Flag that indicates if the MachineHealthCheck resource is enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.",
-                            "default": true
-                        },
-                        "machinePoolResourcesEnabled": {
-                            "type": "boolean",
-                            "title": "Machine pool resources enabled",
-                            "description": "Flag that indicates if the machine pool resources are enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.",
-                            "default": true
-                        }
-                    },
-                    "allOf": [
-                        {
-                            "if": {
-                                "type": "object",
-                                "properties": {
-                                    "machinePoolResourcesEnabled": {
-                                        "const": true
-                                    }
-                                }
-                            },
-                            "then": {
-                                "required": [
-                                    "nodePoolKind"
-                                ],
-                                "properties": {
-                                    "nodePoolKind": {
-                                        "type": "string",
-                                        "title": "Node pool kind",
-                                        "description": "Specifies which resource kind is used for node pools.",
-                                        "enum": [
-                                            "MachineDeployment",
-                                            "MachinePool"
-                                        ]
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "if": {
-                                "type": "object",
-                                "properties": {
-                                    "machinePoolResourcesEnabled": {
-                                        "const": true
-                                    },
-                                    "nodePoolKind": {
-                                        "const": "MachinePool"
-                                    }
-                                }
-                            },
-                            "then": {
-                                "required": [
-                                    "infrastructureMachinePool"
-                                ],
-                                "properties": {
-                                    "infrastructureMachinePool": {
-                                        "$ref": "#/$defs/infrastructureMachinePool"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "if": {
-                                "type": "object",
-                                "properties": {
-                                    "bastionResourceEnabled": {
-                                        "const": true
-                                    }
-                                }
-                            },
-                            "then": {
-                                "required": [
-                                    "bastion"
-                                ],
-                                "properties": {
-                                    "bastion": {
-                                        "type": "object",
-                                        "title": "Bastion",
-                                        "description": "Configuration of bastion resources API and names.",
-                                        "properties": {
-                                            "infrastructureMachineTemplate": {
-                                                "$ref": "#/$defs/infrastructureMachineTemplate"
-                                            },
-                                            "infrastructureMachineTemplateSpecTemplateName": {
-                                                "type": "string",
-                                                "title": "Infrastructure Machine template spec template name",
-                                                "description": "The name of Helm template that renders Infrastructure Machine template spec."
->>>>>>> bbfacaf (Revert "run make generate-schema")
                                             }
                                         }
                                     }
@@ -2771,43 +1703,19 @@
                     "title": "Teleport",
                     "properties": {
                         "enabled": {
-<<<<<<< HEAD
                             "type": "boolean",
                             "title": "Enable teleport",
                             "default": true
-||||||| parent of bbfacaf (Revert "run make generate-schema")
-                            "type": "boolean"
-=======
-                            "type": "boolean",
-                            "title": "Enable teleport",
-                            "default": false
->>>>>>> bbfacaf (Revert "run make generate-schema")
                         },
                         "proxyAddr": {
-<<<<<<< HEAD
                             "type": "string",
                             "title": "Teleport proxy address",
                             "default": "teleport.giantswarm.io:443"
-||||||| parent of bbfacaf (Revert "run make generate-schema")
-                            "type": "string"
-=======
-                            "type": "string",
-                            "title": "Teleport proxy address",
-                            "default": "test.teleport.giantswarm.io:443"
->>>>>>> bbfacaf (Revert "run make generate-schema")
                         },
                         "version": {
-<<<<<<< HEAD
                             "type": "string",
                             "title": "Teleport version",
                             "default": "14.1.3"
-||||||| parent of bbfacaf (Revert "run make generate-schema")
-                            "type": "string"
-=======
-                            "type": "string",
-                            "title": "Teleport version",
-                            "default": "13.3.8"
->>>>>>> bbfacaf (Revert "run make generate-schema")
                         }
                     }
                 },

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1293,7 +1293,9 @@
                             "type": "integer",
                             "title": "API server port",
                             "description": "The public facing API server Load Balancer port.",
-                            "default": 6443
+                            "default": 6443,
+                            "minimum": 0,
+                            "maximum": 65535
                         },
                         "customNodeTaints": {
                             "$ref": "#/$defs/customNodeTaints"

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -140,7 +140,7 @@
                                 "storage": {
                                     "type": "object",
                                     "title": "Storage",
-                                    "description": "It describes the desired state of the system’s storage devices.",
+                                    "description": "It describes the desired state of the system\u2019s storage devices.",
                                     "properties": {
                                         "directories": {
                                             "type": "array",
@@ -179,7 +179,7 @@
                                                     "mode": {
                                                         "type": "integer",
                                                         "title": "Mode",
-                                                        "description": "The directory’s permission mode."
+                                                        "description": "The directory\u2019s permission mode."
                                                     },
                                                     "overwrite": {
                                                         "type": "boolean",
@@ -194,7 +194,7 @@
                                                     "user": {
                                                         "type": "object",
                                                         "title": "User",
-                                                        "description": "It specifies the directory’s owner.",
+                                                        "description": "It specifies the directory\u2019s owner.",
                                                         "properties": {
                                                             "id": {
                                                                 "type": "integer",
@@ -214,11 +214,11 @@
                                         "filesystems": {
                                             "type": "array",
                                             "title": "File systems",
-                                            "description": "The list of filesystems to be configured and/or used in the “files” section. Either “mount” or “path” needs to be specified.",
+                                            "description": "The list of filesystems to be configured and/or used in the \u201cfiles\u201d section. Either \u201cmount\u201d or \u201cpath\u201d needs to be specified.",
                                             "items": {
                                                 "type": "object",
                                                 "title": "File system",
-                                                "description": "The filesystem to be configured and/or used in the “files” section. Either “mount” or “path” needs to be specified.",
+                                                "description": "The filesystem to be configured and/or used in the \u201cfiles\u201d section. Either \u201cmount\u201d or \u201cpath\u201d needs to be specified.",
                                                 "properties": {
                                                     "mount": {
                                                         "type": "object",
@@ -267,19 +267,19 @@
                                                             "wipeFilesystem": {
                                                                 "type": "boolean",
                                                                 "title": "Wipe filesystem",
-                                                                "description": "Whether or not to wipe the device before filesystem creation, see Ignition’s documentation on filesystems for more information https://github.com/coreos/ignition/blob/main/docs/operator-notes.md#filesystem-reuse-semantics."
+                                                                "description": "Whether or not to wipe the device before filesystem creation, see Ignition\u2019s documentation on filesystems for more information https://github.com/coreos/ignition/blob/main/docs/operator-notes.md#filesystem-reuse-semantics."
                                                             }
                                                         }
                                                     },
                                                     "name": {
                                                         "type": "string",
                                                         "title": "Name",
-                                                        "description": "The identifier for the filesystem, internal to Ignition. This is only required if the filesystem needs to be referenced in the “files” section."
+                                                        "description": "The identifier for the filesystem, internal to Ignition. This is only required if the filesystem needs to be referenced in the \u201cfiles\u201d section."
                                                     },
                                                     "path": {
                                                         "type": "string",
                                                         "title": "Path",
-                                                        "description": "The mount-point of the filesystem. A non-null entry indicates that the filesystem has already been mounted by the system at the specified path. This is really only useful for “/sysroot”."
+                                                        "description": "The mount-point of the filesystem. A non-null entry indicates that the filesystem has already been mounted by the system at the specified path. This is really only useful for \u201c/sysroot\u201d."
                                                     }
                                                 }
                                             }
@@ -540,7 +540,7 @@
                             "name": {
                                 "type": "string",
                                 "title": "Name",
-                                "description": "The name of the drop-in. This must be suffixed with “.conf”",
+                                "description": "The name of the drop-in. This must be suffixed with \u201c.conf\u201d",
                                 "pattern": "^.+\\.conf$"
                             }
                         }
@@ -559,7 +559,7 @@
                 "name": {
                     "type": "string",
                     "title": "Name",
-                    "description": "The name of the unit. This must be suffixed with a valid unit type (e.g. “thing.service”)."
+                    "description": "The name of the unit. This must be suffixed with a valid unit type (e.g. \u201cthing.service\u201d)."
                 }
             }
         }
@@ -792,6 +792,14 @@
                         "replicas"
                     ],
                     "properties": {
+                        "apiServerPort": {
+                            "type": "integer",
+                            "title": "API server port",
+                            "description": "The public facing API server Load Balancer port.",
+                            "default": 6443,
+                            "minimum": 0,
+                            "maximum": 65535
+                        },
                         "customNodeTaints": {
                             "$ref": "#/$defs/customNodeTaints"
                         },
@@ -931,6 +939,7 @@
                             }
                         },
                         "name": {
+
                             "type": "string",
                             "title": "Cluster name",
                             "description": "Unique identifier, cannot be changed after creation.",
@@ -1268,6 +1277,7 @@
                                                 "additionalAdmissionPlugins": {
                                                     "type": "array",
                                                     "title": "Additional admission plugins",
+
                                                     "description": "A list of plugins to enable, in addition to the default ones that include DefaultStorageClass, DefaultTolerationSeconds, LimitRanger, MutatingAdmissionWebhook, NamespaceLifecycle, PersistentVolumeClaimResize, Priority, ResourceQuota, ServiceAccount and ValidatingAdmissionWebhook.",
                                                     "items": {
                                                         "type": "string",
@@ -1750,3 +1760,4 @@
         }
     }
 }
+

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -140,7 +140,7 @@
                                 "storage": {
                                     "type": "object",
                                     "title": "Storage",
-                                    "description": "It describes the desired state of the system\u2019s storage devices.",
+                                    "description": "It describes the desired state of the system’s storage devices.",
                                     "properties": {
                                         "directories": {
                                             "type": "array",
@@ -179,7 +179,7 @@
                                                     "mode": {
                                                         "type": "integer",
                                                         "title": "Mode",
-                                                        "description": "The directory\u2019s permission mode."
+                                                        "description": "The directory’s permission mode."
                                                     },
                                                     "overwrite": {
                                                         "type": "boolean",
@@ -194,7 +194,7 @@
                                                     "user": {
                                                         "type": "object",
                                                         "title": "User",
-                                                        "description": "It specifies the directory\u2019s owner.",
+                                                        "description": "It specifies the directory’s owner.",
                                                         "properties": {
                                                             "id": {
                                                                 "type": "integer",
@@ -214,11 +214,11 @@
                                         "filesystems": {
                                             "type": "array",
                                             "title": "File systems",
-                                            "description": "The list of filesystems to be configured and/or used in the \u201cfiles\u201d section. Either \u201cmount\u201d or \u201cpath\u201d needs to be specified.",
+                                            "description": "The list of filesystems to be configured and/or used in the “files” section. Either “mount” or “path” needs to be specified.",
                                             "items": {
                                                 "type": "object",
                                                 "title": "File system",
-                                                "description": "The filesystem to be configured and/or used in the \u201cfiles\u201d section. Either \u201cmount\u201d or \u201cpath\u201d needs to be specified.",
+                                                "description": "The filesystem to be configured and/or used in the “files” section. Either “mount” or “path” needs to be specified.",
                                                 "properties": {
                                                     "mount": {
                                                         "type": "object",
@@ -267,19 +267,19 @@
                                                             "wipeFilesystem": {
                                                                 "type": "boolean",
                                                                 "title": "Wipe filesystem",
-                                                                "description": "Whether or not to wipe the device before filesystem creation, see Ignition\u2019s documentation on filesystems for more information https://github.com/coreos/ignition/blob/main/docs/operator-notes.md#filesystem-reuse-semantics."
+                                                                "description": "Whether or not to wipe the device before filesystem creation, see Ignition’s documentation on filesystems for more information https://github.com/coreos/ignition/blob/main/docs/operator-notes.md#filesystem-reuse-semantics."
                                                             }
                                                         }
                                                     },
                                                     "name": {
                                                         "type": "string",
                                                         "title": "Name",
-                                                        "description": "The identifier for the filesystem, internal to Ignition. This is only required if the filesystem needs to be referenced in the \u201cfiles\u201d section."
+                                                        "description": "The identifier for the filesystem, internal to Ignition. This is only required if the filesystem needs to be referenced in the “files” section."
                                                     },
                                                     "path": {
                                                         "type": "string",
                                                         "title": "Path",
-                                                        "description": "The mount-point of the filesystem. A non-null entry indicates that the filesystem has already been mounted by the system at the specified path. This is really only useful for \u201c/sysroot\u201d."
+                                                        "description": "The mount-point of the filesystem. A non-null entry indicates that the filesystem has already been mounted by the system at the specified path. This is really only useful for “/sysroot”."
                                                     }
                                                 }
                                             }
@@ -540,7 +540,7 @@
                             "name": {
                                 "type": "string",
                                 "title": "Name",
-                                "description": "The name of the drop-in. This must be suffixed with \u201c.conf\u201d",
+                                "description": "The name of the drop-in. This must be suffixed with “.conf”",
                                 "pattern": "^.+\\.conf$"
                             }
                         }
@@ -559,7 +559,7 @@
                 "name": {
                     "type": "string",
                     "title": "Name",
-                    "description": "The name of the unit. This must be suffixed with a valid unit type (e.g. \u201cthing.service\u201d)."
+                    "description": "The name of the unit. This must be suffixed with a valid unit type (e.g. “thing.service”)."
                 }
             }
         }
@@ -797,8 +797,8 @@
                             "title": "API server port",
                             "description": "The public facing API server Load Balancer port.",
                             "default": 6443,
-                            "minimum": 0,
-                            "maximum": 65535
+                            "maximum": 65535,
+                            "minimum": 0
                         },
                         "customNodeTaints": {
                             "$ref": "#/$defs/customNodeTaints"
@@ -1758,4 +1758,3 @@
         }
     }
 }
-

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -66,7 +66,7 @@ providerIntegration:
             storage: {}
             systemd: {}
       localAPIEndpoint:
-        bindPort: 443
+        bindPort: 6443
     resources:
       controlPlane:
         api:

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -21,6 +21,7 @@ global:
     proxy:
       enabled: false
   controlPlane:
+    apiServerPort: 6443
     machineHealthCheck:
       enabled: true
       maxUnhealthy: 40%

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -21,7 +21,7 @@ global:
     proxy:
       enabled: false
   controlPlane:
-    apiServerPort: 443
+    apiServerPort: 6443
     machineHealthCheck:
       enabled: true
       maxUnhealthy: 40%

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -21,7 +21,7 @@ global:
     proxy:
       enabled: false
   controlPlane:
-    apiServerPort: 6443
+    apiServerPort: 443
     machineHealthCheck:
       enabled: true
       maxUnhealthy: 40%
@@ -66,7 +66,7 @@ providerIntegration:
             storage: {}
             systemd: {}
       localAPIEndpoint:
-        bindPort: 6443
+        bindPort: 443
     resources:
       controlPlane:
         api:


### PR DESCRIPTION
### What does this PR do?

Adds a new value - `global.controlPlane.apiServer`. This configures the public facing port for the API on the LoadBalancer
(Please set a descriptive PR title. Use this space for additional explanations.)

### What is the effect of this change to users?

New value, also changes the default from 6443 to 443 on CAPA.

### How does it look like?

N/A

### Any background context you can provide?

https://github.com/giantswarm/roadmap/issues/3055

### What is needed from the reviewers?

Make sure e2e tests pass. Agree on the value name.

### Do the docs need to be updated?

It's a new value so probably yes?

### Should this change be mentioned in the release notes?

Yes

- [x] CHANGELOG.md has been updated (if it exists)
