### PR TITLE
Improve NO_PROXY template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Align API for properties that can be set as pre-defined static values and/or via templates.
+- Improve NO_PROXY template: rename to cluster.connectivity.proxy.noProxy, make it public and usable from other charts.
 
 ## [0.2.1] - 2024-01-17
 

--- a/helm/cluster/files/etc/systemd/http-proxy.conf
+++ b/helm/cluster/files/etc/systemd/http-proxy.conf
@@ -1,7 +1,7 @@
 [Service]
 Environment="HTTP_PROXY={{ $.Values.global.connectivity.proxy.httpProxy }}"
 Environment="HTTPS_PROXY={{ $.Values.global.connectivity.proxy.httpsProxy }}"
-Environment="NO_PROXY={{ include "cluster.internal.kubeadm.proxy.noProxyList" $ }}"
+Environment="NO_PROXY={{ include "cluster.connectivity.proxy.noProxy" (dict "global" $.Values.global "providerIntegration" $.Values.providerIntegration) }}"
 Environment="http_proxy={{ $.Values.global.connectivity.proxy.httpProxy }}"
 Environment="https_proxy={{ $.Values.global.connectivity.proxy.httpsProxy }}"
-Environment="no_proxy={{ include "cluster.internal.kubeadm.proxy.noProxyList" $ }}"
+Environment="no_proxy={{ include "cluster.connectivity.proxy.noProxy" (dict "global" $.Values.global "providerIntegration" $.Values.providerIntegration) }}"

--- a/helm/cluster/templates/clusterapi/_helpers.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers.tpl
@@ -26,7 +26,7 @@
 {{- define "cluster.connectivity.proxy.noProxy" }}
 {{- $global := .global }}
 {{- $metadata := $global.metadata }}
-{{- $connectivity := $global.connectivity }}=
+{{- $connectivity := $global.connectivity }}
 {{- $providerIntegration := .providerIntegration }}
 {{- /* Static NO_PROXY values */}}
 {{- $noProxyList := list

--- a/helm/cluster/templates/clusterapi/_helpers.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers.tpl
@@ -1,4 +1,33 @@
-{{- define "cluster.internal.kubeadm.proxy.noProxyList" }}
+{{/*
+  "cluster.connectivity.proxy.noProxy" template renders the NO_PROXY value as a comma-separated string.
+
+  Template argument is a dictionary with the following keys:
+  - "global": mapped to $.Values.global,
+  - "providerIntegration": mapped to provider-integration object.
+
+  Example usage when inlcuded in the cluster chart:
+    {{ include "cluster.connectivity.proxy.noProxy" (dict "global" $.Values.global "providerIntegration" $.Values.providerIntegration) }}
+
+  Example usage when inlcuded in the parent chart (cluster-<provider> app):
+    {{ include "cluster.connectivity.proxy.noProxy" (dict "global" $.Values.global "providerIntegration" $.Values.cluster.providerIntegration) }}
+
+  You can notice in the above two examples that "providerIntegration" dict key is set to different Helm values, depending
+  on from which chart it has been called. That is because the cluster chart value $.Values.providerIntegration is set as
+  $.Values.cluster.providerIntegration in the parent chart (cluster-<provider> app).
+
+  The rendered NO_PROXY value includes the following hosts, IP addresses and ranges:
+  1. Static values "127.0.0.1", "localhost", "svc" and "local",
+  2. Cluster domain in format "<cluster name>.<base domain>",
+  3. Kubernetes services CIDR range, e.g. "172.31.0.0/16",
+  4. Kubernetes pods CIDR range, e.g. "100.64.0.0/12",
+  5. Provider-specific noProxy values specified in $.Values.providerIntegration.connectivity.proxy.noProxy, and
+  6. Customer-provider cluster-specific noProxy values specified in $.Values.global.connectivity.proxy.noProxy.
+*/}}
+{{- define "cluster.connectivity.proxy.noProxy" }}
+{{- $global := .global }}
+{{- $metadata := $global.metadata }}
+{{- $connectivity := $global.connectivity }}=
+{{- $providerIntegration := .providerIntegration }}
 {{- /* Static NO_PROXY values */}}
 {{- $noProxyList := list
   "127.0.0.1"
@@ -7,28 +36,28 @@
   "local"
 -}}
 {{- /* Add cluster domain */}}
-{{- $noProxyList = append $noProxyList (printf "%s.%s" (include "cluster.resource.name" $) $.Values.global.connectivity.baseDomain) -}}
+{{- $noProxyList = append $noProxyList (printf "%s.%s" $metadata.name $connectivity.baseDomain) -}}
 {{- /* Add services CIDR blocks */}}
-{{- range $servicesCidrBlock := $.Values.global.connectivity.network.services.cidrBlocks }}
+{{- range $servicesCidrBlock := $connectivity.network.services.cidrBlocks }}
 {{- $noProxyList = append $noProxyList $servicesCidrBlock -}}
 {{- end }}
 {{- /* Add pods CIDR blocks */}}
-{{- range $podsCidrBlock := $.Values.global.connectivity.network.pods.cidrBlocks }}
+{{- range $podsCidrBlock := $connectivity.network.pods.cidrBlocks }}
 {{- $noProxyList = append $noProxyList $podsCidrBlock -}}
 {{- end }}
 {{- /* Add provider-specific NO_PROXY values */}}
-{{- range $noProxyAddress := $.Values.providerIntegration.connectivity.proxy.noProxy.value }}
+{{- range $noProxyAddress := $providerIntegration.connectivity.proxy.noProxy.value }}
 {{- $noProxyList = append $noProxyList $noProxyAddress -}}
 {{- end }}
 {{- /* Add provider-specific NO_PROXY values from template */}}
-{{- if $.Values.providerIntegration.connectivity.proxy.noProxy.templateName }}
-{{- range $noProxyAddress := include $.Values.providerIntegration.connectivity.proxy.noProxy.templateName $ | fromYamlArray }}
+{{- if $providerIntegration.connectivity.proxy.noProxy.templateName }}
+{{- range $noProxyAddress := include $providerIntegration.connectivity.proxy.noProxy.templateName $ | fromYamlArray }}
 {{- $noProxyList = append $noProxyList $noProxyAddress -}}
 {{- end }}
 {{- end }}
 {{- /* Add custom NO_PROXY values */}}
-{{- if $.Values.global.connectivity.proxy.noProxy }}
-{{- $customNoProxy := split "," $.Values.global.connectivity.proxy.noProxy }}
+{{- if $connectivity.proxy.noProxy }}
+{{- $customNoProxy := split "," $connectivity.proxy.noProxy }}
 {{- range $noProxyAddress := $customNoProxy }}
 {{- $noProxyList = append $noProxyList $noProxyAddress -}}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/_helpers_prekubeadmcommands.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_prekubeadmcommands.tpl
@@ -29,10 +29,10 @@
 {{- if and $.Values.global.connectivity.proxy $.Values.global.connectivity.proxy.enabled }}
 - export HTTP_PROXY={{ $.Values.global.connectivity.proxy.httpProxy }}
 - export HTTPS_PROXY={{ $.Values.global.connectivity.proxy.httpsProxy }}
-- export NO_PROXY="{{ include "cluster.internal.kubeadm.proxy.noProxyList" $ }}"
+- export NO_PROXY="{{ include "cluster.connectivity.proxy.noProxy" (dict "global" $.Values.global "providerIntegration" $.Values.providerIntegration) }}"
 - export http_proxy={{ $.Values.global.connectivity.proxy.httpProxy }}
 - export https_proxy={{ $.Values.global.connectivity.proxy.httpsProxy }}
-- export no_proxy="{{ include "cluster.internal.kubeadm.proxy.noProxyList" $ }}"
+- export no_proxy="{{ include "cluster.connectivity.proxy.noProxy" (dict "global" $.Values.global "providerIntegration" $.Values.providerIntegration) }}"
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3047

### What does this PR do?

Coming from https://github.com/giantswarm/cluster-aws/pull/479#discussion_r1455411843

This PR does few things:
- It renames NO_PROXY template from `cluster.internal.kubeadm.proxy.noProxyList` to `cluster.connectivity.proxy.noProxy`
  - So this named template is not internal anymore, and now it can be considered public API offered by the cluster chart.
- It refactors the `cluster.connectivity.proxy.noProxy` template so it can be correctly called from other charts (e.g. render NO_PROXY value in cluster-aws).

### What is the effect of this change to users?

Developers from provider-integration KaaS teams can use `cluster.connectivity.proxy.noProxy` template to render NO_PROXY value consistently in their charts.

### How does it look like?

Example usage when inlcuded in the cluster chart:

```
{{ include "cluster.connectivity.proxy.noProxy" (dict "global" $.Values.global "providerIntegration" $.Values.providerIntegration) }}
```

Example usage when inlcuded in the parent chart (cluster-\<provider\> app):

```
{{ include "cluster.connectivity.proxy.noProxy" (dict "global" $.Values.global "providerIntegration" $.Values.cluster.providerIntegration) }}
```

### Any background context you can provide?

PR review in cluster-aws where Nick spotted an issue with NO_PROXY value rendering https://github.com/giantswarm/cluster-aws/pull/479#discussion_r1455411843


### Do the docs need to be updated?

Yes. Updated Helm template docs.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
