### PR TITLE
Align API for properties that can be set as pre-defined static values and/or via templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Align API for properties that can be set as pre-defined static values and/or via templates.
+
 ## [0.2.1] - 2024-01-17
 
 ### Added

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -205,10 +205,10 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.components.systemd` | **systemd**||
 | `providerIntegration.connectivity` | **Connectivity** - Internal connectivity configuration.|**Type:** `object`<br/>|
 | `providerIntegration.connectivity.proxy` | **Proxy** - Whether/how outgoing traffic is routed through proxy servers.|**Type:** `object`<br/>|
-| `providerIntegration.connectivity.proxy.noProxy` | **No proxy**|**Type:** `object`<br/>|
-| `providerIntegration.connectivity.proxy.noProxy.addresses` | **Addresses** - To be passed to the NO_PROXY environment variable in all hosts.|**Type:** `array`<br/>|
-| `providerIntegration.connectivity.proxy.noProxy.addressesTemplate` | **Addresses template** - Name of Helm template that renders a YAML array with NO_PROXY addresses.|**Type:** `string`<br/>|
-| `providerIntegration.connectivity.proxy.noProxy.addresses[*]` |**None**|**Type:** `string`<br/>|
+| `providerIntegration.connectivity.proxy.noProxy` | **No proxy** - To be passed to the NO_PROXY environment variable in all hosts.|**Type:** `object`<br/>|
+| `providerIntegration.connectivity.proxy.noProxy.templateName` | **Template name** - Name of Helm template that renders a YAML array with NO_PROXY addresses.|**Type:** `string`<br/>|
+| `providerIntegration.connectivity.proxy.noProxy.value` | **Value** - Pre-defined static NO_PROXY values.|**Type:** `array`<br/>|
+| `providerIntegration.connectivity.proxy.noProxy.value[*]` |**None**|**Type:** `string`<br/>|
 | `providerIntegration.connectivity.sshSsoPublicKey` | **SSH public key for single sign-on**|**Type:** `string`<br/>**Default:** `"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"`|
 | `providerIntegration.controlPlane` | **Internal control plane configuration**|**Type:** `object`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig` | **Kubeadm config** - Configuration of control plane nodes.|**Type:** `object`<br/>|

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -85,10 +85,10 @@ providerIntegration:
   connectivity:
     proxy:
       noProxy:
-        addresses:
+        value:
         - elb.amazonaws.com
         - 169.254.169.254
-        addressesTemplate: "cluster.test.internal.kubeadm.proxy.anotherNoProxyList"
+        templateName: "cluster.test.internal.kubeadm.proxy.anotherNoProxyList"
   controlPlane:
     kubeadmConfig:
       clusterConfiguration:

--- a/helm/cluster/ci/test-dummy-values.yaml
+++ b/helm/cluster/ci/test-dummy-values.yaml
@@ -1,0 +1,2 @@
+# CI needs at least one test-<something>-values.yaml file
+global: {}

--- a/helm/cluster/ci/test-dummy-values.yaml
+++ b/helm/cluster/ci/test-dummy-values.yaml
@@ -1,2 +1,0 @@
-# CI needs at least one test-<something>-values.yaml file
-global: {}

--- a/helm/cluster/ci/test-required-values.yaml
+++ b/helm/cluster/ci/test-required-values.yaml
@@ -5,6 +5,7 @@ global:
   connectivity:
     baseDomain: example.gigantic.io
 providerIntegration:
+  provider: aws
   resourcesApi:
     bastionResourceEnabled: false
     clusterResourceEnabled: true

--- a/helm/cluster/ci/test-required-values.yaml
+++ b/helm/cluster/ci/test-required-values.yaml
@@ -1,0 +1,25 @@
+global:
+  metadata:
+    name: awesome
+    organization: giantswarm
+  connectivity:
+    baseDomain: example.gigantic.io
+providerIntegration:
+  resourcesApi:
+    bastionResourceEnabled: false
+    clusterResourceEnabled: true
+    controlPlaneResourceEnabled: true
+    infrastructureCluster:
+      group: infrastructure.cluster.x-k8s.io
+      kind: GiantCluster
+      version: v1beta1
+    machineHealthCheckResourceEnabled: false
+    machinePoolResourcesEnabled: false
+    nodePoolKind: MachinePool
+  controlPlane:
+    resources:
+      infrastructureMachineTemplate:
+        group: infrastructure.cluster.x-k8s.io
+        kind: GiantMachineTemplate
+        version: v1beta1
+      infrastructureMachineTemplateSpecTemplateName: cluster.internal.test.controlPlane.machineTemplate.spec

--- a/helm/cluster/templates/clusterapi/_helpers.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers.tpl
@@ -17,12 +17,12 @@
 {{- $noProxyList = append $noProxyList $podsCidrBlock -}}
 {{- end }}
 {{- /* Add provider-specific NO_PROXY values */}}
-{{- range $noProxyAddress := $.Values.providerIntegration.connectivity.proxy.noProxy.addresses }}
+{{- range $noProxyAddress := $.Values.providerIntegration.connectivity.proxy.noProxy.value }}
 {{- $noProxyList = append $noProxyList $noProxyAddress -}}
 {{- end }}
 {{- /* Add provider-specific NO_PROXY values from template */}}
-{{- if $.Values.providerIntegration.connectivity.proxy.noProxy.addressesTemplate }}
-{{- range $noProxyAddress := include $.Values.providerIntegration.connectivity.proxy.noProxy.addressesTemplate $ | fromYamlArray }}
+{{- if $.Values.providerIntegration.connectivity.proxy.noProxy.templateName }}
+{{- range $noProxyAddress := include $.Values.providerIntegration.connectivity.proxy.noProxy.templateName $ | fromYamlArray }}
 {{- $noProxyList = append $noProxyList $noProxyAddress -}}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_apiserver.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_apiserver.tpl
@@ -71,9 +71,9 @@ extraVolumes:
 {{- end }}
 
 {{- define "cluster.internal.controlPlane.kubeadm.clusterConfiguration.apiServer.apiAudiences" }}
-{{- if kindIs "string" $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.apiAudiences }}
-{{ $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.apiAudiences | trim }}
-{{- else if $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.apiAudiences.templateName }}
+{{- if ($.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.apiAudiences).value }}
+{{ $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.apiAudiences.value | trim }}
+{{- else if ($.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.apiAudiences).templateName }}
 {{ include $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.apiAudiences.templateName $ | trim }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1217,19 +1217,20 @@
                                 "noProxy": {
                                     "type": "object",
                                     "title": "No proxy",
+                                    "description": "To be passed to the NO_PROXY environment variable in all hosts.",
                                     "properties": {
-                                        "addresses": {
+                                        "templateName": {
+                                            "type": "string",
+                                            "title": "Template name",
+                                            "description": "Name of Helm template that renders a YAML array with NO_PROXY addresses."
+                                        },
+                                        "value": {
                                             "type": "array",
-                                            "title": "Addresses",
-                                            "description": "To be passed to the NO_PROXY environment variable in all hosts.",
+                                            "title": "Value",
+                                            "description": "Pre-defined static NO_PROXY values.",
                                             "items": {
                                                 "type": "string"
                                             }
-                                        },
-                                        "addressesTemplate": {
-                                            "type": "string",
-                                            "title": "Addresses template",
-                                            "description": "Name of Helm template that renders a YAML array with NO_PROXY addresses."
                                         }
                                     }
                                 }

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1290,21 +1290,42 @@
                                                             "type": "null"
                                                         },
                                                         {
-                                                            "type": "string"
-                                                        },
-                                                        {
                                                             "type": "object",
-                                                            "required": [
-                                                                "templateName"
-                                                            ],
                                                             "additionalProperties": false,
                                                             "properties": {
                                                                 "templateName": {
                                                                     "type": "string",
                                                                     "title": "Template name",
                                                                     "description": "The name of the Helm template which renders the 'api-audiences' value"
+                                                                },
+                                                                "value": {
+                                                                    "type": "string",
+                                                                    "title": "Value",
+                                                                    "description": "Static value for api-audiences."
                                                                 }
-                                                            }
+                                                            },
+                                                            "oneOf": [
+                                                                {
+                                                                    "required": [
+                                                                        "templateName"
+                                                                    ],
+                                                                    "not": {
+                                                                        "required": [
+                                                                            "value"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "required": [
+                                                                        "value"
+                                                                    ],
+                                                                    "not": {
+                                                                        "required": [
+                                                                            "templateName"
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
                                                         }
                                                     ]
                                                 },


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3047

### What does this PR do?

This PR aligns Helm values API for properties that can be set as pre-defined static values and/or via templates.

### How does it look like?

Before:

```
  connectivity:
    proxy:
      noProxy:
        addresses:
        - elb.amazonaws.com
        - 169.254.169.254
        addressesTemplate: "providerNoProxyTemplateName"
...
          apiAudiences:
            templateName: "providerApiAudiencesTemplateName"
```

After:

```
  connectivity:
    proxy:
      noProxy:
        value:
        - elb.amazonaws.com
        - 169.254.169.254
        templateName: "providerNoProxyTemplateName"
...
          apiAudiences:
            templateName: "providerApiAudiencesTemplateName"
```

### Any background context you can provide?

https://github.com/giantswarm/cluster-aws/pull/479#discussion_r1455427379

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
