### PR TITLE
Add podSecurityStandards.enforced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add custom `files` config to Helm value to `.Values.internal.advancedConfiguration`.
 - Add custom `preKubeadmCommands` config to Helm value to `.Values.internal.advancedConfiguration`.
 - Add custom `postKubeadmCommands` config to Helm value to `.Values.internal.advancedConfiguration`.
+- Add `global.podSecurityStandards.enforced` value which sets `policy.giantswarm.io/psp-status: disabled` label on the Cluster CR.
 
 ### Changed
 

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -185,6 +185,13 @@ Properties within the `.global.nodePools` object
 | :----------- | :-------------- | :--------------- |
 | `global.managementCluster` | **Management cluster** - Name of the Cluster API cluster managing this workload cluster.|**Type:** `string`<br/>|
 
+### Pod Security Standards
+Properties within the `.global.podSecurityStandards` object
+
+| **Property** | **Description** | **More Details** |
+| :----------- | :-------------- | :--------------- |
+| `global.podSecurityStandards.enforced` | **Enforced**|**Type:** `boolean`<br/>**Default:** `false`|
+
 ### Provider integration
 Properties within the `.providerIntegration` top-level object
 Provider-specific properties that can be set by cluster-$provider chart in order to render correct templates for the provider.

--- a/helm/cluster/templates/clusterapi/cluster.yaml
+++ b/helm/cluster/templates/clusterapi/cluster.yaml
@@ -15,6 +15,9 @@ metadata:
     {{- include "cluster.labels.common" $ | nindent 4 }}
     {{- include "cluster.labels.preventDeletion" $ | indent 4 }}
     {{- include "cluster.labels.custom" $ | indent 4 }}
+    {{- if .Values.global.podSecurityStandards.enforced }}
+    policy.giantswarm.io/psp-status: disabled
+    {{- end }}
   name: {{ include "cluster.resource.name" $ }}
   namespace: {{ .Release.Namespace }}
 spec:

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_apiserver.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_apiserver.tpl
@@ -135,7 +135,7 @@ api-audiences-example.giantswarm.io
 
 {{- define "cluster.internal.controlPlane.kubeadm.clusterConfiguration.apiServer.featureGates" }}
 {{- $featureGates := list -}}
-{{- if semverCompare "<1.25-0" .Values.internal.kubernetesVersion -}}
+{{- if semverCompare "<1.25-0" .Values.providerIntegration.kubernetesVersion -}}
 {{- $featureGates = append $featureGates "TTLAfterFinished=true" -}}
 {{- end -}}
 {{- range $featureGate := $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_apiserver.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_apiserver.tpl
@@ -135,6 +135,9 @@ api-audiences-example.giantswarm.io
 
 {{- define "cluster.internal.controlPlane.kubeadm.clusterConfiguration.apiServer.featureGates" }}
 {{- $featureGates := list -}}
+{{- if semverCompare "<1.25-0" .Values.internal.kubernetesVersion -}}
+{{- $featureGates = append $featureGates "TTLAfterFinished=true" -}}
+{{- end -}}
 {{- range $featureGate := $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates }}
 {{- $featureGates = append $featureGates (printf "%s=%t" $featureGate.name $featureGate.enabled) -}}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_apiserver.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_apiserver.tpl
@@ -135,9 +135,6 @@ api-audiences-example.giantswarm.io
 
 {{- define "cluster.internal.controlPlane.kubeadm.clusterConfiguration.apiServer.featureGates" }}
 {{- $featureGates := list -}}
-{{- if semverCompare "<1.25-0" .Values.providerIntegration.kubernetesVersion -}}
-{{- $featureGates = append $featureGates "TTLAfterFinished=true" -}}
-{{- end -}}
 {{- range $featureGate := $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates }}
 {{- $featureGates = append $featureGates (printf "%s=%t" $featureGate.name $featureGate.enabled) -}}
 {{- end }}

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1057,6 +1057,17 @@
                             }
                         }
                     }
+                },
+                "podSecurityStandards": {
+                    "type": "object",
+                    "title": "Pod Security Standards",
+                    "properties": {
+                        "enforced": {
+                            "type": "boolean",
+                            "title": "Enforced",
+                            "default": false
+                        }
+                    }
                 }
             }
         },

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -33,6 +33,8 @@ global:
   metadata:
     preventDeletion: false
     servicePriority: highest
+  podSecurityStandards:
+    enforced: false
 internal:
   advancedConfiguration:
     cgroupsv1: false


### PR DESCRIPTION
### What does this PR do?

`Sets policy.giantswarm.io/psp-status: disabled` on the Cluster CR. This is needed for upgrading to kubernetes 1.25

### What is the effect of this change to users?

None, this is just necessary for upgrading to 1.25

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/2925

### Do the docs need to be updated?
no

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
