### PR TITLE
Move customisable advanced properties to Values.internal.advancedConfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move API server `bindPort` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
 - Move `files` config for all nodes to Helm value to `.Values.internal.advancedConfiguration`.
 - Move control plane `files` config to Helm value to `.Values.internal.advancedConfiguration.controlPlane`.
+- Move worker `files` config to Helm value to `.Values.internal.advancedConfiguration.workers`.
 
 ## [0.2.1] - 2024-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move API server `extraArgs` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
 - Move API server `etcdPrefix` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
 - Move API server `bindPort` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
+- Move advanced etcd config to `.Values.internal.advancedConfiguration.controlPlane.etcd`.
 
 ## [0.3.1] - 2024-01-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add custom `files` config for all nodes to Helm value to `.Values.internal.advancedConfiguration`.
-- Add custom control plane `files` config to Helm value to `.Values.internal.advancedConfiguration.controlPlane`.
-- Add custom worker `files` config to Helm value to `.Values.internal.advancedConfiguration.workers`.
+- Add custom `files` config to Helm value to `.Values.internal.advancedConfiguration`.
+- Add custom `preKubeadmCommands` config to Helm value to `.Values.internal.advancedConfiguration`.
+- Add custom `postKubeadmCommands` config to Helm value to `.Values.internal.advancedConfiguration`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move API server `extraCertificateSANs` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
 - Move API server `extraArgs` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
 - Move API server `etcdPrefix` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
+- Move API server `bindPort` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
 
 ## [0.2.1] - 2024-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add custom `files` config for all nodes to Helm value to `.Values.internal.advancedConfiguration`.
+- Add custom control plane `files` config to Helm value to `.Values.internal.advancedConfiguration.controlPlane`.
+- Add custom worker `files` config to Helm value to `.Values.internal.advancedConfiguration.workers`.
+
+### Changed
+
+- Move API server `extraCertificateSANs` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
+- Move API server `extraArgs` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
+- Move API server `etcdPrefix` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
+- Move API server `bindPort` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
+
 ## [0.3.1] - 2024-01-23
 
 ### Fixed
@@ -21,13 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Align API for properties that can be set as pre-defined static values and/or via templates.
 - Improve NO_PROXY template: rename to cluster.connectivity.proxy.noProxy, make it public and usable from other charts.
-- Move API server `extraCertificateSANs` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
-- Move API server `extraArgs` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
-- Move API server `etcdPrefix` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
-- Move API server `bindPort` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
-- Move `files` config for all nodes to Helm value to `.Values.internal.advancedConfiguration`.
-- Move control plane `files` config to Helm value to `.Values.internal.advancedConfiguration.controlPlane`.
-- Move worker `files` config to Helm value to `.Values.internal.advancedConfiguration.workers`.
 
 ## [0.2.1] - 2024-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve NO_PROXY template: rename to cluster.connectivity.proxy.noProxy, make it public and usable from other charts.
 - Move API server `extraCertificateSANs` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
 - Move API server `extraArgs` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
+- Move API server `etcdPrefix` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
 
 ## [0.2.1] - 2024-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move API server `extraArgs` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
 - Move API server `etcdPrefix` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
 - Move API server `bindPort` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
-- Move `files` for all nodes to Helm value to `.Values.internal.advancedConfiguration`.
+- Move `files` config for all nodes to Helm value to `.Values.internal.advancedConfiguration`.
+- Move control plane `files` config to Helm value to `.Values.internal.advancedConfiguration.controlPlane`.
 
 ## [0.2.1] - 2024-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move API server `extraArgs` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
 - Move API server `etcdPrefix` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
 - Move API server `bindPort` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
+- Move `files` for all nodes to Helm value to `.Values.internal.advancedConfiguration`.
 
 ## [0.2.1] - 2024-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Align API for properties that can be set as pre-defined static values and/or via templates.
 - Improve NO_PROXY template: rename to cluster.connectivity.proxy.noProxy, make it public and usable from other charts.
-- Move `extraCertificateSANs` property to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
+- Move API server `extraCertificateSANs` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
+- Move API server `extraArgs` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
 
 ## [0.2.1] - 2024-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Align API for properties that can be set as pre-defined static values and/or via templates.
 - Improve NO_PROXY template: rename to cluster.connectivity.proxy.noProxy, make it public and usable from other charts.
+- Move `extraCertificateSANs` property to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
 
 ## [0.2.1] - 2024-01-17
 

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -242,7 +242,7 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.connectivity.proxy.noProxy.value` | **Value** - Pre-defined static NO_PROXY values.|**Type:** `array`<br/>|
 | `providerIntegration.connectivity.proxy.noProxy.value[*]` |**None**|**Type:** `string`<br/>|
 | `providerIntegration.connectivity.sshSsoPublicKey` | **SSH public key for single sign-on**|**Type:** `string`<br/>**Default:** `"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"`|
-| `providerIntegration.controlPlane` | **Internal control plane configuration**|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane` | **Provider-specific control plane configuration**|**Type:** `object`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig` | **Kubeadm config** - Configuration of control plane nodes.|**Type:** `object`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration` | **Cluster configuration** - Configuration of Kubernetes components.|**Type:** `object`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer` | **API server** - Configuration of API server.|**Type:** `object`<br/>**Default:** `{}`|
@@ -260,6 +260,14 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.etcd.extraArgs` | **Extra args**|**Type:** `object`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.etcd.initialCluster` | **Initial cluster** - Initial cluster configuration for bootstrapping.|**Type:** `string`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.etcd.initialClusterState` | **Initial cluster state**|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.files` | **Files** - These are the files that are included on control plane nodes.|**Type:** `array`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.files[*].contentFrom.secret` | **Secret** - Kubernetes Secret resource with the file content.|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.files[*].contentFrom.secret.key` | **Key** - Secret key where the file content is.|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.files[*].contentFrom.secret.name` | **Name** - Name of the Secret resource.|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.files[*].path` | **Path** - File path on the node.|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.files[*].permissions` | **Permissions** - File permissions in form 0644|**Type:** `string`<br/>**Default:** `"0644"`|
 | `providerIntegration.controlPlane.kubeadmConfig.ignition` | **Ignition** - Ignition-specific configuration.|**Type:** `object`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig` | **Container Linux configuration**|**Type:** `object`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig` | **Additional config** - Additional configuration to be merged with the Ignition. More info: https://coreos.github.io/ignition/operator-notes/#config-merging.|**Type:** `object`<br/>|
@@ -327,6 +335,14 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.controlPlane.resources.infrastructureMachineTemplateSpecTemplateName` | **Infrastructure Machine template spec template name** - The name of Helm template that renders Infrastructure Machine template spec.|**Type:** `string`<br/>|
 | `providerIntegration.hashSalt` | **Hash salt** - If specified, this token is used as a salt to the hash suffix of some resource names. Can be used to force-recreate some resources.|**Type:** `string`<br/>|
 | `providerIntegration.kubeadmConfig` | **Kubeadm config** - Common kubeadm config for all nodes, including both control plane and workers.|**Type:** `object`<br/>|
+| `providerIntegration.kubeadmConfig.files` | **Files** - These are the files that are included on control plane nodes.|**Type:** `array`<br/>|
+| `providerIntegration.kubeadmConfig.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
+| `providerIntegration.kubeadmConfig.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|
+| `providerIntegration.kubeadmConfig.files[*].contentFrom.secret` | **Secret** - Kubernetes Secret resource with the file content.|**Type:** `object`<br/>|
+| `providerIntegration.kubeadmConfig.files[*].contentFrom.secret.key` | **Key** - Secret key where the file content is.|**Type:** `string`<br/>|
+| `providerIntegration.kubeadmConfig.files[*].contentFrom.secret.name` | **Name** - Name of the Secret resource.|**Type:** `string`<br/>|
+| `providerIntegration.kubeadmConfig.files[*].path` | **Path** - File path on the node.|**Type:** `string`<br/>|
+| `providerIntegration.kubeadmConfig.files[*].permissions` | **Permissions** - File permissions in form 0644|**Type:** `string`<br/>**Default:** `"0644"`|
 | `providerIntegration.kubeadmConfig.ignition` | **Ignition** - Ignition-specific configuration.|**Type:** `object`<br/>|
 | `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig` | **Container Linux configuration**|**Type:** `object`<br/>|
 | `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig` | **Additional config** - Additional configuration to be merged with the Ignition. More info: https://coreos.github.io/ignition/operator-notes/#config-merging.|**Type:** `object`<br/>|
@@ -399,8 +415,16 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.teleport.enabled` | **Enable teleport**|**Type:** `boolean`<br/>**Default:** `true`|
 | `providerIntegration.teleport.proxyAddr` | **Teleport proxy address**|**Type:** `string`<br/>**Default:** `"teleport.giantswarm.io:443"`|
 | `providerIntegration.teleport.version` | **Teleport version**|**Type:** `string`<br/>**Default:** `"14.1.3"`|
-| `providerIntegration.workers` | **Internal workers configuration**|**Type:** `object`<br/>|
+| `providerIntegration.workers` | **Provider-specific workers configuration**|**Type:** `object`<br/>|
 | `providerIntegration.workers.kubeadmConfig` | **Kubeadm config** - Configuration of workers nodes.|**Type:** `object`<br/>|
+| `providerIntegration.workers.kubeadmConfig.files` | **Files** - These are the files that are included on worker nodes.|**Type:** `array`<br/>|
+| `providerIntegration.workers.kubeadmConfig.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
+| `providerIntegration.workers.kubeadmConfig.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|
+| `providerIntegration.workers.kubeadmConfig.files[*].contentFrom.secret` | **Secret** - Kubernetes Secret resource with the file content.|**Type:** `object`<br/>|
+| `providerIntegration.workers.kubeadmConfig.files[*].contentFrom.secret.key` | **Key** - Secret key where the file content is.|**Type:** `string`<br/>|
+| `providerIntegration.workers.kubeadmConfig.files[*].contentFrom.secret.name` | **Name** - Name of the Secret resource.|**Type:** `string`<br/>|
+| `providerIntegration.workers.kubeadmConfig.files[*].path` | **Path** - File path on the node.|**Type:** `string`<br/>|
+| `providerIntegration.workers.kubeadmConfig.files[*].permissions` | **Permissions** - File permissions in form 0644|**Type:** `string`<br/>**Default:** `"0644"`|
 | `providerIntegration.workers.kubeadmConfig.ignition` | **Ignition** - Ignition-specific configuration.|**Type:** `object`<br/>|
 | `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig` | **Container Linux configuration**|**Type:** `object`<br/>|
 | `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig` | **Additional config** - Additional configuration to be merged with the Ignition. More info: https://coreos.github.io/ignition/operator-notes/#config-merging.|**Type:** `object`<br/>|

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -117,7 +117,7 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.advancedConfiguration.files[*].contentFrom.secret.name` | **Name** - Name of the Secret resource.|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.files[*].path` | **Path** - File path on the node.|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.files[*].permissions` | **Permissions** - File permissions in form 0644|**Type:** `string`<br/>**Default:** `"0644"`|
-| `internal.advancedConfiguration.workers` | **Workers** - Advanced configuration of worker nodes|**Type:** `object`<br/>|
+| `internal.advancedConfiguration.workers` | **Workers** - Advanced configuration of worker nodes.|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.workers.files` | **Files** - These are the files that are included on worker nodes.|**Type:** `array`<br/>|
 | `internal.advancedConfiguration.workers.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.workers.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -109,6 +109,10 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.advancedConfiguration.controlPlane.files[*].contentFrom.secret.name` | **Name** - Name of the Secret resource.|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.controlPlane.files[*].path` | **Path** - File path on the node.|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.controlPlane.files[*].permissions` | **Permissions** - File permissions in form 0644|**Type:** `string`<br/>**Default:** `"0644"`|
+| `internal.advancedConfiguration.controlPlane.postKubeadmCommands` | **Post-kubeadm commands** - Extra commands to run after kubeadm runs.|**Type:** `array`<br/>|
+| `internal.advancedConfiguration.controlPlane.postKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
+| `internal.advancedConfiguration.controlPlane.preKubeadmCommands` | **Pre-kubeadm commands** - Extra commands to run before kubeadm runs.|**Type:** `array`<br/>|
+| `internal.advancedConfiguration.controlPlane.preKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.files` | **Files** - Custom cluster-specific files that are deployed to all nodes.|**Type:** `array`<br/>|
 | `internal.advancedConfiguration.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|
@@ -117,6 +121,10 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.advancedConfiguration.files[*].contentFrom.secret.name` | **Name** - Name of the Secret resource.|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.files[*].path` | **Path** - File path on the node.|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.files[*].permissions` | **Permissions** - File permissions in form 0644|**Type:** `string`<br/>**Default:** `"0644"`|
+| `internal.advancedConfiguration.postKubeadmCommands` | **Post-kubeadm commands** - Extra commands to run after kubeadm runs.|**Type:** `array`<br/>|
+| `internal.advancedConfiguration.postKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
+| `internal.advancedConfiguration.preKubeadmCommands` | **Pre-kubeadm commands** - Extra commands to run before kubeadm runs.|**Type:** `array`<br/>|
+| `internal.advancedConfiguration.preKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.workers` | **Workers** - Advanced configuration of worker nodes.|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.workers.files` | **Files** - Custom cluster-specific files that are deployed to worker nodes.|**Type:** `array`<br/>|
 | `internal.advancedConfiguration.workers.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
@@ -126,6 +134,10 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.advancedConfiguration.workers.files[*].contentFrom.secret.name` | **Name** - Name of the Secret resource.|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.workers.files[*].path` | **Path** - File path on the node.|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.workers.files[*].permissions` | **Permissions** - File permissions in form 0644|**Type:** `string`<br/>**Default:** `"0644"`|
+| `internal.advancedConfiguration.workers.postKubeadmCommands` | **Post-kubeadm commands** - Extra commands to run after kubeadm runs.|**Type:** `array`<br/>|
+| `internal.advancedConfiguration.workers.postKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
+| `internal.advancedConfiguration.workers.preKubeadmCommands` | **Pre-kubeadm commands** - Extra commands to run before kubeadm runs.|**Type:** `array`<br/>|
+| `internal.advancedConfiguration.workers.preKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
 
 ### Metadata
 Properties within the `.global.metadata` object
@@ -334,7 +346,7 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.controlPlane.resources.infrastructureMachineTemplate.version` | **API version**|**Type:** `string`<br/>**Examples:** `"v1alpha1", "v1beta1", "v1beta2", "v1", "v2"`<br/>|
 | `providerIntegration.controlPlane.resources.infrastructureMachineTemplateSpecTemplateName` | **Infrastructure Machine template spec template name** - The name of Helm template that renders Infrastructure Machine template spec.|**Type:** `string`<br/>|
 | `providerIntegration.hashSalt` | **Hash salt** - If specified, this token is used as a salt to the hash suffix of some resource names. Can be used to force-recreate some resources.|**Type:** `string`<br/>|
-| `providerIntegration.kubeadmConfig` | **Kubeadm config** - Common kubeadm config for all nodes, including both control plane and workers.|**Type:** `object`<br/>|
+| `providerIntegration.kubeadmConfig` | **Provider-specific kubeadm config** - Provider-specific kubeadm config that is common for all nodes, including both control plane and workers.|**Type:** `object`<br/>|
 | `providerIntegration.kubeadmConfig.files` | **Files** - Provider-specific files that are deployed to all nodes. They are specified in the cluster-<provider> apps.|**Type:** `array`<br/>|
 | `providerIntegration.kubeadmConfig.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
 | `providerIntegration.kubeadmConfig.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -94,6 +94,10 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | :----------- | :-------------- | :--------------- |
 | `internal.advancedConfiguration` | **Advanced configuration** - Advanced configuration of cluster components, to be configured by Giant Swarm staff only.|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.cgroupsv1` | **CGroups v1** - Force use of CGroups v1 for whole cluster.|**Type:** `boolean`<br/>**Default:** `false`|
+| `internal.advancedConfiguration.controlPlane` | **Control plane** - Advanced configuration of control plane components.|**Type:** `object`<br/>|
+| `internal.advancedConfiguration.controlPlane.apiServer` | **API server** - Advanced configuration of API server.|**Type:** `object`<br/>|
+| `internal.advancedConfiguration.controlPlane.apiServer.extraCertificateSANs` | **Extra certificate SANs** - The additional certificate SANs that are appended to the default SANs.|**Type:** `array`<br/>|
+| `internal.advancedConfiguration.controlPlane.apiServer.extraCertificateSANs[*]` | **Extra certificate SAN**|**Type:** `string`<br/>|
 
 ### Metadata
 Properties within the `.global.metadata` object
@@ -219,8 +223,6 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.apiAudiences` | **API audiences** - Identifiers of the API. The service account token authenticator will validate that tokens used against the API are bound to at least one of these audiences. If the --service-account-issuer flag is configured and this flag is not, 'api-audiences' field defaults to a single element list containing the issuer URL.||
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.etcdPrefix` | **etcd prefix**|**Type:** `string`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.extraArgs` | **Extra args**|**Type:** `object`<br/>|
-| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.extraCertificateSANs` | **Extra certificate SANs** - The additional certificate SANs that are appended to the default SANs.|**Type:** `array`<br/>|
-| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.extraCertificateSANs[*]` | **Extra certificate SAN**|**Type:** `string`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates` | **Feature gates**|**Type:** `array`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates[*]` | **Feature gate**|**Type:** `object`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates[*].enabled` | **Enabled**|**Type:** `boolean`<br/>|

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -96,7 +96,8 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.advancedConfiguration.cgroupsv1` | **CGroups v1** - Force use of CGroups v1 for whole cluster.|**Type:** `boolean`<br/>**Default:** `false`|
 | `internal.advancedConfiguration.controlPlane` | **Control plane** - Advanced configuration of control plane components.|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer` | **API server** - Advanced configuration of API server.|**Type:** `object`<br/>|
-| `internal.advancedConfiguration.controlPlane.apiServer.extraCertificateSANs` | **Extra certificate SANs** - The additional certificate SANs that are appended to the default SANs.|**Type:** `array`<br/>|
+| `internal.advancedConfiguration.controlPlane.apiServer.extraArgs` | **Extra CLI args** - A map with the additional CLI flags that are appended to the default flags. Use with caution, as there is no validation for these values, so you can set incorrect or duplicate flags.|**Type:** `object`<br/>|
+| `internal.advancedConfiguration.controlPlane.apiServer.extraCertificateSANs` | **Extra certificate SANs** - The additional certificate SANs that are appended to the default SANs. Use with caution, as there is no validation for these values, so you can set incorrect or duplicate certificates.|**Type:** `array`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.extraCertificateSANs[*]` | **Extra certificate SAN**|**Type:** `string`<br/>|
 
 ### Metadata
@@ -222,7 +223,6 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.additionalAdmissionPlugins[*]` | **Additional admission plugin**|**Type:** `string`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.apiAudiences` | **API audiences** - Identifiers of the API. The service account token authenticator will validate that tokens used against the API are bound to at least one of these audiences. If the --service-account-issuer flag is configured and this flag is not, 'api-audiences' field defaults to a single element list containing the issuer URL.||
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.etcdPrefix` | **etcd prefix**|**Type:** `string`<br/>|
-| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.extraArgs` | **Extra args**|**Type:** `object`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates` | **Feature gates**|**Type:** `array`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates[*]` | **Feature gate**|**Type:** `object`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates[*].enabled` | **Enabled**|**Type:** `boolean`<br/>|

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -96,7 +96,7 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.advancedConfiguration.cgroupsv1` | **CGroups v1** - Force use of CGroups v1 for whole cluster.|**Type:** `boolean`<br/>**Default:** `false`|
 | `internal.advancedConfiguration.controlPlane` | **Control plane** - Advanced configuration of control plane components.|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer` | **API server** - Advanced configuration of API server.|**Type:** `object`<br/>|
-| `internal.advancedConfiguration.controlPlane.apiServer.etcdPrefix` | **etcd prefix**|**Type:** `string`<br/>|
+| `internal.advancedConfiguration.controlPlane.apiServer.etcdPrefix` | **etcd prefix** - The prefix to prepend to all resource paths in etcd. If nothing is specified, the API server uses '/registry' prefix by default.|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.extraArgs` | **Extra CLI args** - A map with the additional CLI flags that are appended to the default flags. Use with caution, as there is no validation for these values, so you can set incorrect or duplicate flags.|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.extraCertificateSANs` | **Extra certificate SANs** - The additional certificate SANs that are appended to the default SANs. Use with caution, as there is no validation for these values, so you can set incorrect or duplicate certificates.|**Type:** `array`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.extraCertificateSANs[*]` | **Extra certificate SAN**|**Type:** `string`<br/>|

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -117,6 +117,15 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.advancedConfiguration.files[*].contentFrom.secret.name` | **Name** - Name of the Secret resource.|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.files[*].path` | **Path** - File path on the node.|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.files[*].permissions` | **Permissions** - File permissions in form 0644|**Type:** `string`<br/>**Default:** `"0644"`|
+| `internal.advancedConfiguration.workers` | **Workers** - Advanced configuration of worker nodes|**Type:** `object`<br/>|
+| `internal.advancedConfiguration.workers.files` | **Files** - These are the files that are included on worker nodes.|**Type:** `array`<br/>|
+| `internal.advancedConfiguration.workers.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
+| `internal.advancedConfiguration.workers.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|
+| `internal.advancedConfiguration.workers.files[*].contentFrom.secret` | **Secret** - Kubernetes Secret resource with the file content.|**Type:** `object`<br/>|
+| `internal.advancedConfiguration.workers.files[*].contentFrom.secret.key` | **Key** - Secret key where the file content is.|**Type:** `string`<br/>|
+| `internal.advancedConfiguration.workers.files[*].contentFrom.secret.name` | **Name** - Name of the Secret resource.|**Type:** `string`<br/>|
+| `internal.advancedConfiguration.workers.files[*].path` | **Path** - File path on the node.|**Type:** `string`<br/>|
+| `internal.advancedConfiguration.workers.files[*].permissions` | **Permissions** - File permissions in form 0644|**Type:** `string`<br/>**Default:** `"0644"`|
 
 ### Metadata
 Properties within the `.global.metadata` object
@@ -392,14 +401,6 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.teleport.version` | **Teleport version**|**Type:** `string`<br/>**Default:** `"14.1.3"`|
 | `providerIntegration.workers` | **Internal workers configuration**|**Type:** `object`<br/>|
 | `providerIntegration.workers.kubeadmConfig` | **Kubeadm config** - Configuration of workers nodes.|**Type:** `object`<br/>|
-| `providerIntegration.workers.kubeadmConfig.files` | **Files** - These are the files that are included on worker nodes.|**Type:** `array`<br/>|
-| `providerIntegration.workers.kubeadmConfig.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
-| `providerIntegration.workers.kubeadmConfig.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|
-| `providerIntegration.workers.kubeadmConfig.files[*].contentFrom.secret` | **Secret** - Kubernetes Secret resource with the file content.|**Type:** `object`<br/>|
-| `providerIntegration.workers.kubeadmConfig.files[*].contentFrom.secret.key` | **Key** - Secret key where the file content is.|**Type:** `string`<br/>|
-| `providerIntegration.workers.kubeadmConfig.files[*].contentFrom.secret.name` | **Name** - Name of the Secret resource.|**Type:** `string`<br/>|
-| `providerIntegration.workers.kubeadmConfig.files[*].path` | **Path** - File path on the node.|**Type:** `string`<br/>|
-| `providerIntegration.workers.kubeadmConfig.files[*].permissions` | **Permissions** - File permissions in form 0644|**Type:** `string`<br/>**Default:** `"0644"`|
 | `providerIntegration.workers.kubeadmConfig.ignition` | **Ignition** - Ignition-specific configuration.|**Type:** `object`<br/>|
 | `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig` | **Container Linux configuration**|**Type:** `object`<br/>|
 | `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig` | **Additional config** - Additional configuration to be merged with the Ignition. More info: https://coreos.github.io/ignition/operator-notes/#config-merging.|**Type:** `object`<br/>|

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -96,6 +96,7 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.advancedConfiguration.cgroupsv1` | **CGroups v1** - Force use of CGroups v1 for whole cluster.|**Type:** `boolean`<br/>**Default:** `false`|
 | `internal.advancedConfiguration.controlPlane` | **Control plane** - Advanced configuration of control plane components.|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer` | **API server** - Advanced configuration of API server.|**Type:** `object`<br/>|
+| `internal.advancedConfiguration.controlPlane.apiServer.etcdPrefix` | **etcd prefix**|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.extraArgs` | **Extra CLI args** - A map with the additional CLI flags that are appended to the default flags. Use with caution, as there is no validation for these values, so you can set incorrect or duplicate flags.|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.extraCertificateSANs` | **Extra certificate SANs** - The additional certificate SANs that are appended to the default SANs. Use with caution, as there is no validation for these values, so you can set incorrect or duplicate certificates.|**Type:** `array`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.extraCertificateSANs[*]` | **Extra certificate SAN**|**Type:** `string`<br/>|
@@ -222,7 +223,6 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.additionalAdmissionPlugins` | **Additional admission plugins** - A list of plugins to enable, in addition to the default ones that include DefaultStorageClass, DefaultTolerationSeconds, LimitRanger, MutatingAdmissionWebhook, NamespaceLifecycle, PersistentVolumeClaimResize, Priority, ResourceQuota, ServiceAccount and ValidatingAdmissionWebhook.|**Type:** `array`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.additionalAdmissionPlugins[*]` | **Additional admission plugin**|**Type:** `string`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.apiAudiences` | **API audiences** - Identifiers of the API. The service account token authenticator will validate that tokens used against the API are bound to at least one of these audiences. If the --service-account-issuer flag is configured and this flag is not, 'api-audiences' field defaults to a single element list containing the issuer URL.||
-| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.etcdPrefix` | **etcd prefix**|**Type:** `string`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates` | **Feature gates**|**Type:** `array`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates[*]` | **Feature gate**|**Type:** `object`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates[*].enabled` | **Enabled**|**Type:** `boolean`<br/>|

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -101,6 +101,14 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.advancedConfiguration.controlPlane.apiServer.extraArgs` | **Extra CLI args** - A map with the additional CLI flags that are appended to the default flags. Use with caution, as there is no validation for these values, so you can set incorrect or duplicate flags.|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.extraCertificateSANs` | **Extra certificate SANs** - The additional certificate SANs that are appended to the default SANs. Use with caution, as there is no validation for these values, so you can set incorrect or duplicate certificates.|**Type:** `array`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.extraCertificateSANs[*]` | **Extra certificate SAN**|**Type:** `string`<br/>|
+| `internal.advancedConfiguration.controlPlane.files` | **Files** - These are the files that are included on control plane nodes.|**Type:** `array`<br/>|
+| `internal.advancedConfiguration.controlPlane.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
+| `internal.advancedConfiguration.controlPlane.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|
+| `internal.advancedConfiguration.controlPlane.files[*].contentFrom.secret` | **Secret** - Kubernetes Secret resource with the file content.|**Type:** `object`<br/>|
+| `internal.advancedConfiguration.controlPlane.files[*].contentFrom.secret.key` | **Key** - Secret key where the file content is.|**Type:** `string`<br/>|
+| `internal.advancedConfiguration.controlPlane.files[*].contentFrom.secret.name` | **Name** - Name of the Secret resource.|**Type:** `string`<br/>|
+| `internal.advancedConfiguration.controlPlane.files[*].path` | **Path** - File path on the node.|**Type:** `string`<br/>|
+| `internal.advancedConfiguration.controlPlane.files[*].permissions` | **Permissions** - File permissions in form 0644|**Type:** `string`<br/>**Default:** `"0644"`|
 | `internal.advancedConfiguration.files` | **Files** - These are the files that are included on all the nodes.|**Type:** `array`<br/>|
 | `internal.advancedConfiguration.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|
@@ -243,14 +251,6 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.etcd.extraArgs` | **Extra args**|**Type:** `object`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.etcd.initialCluster` | **Initial cluster** - Initial cluster configuration for bootstrapping.|**Type:** `string`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.etcd.initialClusterState` | **Initial cluster state**|**Type:** `string`<br/>|
-| `providerIntegration.controlPlane.kubeadmConfig.files` | **Files** - These are the files that are included on control plane nodes.|**Type:** `array`<br/>|
-| `providerIntegration.controlPlane.kubeadmConfig.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
-| `providerIntegration.controlPlane.kubeadmConfig.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|
-| `providerIntegration.controlPlane.kubeadmConfig.files[*].contentFrom.secret` | **Secret** - Kubernetes Secret resource with the file content.|**Type:** `object`<br/>|
-| `providerIntegration.controlPlane.kubeadmConfig.files[*].contentFrom.secret.key` | **Key** - Secret key where the file content is.|**Type:** `string`<br/>|
-| `providerIntegration.controlPlane.kubeadmConfig.files[*].contentFrom.secret.name` | **Name** - Name of the Secret resource.|**Type:** `string`<br/>|
-| `providerIntegration.controlPlane.kubeadmConfig.files[*].path` | **Path** - File path on the node.|**Type:** `string`<br/>|
-| `providerIntegration.controlPlane.kubeadmConfig.files[*].permissions` | **Permissions** - File permissions in form 0644|**Type:** `string`<br/>**Default:** `"0644"`|
 | `providerIntegration.controlPlane.kubeadmConfig.ignition` | **Ignition** - Ignition-specific configuration.|**Type:** `object`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig` | **Container Linux configuration**|**Type:** `object`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig` | **Additional config** - Additional configuration to be merged with the Ignition. More info: https://coreos.github.io/ignition/operator-notes/#config-merging.|**Type:** `object`<br/>|

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -101,7 +101,7 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.advancedConfiguration.controlPlane.apiServer.extraArgs` | **Extra CLI args** - A map with the additional CLI flags that are appended to the default flags. Use with caution, as there is no validation for these values, so you can set incorrect or duplicate flags.|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.extraCertificateSANs` | **Extra certificate SANs** - The additional certificate SANs that are appended to the default SANs. Use with caution, as there is no validation for these values, so you can set incorrect or duplicate certificates.|**Type:** `array`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.extraCertificateSANs[*]` | **Extra certificate SAN**|**Type:** `string`<br/>|
-| `internal.advancedConfiguration.controlPlane.files` | **Files** - These are the files that are included on control plane nodes.|**Type:** `array`<br/>|
+| `internal.advancedConfiguration.controlPlane.files` | **Files** - Custom cluster-specific files that are deployed to control plane nodes.|**Type:** `array`<br/>|
 | `internal.advancedConfiguration.controlPlane.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.controlPlane.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.controlPlane.files[*].contentFrom.secret` | **Secret** - Kubernetes Secret resource with the file content.|**Type:** `object`<br/>|
@@ -109,7 +109,7 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.advancedConfiguration.controlPlane.files[*].contentFrom.secret.name` | **Name** - Name of the Secret resource.|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.controlPlane.files[*].path` | **Path** - File path on the node.|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.controlPlane.files[*].permissions` | **Permissions** - File permissions in form 0644|**Type:** `string`<br/>**Default:** `"0644"`|
-| `internal.advancedConfiguration.files` | **Files** - These are the files that are included on all the nodes.|**Type:** `array`<br/>|
+| `internal.advancedConfiguration.files` | **Files** - Custom cluster-specific files that are deployed to all nodes.|**Type:** `array`<br/>|
 | `internal.advancedConfiguration.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.files[*].contentFrom.secret` | **Secret** - Kubernetes Secret resource with the file content.|**Type:** `object`<br/>|
@@ -118,7 +118,7 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.advancedConfiguration.files[*].path` | **Path** - File path on the node.|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.files[*].permissions` | **Permissions** - File permissions in form 0644|**Type:** `string`<br/>**Default:** `"0644"`|
 | `internal.advancedConfiguration.workers` | **Workers** - Advanced configuration of worker nodes.|**Type:** `object`<br/>|
-| `internal.advancedConfiguration.workers.files` | **Files** - These are the files that are included on worker nodes.|**Type:** `array`<br/>|
+| `internal.advancedConfiguration.workers.files` | **Files** - Custom cluster-specific files that are deployed to worker nodes.|**Type:** `array`<br/>|
 | `internal.advancedConfiguration.workers.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.workers.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.workers.files[*].contentFrom.secret` | **Secret** - Kubernetes Secret resource with the file content.|**Type:** `object`<br/>|
@@ -260,7 +260,7 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.etcd.extraArgs` | **Extra args**|**Type:** `object`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.etcd.initialCluster` | **Initial cluster** - Initial cluster configuration for bootstrapping.|**Type:** `string`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.etcd.initialClusterState` | **Initial cluster state**|**Type:** `string`<br/>|
-| `providerIntegration.controlPlane.kubeadmConfig.files` | **Files** - These are the files that are included on control plane nodes.|**Type:** `array`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.files` | **Files** - Provider-specific files that are deployed to control plane nodes. They are specified in the cluster-<provider> apps.|**Type:** `array`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.files[*].contentFrom.secret` | **Secret** - Kubernetes Secret resource with the file content.|**Type:** `object`<br/>|
@@ -335,7 +335,7 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.controlPlane.resources.infrastructureMachineTemplateSpecTemplateName` | **Infrastructure Machine template spec template name** - The name of Helm template that renders Infrastructure Machine template spec.|**Type:** `string`<br/>|
 | `providerIntegration.hashSalt` | **Hash salt** - If specified, this token is used as a salt to the hash suffix of some resource names. Can be used to force-recreate some resources.|**Type:** `string`<br/>|
 | `providerIntegration.kubeadmConfig` | **Kubeadm config** - Common kubeadm config for all nodes, including both control plane and workers.|**Type:** `object`<br/>|
-| `providerIntegration.kubeadmConfig.files` | **Files** - These are the files that are included on control plane nodes.|**Type:** `array`<br/>|
+| `providerIntegration.kubeadmConfig.files` | **Files** - Provider-specific files that are deployed to all nodes. They are specified in the cluster-<provider> apps.|**Type:** `array`<br/>|
 | `providerIntegration.kubeadmConfig.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
 | `providerIntegration.kubeadmConfig.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|
 | `providerIntegration.kubeadmConfig.files[*].contentFrom.secret` | **Secret** - Kubernetes Secret resource with the file content.|**Type:** `object`<br/>|
@@ -417,7 +417,7 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.teleport.version` | **Teleport version**|**Type:** `string`<br/>**Default:** `"14.1.3"`|
 | `providerIntegration.workers` | **Provider-specific workers configuration**|**Type:** `object`<br/>|
 | `providerIntegration.workers.kubeadmConfig` | **Kubeadm config** - Configuration of workers nodes.|**Type:** `object`<br/>|
-| `providerIntegration.workers.kubeadmConfig.files` | **Files** - These are the files that are included on worker nodes.|**Type:** `array`<br/>|
+| `providerIntegration.workers.kubeadmConfig.files` | **Files** - Provider-specific files that are deployed to worker nodes. They are specified in the cluster-<provider> apps.|**Type:** `array`<br/>|
 | `providerIntegration.workers.kubeadmConfig.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
 | `providerIntegration.workers.kubeadmConfig.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|
 | `providerIntegration.workers.kubeadmConfig.files[*].contentFrom.secret` | **Secret** - Kubernetes Secret resource with the file content.|**Type:** `object`<br/>|

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -101,6 +101,14 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.advancedConfiguration.controlPlane.apiServer.extraArgs` | **Extra CLI args** - A map with the additional CLI flags that are appended to the default flags. Use with caution, as there is no validation for these values, so you can set incorrect or duplicate flags.|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.extraCertificateSANs` | **Extra certificate SANs** - The additional certificate SANs that are appended to the default SANs. Use with caution, as there is no validation for these values, so you can set incorrect or duplicate certificates.|**Type:** `array`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.extraCertificateSANs[*]` | **Extra certificate SAN**|**Type:** `string`<br/>|
+| `internal.advancedConfiguration.files` | **Files** - These are the files that are included on all the nodes.|**Type:** `array`<br/>|
+| `internal.advancedConfiguration.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
+| `internal.advancedConfiguration.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|
+| `internal.advancedConfiguration.files[*].contentFrom.secret` | **Secret** - Kubernetes Secret resource with the file content.|**Type:** `object`<br/>|
+| `internal.advancedConfiguration.files[*].contentFrom.secret.key` | **Key** - Secret key where the file content is.|**Type:** `string`<br/>|
+| `internal.advancedConfiguration.files[*].contentFrom.secret.name` | **Name** - Name of the Secret resource.|**Type:** `string`<br/>|
+| `internal.advancedConfiguration.files[*].path` | **Path** - File path on the node.|**Type:** `string`<br/>|
+| `internal.advancedConfiguration.files[*].permissions` | **Permissions** - File permissions in form 0644|**Type:** `string`<br/>**Default:** `"0644"`|
 
 ### Metadata
 Properties within the `.global.metadata` object
@@ -310,14 +318,6 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.controlPlane.resources.infrastructureMachineTemplateSpecTemplateName` | **Infrastructure Machine template spec template name** - The name of Helm template that renders Infrastructure Machine template spec.|**Type:** `string`<br/>|
 | `providerIntegration.hashSalt` | **Hash salt** - If specified, this token is used as a salt to the hash suffix of some resource names. Can be used to force-recreate some resources.|**Type:** `string`<br/>|
 | `providerIntegration.kubeadmConfig` | **Kubeadm config** - Common kubeadm config for all nodes, including both control plane and workers.|**Type:** `object`<br/>|
-| `providerIntegration.kubeadmConfig.files` | **Files** - These are the files that are included on all the nodes.|**Type:** `array`<br/>|
-| `providerIntegration.kubeadmConfig.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
-| `providerIntegration.kubeadmConfig.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|
-| `providerIntegration.kubeadmConfig.files[*].contentFrom.secret` | **Secret** - Kubernetes Secret resource with the file content.|**Type:** `object`<br/>|
-| `providerIntegration.kubeadmConfig.files[*].contentFrom.secret.key` | **Key** - Secret key where the file content is.|**Type:** `string`<br/>|
-| `providerIntegration.kubeadmConfig.files[*].contentFrom.secret.name` | **Name** - Name of the Secret resource.|**Type:** `string`<br/>|
-| `providerIntegration.kubeadmConfig.files[*].path` | **Path** - File path on the node.|**Type:** `string`<br/>|
-| `providerIntegration.kubeadmConfig.files[*].permissions` | **Permissions** - File permissions in form 0644|**Type:** `string`<br/>**Default:** `"0644"`|
 | `providerIntegration.kubeadmConfig.ignition` | **Ignition** - Ignition-specific configuration.|**Type:** `object`<br/>|
 | `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig` | **Container Linux configuration**|**Type:** `object`<br/>|
 | `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig` | **Additional config** - Additional configuration to be merged with the Ignition. More info: https://coreos.github.io/ignition/operator-notes/#config-merging.|**Type:** `object`<br/>|

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -96,6 +96,7 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.advancedConfiguration.cgroupsv1` | **CGroups v1** - Force use of CGroups v1 for whole cluster.|**Type:** `boolean`<br/>**Default:** `false`|
 | `internal.advancedConfiguration.controlPlane` | **Control plane** - Advanced configuration of control plane components.|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer` | **API server** - Advanced configuration of API server.|**Type:** `object`<br/>|
+| `internal.advancedConfiguration.controlPlane.apiServer.bindPort` | **Bind port** - Kubernetes API bind port used for API server pod.|**Type:** `integer`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.etcdPrefix` | **etcd prefix** - The prefix to prepend to all resource paths in etcd. If nothing is specified, the API server uses '/registry' prefix by default.|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.extraArgs` | **Extra CLI args** - A map with the additional CLI flags that are appended to the default flags. Use with caution, as there is no validation for these values, so you can set incorrect or duplicate flags.|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.extraCertificateSANs` | **Extra certificate SANs** - The additional certificate SANs that are appended to the default SANs. Use with caution, as there is no validation for these values, so you can set incorrect or duplicate certificates.|**Type:** `array`<br/>|
@@ -292,8 +293,6 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].mask` | **Masked?** - Whether or not the service shall be masked. When true, the service is masked by symlinking it to /dev/null.|**Type:** `boolean`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].name` | **Name** - The name of the unit. This must be suffixed with a valid unit type (e.g. “thing.service”).|**Type:** `string`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.strict` | **Strict** - It controls if AdditionalConfig should be strictly parsed. If so, warnings are treated as errors.|**Type:** `boolean`<br/>|
-| `providerIntegration.controlPlane.kubeadmConfig.localAPIEndpoint` | **Local API endpoint**|**Type:** `object`<br/>|
-| `providerIntegration.controlPlane.kubeadmConfig.localAPIEndpoint.bindPort` | **Bind port** - Kubernetes API bind port used for API server pod.|**Type:** `integer`<br/>**Default:** `6443`|
 | `providerIntegration.controlPlane.kubeadmConfig.postKubeadmCommands` | **Post-kubeadm commands** - Extra commands to run after kubeadm runs.|**Type:** `array`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.postKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.preKubeadmCommands` | **Pre-kubeadm commands** - Extra commands to run before kubeadm runs.|**Type:** `array`<br/>|

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -101,6 +101,12 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.advancedConfiguration.controlPlane.apiServer.extraArgs` | **Extra CLI args** - A map with the additional CLI flags that are appended to the default flags. Use with caution, as there is no validation for these values, so you can set incorrect or duplicate flags.|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.extraCertificateSANs` | **Extra certificate SANs** - The additional certificate SANs that are appended to the default SANs. Use with caution, as there is no validation for these values, so you can set incorrect or duplicate certificates.|**Type:** `array`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.extraCertificateSANs[*]` | **Extra certificate SAN**|**Type:** `string`<br/>|
+| `internal.advancedConfiguration.controlPlane.etcd` | **etcd** - Configuration of etcd|**Type:** `object`<br/>|
+| `internal.advancedConfiguration.controlPlane.etcd.experimental` | **Experimental**|**Type:** `object`<br/>|
+| `internal.advancedConfiguration.controlPlane.etcd.experimental.peerSkipClientSanVerification` | **Peer skip client SAN verification** - Skip verification of SAN field in client certificate for peer connections.|**Type:** `boolean`<br/>|
+| `internal.advancedConfiguration.controlPlane.etcd.extraArgs` | **Extra args**|**Type:** `object`<br/>|
+| `internal.advancedConfiguration.controlPlane.etcd.initialCluster` | **Initial cluster** - Initial cluster configuration for bootstrapping.|**Type:** `string`<br/>|
+| `internal.advancedConfiguration.controlPlane.etcd.initialClusterState` | **Initial cluster state**|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.controlPlane.files` | **Files** - Custom cluster-specific files that are deployed to control plane nodes.|**Type:** `array`<br/>|
 | `internal.advancedConfiguration.controlPlane.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.controlPlane.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|
@@ -266,12 +272,6 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates[*].enabled` | **Enabled**|**Type:** `boolean`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates[*].name` | **Name**|**Type:** `string`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.serviceAccountIssuer` | **Service account issuer** - Configuration of the identifier of the service account token issuer. You must specify either URL or clusterDomainPrefix (only one, not both).||
-| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.etcd` | **etcd** - Configuration of etcd|**Type:** `object`<br/>|
-| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.etcd.experimental` | **Experimental**|**Type:** `object`<br/>|
-| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.etcd.experimental.peerSkipClientSanVerification` | **Peer skip client SAN verification** - Skip verification of SAN field in client certificate for peer connections.|**Type:** `boolean`<br/>|
-| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.etcd.extraArgs` | **Extra args**|**Type:** `object`<br/>|
-| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.etcd.initialCluster` | **Initial cluster** - Initial cluster configuration for bootstrapping.|**Type:** `string`<br/>|
-| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.etcd.initialClusterState` | **Initial cluster state**|**Type:** `string`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.files` | **Files** - Provider-specific files that are deployed to control plane nodes. They are specified in the cluster-<provider> apps.|**Type:** `array`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -73,14 +73,14 @@ internal:
         - this-is-extra-cert-san.giantswarm.io
         - another-extra-cert-san.giantswarm.io
       files:
-      - path: /etc/hello/control-plane/node/stuff.yaml
+      - path: /etc/custom/control-plane/node/file.yaml
         permissions: "0644"
         contentFrom:
           secret:
             name: cluster-super-secret-control-plane
             key: node-stuff
     files:
-    - path: /etc/hello/any/node/stuff.yaml
+    - path: /etc/custom/node/file.yaml
       permissions: "0644"
       contentFrom:
         secret:
@@ -88,7 +88,7 @@ internal:
           key: node-stuff
     workers:
       files:
-      - path: /etc/hello/worker/node/stuff.yaml
+      - path: /etc/custom/worker/node/file.yaml
         permissions: "0644"
         contentFrom:
           secret:
@@ -150,7 +150,7 @@ providerIntegration:
           experimental:
             peerSkipClientSanVerification: true
       files:
-      - path: /etc/hello/control-plane/aws/node/stuff.yaml
+      - path: /etc/aws/control-plane/node/file.yaml
         permissions: "0644"
         contentFrom:
           secret:
@@ -238,7 +238,7 @@ providerIntegration:
   hashSalt: salty-1
   kubeadmConfig:
     files:
-    - path: /etc/hello/any/aws/node/stuff.yaml
+    - path: /etc/aws/node/file.yaml
       permissions: "0644"
       contentFrom:
         secret:
@@ -336,7 +336,7 @@ providerIntegration:
   workers:
     kubeadmConfig:
       files:
-      - path: /etc/hello/worker/aws/node/stuff.yaml
+      - path: /etc/aws/worker/node/file.yaml
         permissions: "0644"
         contentFrom:
           secret:

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -86,6 +86,14 @@ internal:
         secret:
           name: cluster-super-secret
           key: node-stuff
+    workers:
+      files:
+      - path: /etc/hello/worker/node/stuff.yaml
+        permissions: "0644"
+        contentFrom:
+          secret:
+            name: cluster-super-secret-worker
+            key: node-stuff
 providerIntegration:
   provider: aws
   bastion:
@@ -313,13 +321,6 @@ providerIntegration:
     enabled: true
   workers:
     kubeadmConfig:
-      files:
-      - path: /etc/hello/worker/node/stuff.yaml
-        permissions: "0644"
-        contentFrom:
-          secret:
-            name: cluster-super-secret-worker
-            key: node-stuff
       ignition:
         containerLinuxConfig:
           additionalConfig:

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -79,6 +79,10 @@ internal:
           secret:
             name: cluster-super-secret-control-plane
             key: node-stuff
+      preKubeadmCommands:
+      - echo "custom control plane command before kubeadm"
+      postKubeadmCommands:
+      - echo "custom control plane command after kubeadm"
     files:
     - path: /etc/custom/node/file.yaml
       permissions: "0644"
@@ -86,6 +90,10 @@ internal:
         secret:
           name: cluster-super-secret
           key: node-stuff
+    preKubeadmCommands:
+    - echo "custom nodes command before kubeadm"
+    postKubeadmCommands:
+    - echo "custom nodes command after kubeadm"
     workers:
       files:
       - path: /etc/custom/worker/node/file.yaml
@@ -94,6 +102,10 @@ internal:
           secret:
             name: cluster-super-secret-worker
             key: node-stuff
+      preKubeadmCommands:
+      - echo "custom workers command before kubeadm"
+      postKubeadmCommands:
+      - echo "custom workers command after kubeadm"
 providerIntegration:
   provider: aws
   bastion:
@@ -219,11 +231,9 @@ providerIntegration:
                   id: 23456
                   name: giantswarm
       preKubeadmCommands:
-      - echo "hello control plane before kubeadm"
-      - echo "cluster control plane before kubeadm"
+      - echo "aws control plane command before kubeadm"
       postKubeadmCommands:
-      - echo "hello control plane after kubeadm"
-      - echo "cluster control plane after kubeadm"
+      - echo "aws control plane command after kubeadm"
     resources:
       infrastructureMachineTemplate:
         group: infrastructure.cluster.x-k8s.io
@@ -302,11 +312,9 @@ providerIntegration:
                 id: 23456
                 name: giantswarm
     preKubeadmCommands:
-    - echo "hello all nodes before kubeadm"
-    - echo "all cluster nodes before kubeadm"
+    - echo "aws nodes command before kubeadm"
     postKubeadmCommands:
-    - echo "hello all nodes after kubeadm"
-    - echo "all cluster nodes after kubeadm"
+    - echo "aws nodes command after kubeadm"
   kubernetesVersion: 1.24.10
   pauseProperties:
     global.connectivity.vpcMode: private
@@ -386,8 +394,6 @@ providerIntegration:
                   id: 23456
                   name: giantswarm
       preKubeadmCommands:
-      - echo "hello workers before kubeadm"
-      - echo "cluster workers before kubeadm"
+      - echo "aws workers command before kubeadm"
       postKubeadmCommands:
-      - echo "hello workers after kubeadm"
-      - echo "cluster workers after kubeadm"
+      - echo "aws workers command after kubeadm"

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -72,6 +72,13 @@ internal:
         extraCertificateSANs:
         - this-is-extra-cert-san.giantswarm.io
         - another-extra-cert-san.giantswarm.io
+      files:
+      - path: /etc/hello/control-plane/node/stuff.yaml
+        permissions: "0644"
+        contentFrom:
+          secret:
+            name: cluster-super-secret-control-plane
+            key: node-stuff
     files:
     - path: /etc/hello/any/node/stuff.yaml
       permissions: "0644"
@@ -134,13 +141,6 @@ providerIntegration:
             snapshot-count: 50000
           experimental:
             peerSkipClientSanVerification: true
-      files:
-      - path: /etc/hello/control-plane/node/stuff.yaml
-        permissions: "0644"
-        contentFrom:
-          secret:
-            name: cluster-super-secret-control-plane
-            key: node-stuff
       ignition:
         containerLinuxConfig:
           additionalConfig:

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -149,6 +149,13 @@ providerIntegration:
             snapshot-count: 50000
           experimental:
             peerSkipClientSanVerification: true
+      files:
+      - path: /etc/hello/control-plane/aws/node/stuff.yaml
+        permissions: "0644"
+        contentFrom:
+          secret:
+            name: cluster-super-secret-control-plane
+            key: node-stuff
       ignition:
         containerLinuxConfig:
           additionalConfig:
@@ -230,6 +237,13 @@ providerIntegration:
         - 169.254.169.123
   hashSalt: salty-1
   kubeadmConfig:
+    files:
+    - path: /etc/hello/any/aws/node/stuff.yaml
+      permissions: "0644"
+      contentFrom:
+        secret:
+          name: cluster-super-secret
+          key: node-stuff
     ignition:
       containerLinuxConfig:
         additionalConfig:
@@ -321,6 +335,13 @@ providerIntegration:
     enabled: true
   workers:
     kubeadmConfig:
+      files:
+      - path: /etc/hello/worker/aws/node/stuff.yaml
+        permissions: "0644"
+        contentFrom:
+          secret:
+            name: cluster-super-secret-worker
+            key: node-stuff
       ignition:
         containerLinuxConfig:
           additionalConfig:

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -72,6 +72,14 @@ internal:
         extraCertificateSANs:
         - this-is-extra-cert-san.giantswarm.io
         - another-extra-cert-san.giantswarm.io
+      etcd:
+        initialCluster: "default=http://localhost:2380"
+        initialClusterState: "existing"
+        extraArgs:
+          max-snapshots: 3
+          snapshot-count: 50000
+        experimental:
+          peerSkipClientSanVerification: true
       files:
       - path: /etc/custom/control-plane/node/file.yaml
         permissions: "0644"
@@ -153,14 +161,6 @@ providerIntegration:
             enabled: true
           serviceAccountIssuer:
             clusterDomainPrefix: irsa
-        etcd:
-          initialCluster: "default=http://localhost:2380"
-          initialClusterState: "existing"
-          extraArgs:
-            max-snapshots: 3
-            snapshot-count: 50000
-          experimental:
-            peerSkipClientSanVerification: true
       files:
       - path: /etc/aws/control-plane/node/file.yaml
         permissions: "0644"

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -62,6 +62,7 @@ internal:
     cgroupsv1: true
     controlPlane:
       apiServer:
+        etcdPrefix: giantswarm.io
         extraArgs:
           allow-privileged: false
           authorization-webhook-version: v1beta1
@@ -108,7 +109,6 @@ providerIntegration:
           - PodSecurityPolicy
           apiAudiences:
             templateName: "cluster.test.kubeadmControlPlane.kubeadmConfigSpec.clusterConfiguration.apiServer.apiAudiences"
-          etcdPrefix: giantswarm.io
           featureGates:
           - name: CronJobTimeZone
             enabled: true

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -60,6 +60,11 @@ global:
 internal:
   advancedConfiguration:
     cgroupsv1: true
+    controlPlane:
+      apiServer:
+        extraCertificateSANs:
+        - this-is-extra-cert-san.giantswarm.io
+        - another-extra-cert-san.giantswarm.io
 providerIntegration:
   provider: aws
   bastion:
@@ -104,9 +109,6 @@ providerIntegration:
             authorization-webhook-version: v1beta1
             delete-collection-workers: 2
             min-request-timeout: 600
-          extraCertificateSANs:
-          - this-is-extra-cert-san.giantswarm.io
-          - another-extra-cert-san.giantswarm.io
           featureGates:
           - name: CronJobTimeZone
             enabled: true

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -62,6 +62,11 @@ internal:
     cgroupsv1: true
     controlPlane:
       apiServer:
+        extraArgs:
+          allow-privileged: false
+          authorization-webhook-version: v1beta1
+          delete-collection-workers: 2
+          min-request-timeout: 600
         extraCertificateSANs:
         - this-is-extra-cert-san.giantswarm.io
         - another-extra-cert-san.giantswarm.io
@@ -104,11 +109,6 @@ providerIntegration:
           apiAudiences:
             templateName: "cluster.test.kubeadmControlPlane.kubeadmConfigSpec.clusterConfiguration.apiServer.apiAudiences"
           etcdPrefix: giantswarm.io
-          extraArgs:
-            allow-privileged: false
-            authorization-webhook-version: v1beta1
-            delete-collection-workers: 2
-            min-request-timeout: 600
           featureGates:
           - name: CronJobTimeZone
             enabled: true

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -62,6 +62,7 @@ internal:
     cgroupsv1: true
     controlPlane:
       apiServer:
+        bindPort: 6443
         etcdPrefix: giantswarm.io
         extraArgs:
           allow-privileged: false

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -72,6 +72,13 @@ internal:
         extraCertificateSANs:
         - this-is-extra-cert-san.giantswarm.io
         - another-extra-cert-san.giantswarm.io
+    files:
+    - path: /etc/hello/any/node/stuff.yaml
+      permissions: "0644"
+      contentFrom:
+        secret:
+          name: cluster-super-secret
+          key: node-stuff
 providerIntegration:
   provider: aws
   bastion:
@@ -215,13 +222,6 @@ providerIntegration:
         - 169.254.169.123
   hashSalt: salty-1
   kubeadmConfig:
-    files:
-    - path: /etc/hello/any/node/stuff.yaml
-      permissions: "0644"
-      contentFrom:
-        secret:
-          name: cluster-super-secret
-          key: node-stuff
     ignition:
       containerLinuxConfig:
         additionalConfig:

--- a/helm/cluster/templates/clusterapi/_helpers_files.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_files.tpl
@@ -7,6 +7,7 @@
 {{- include "cluster.internal.kubeadm.files.kubelet" $ }}
 {{- include "cluster.internal.kubeadm.files.proxy" $ }}
 {{- include "cluster.internal.kubeadm.files.teleport" $ }}
+{{- include "cluster.internal.kubeadm.files.provider" $ }}
 {{- include "cluster.internal.kubeadm.files.custom" $ }}
 {{- end }}
 
@@ -111,6 +112,14 @@ and is used to join the node to the teleport cluster.
 {{- end }}
 {{- end }}
 
+{{/* Provider-specific files for all nodes */}}
+{{- define "cluster.internal.kubeadm.files.provider" }}
+{{- if $.Values.providerIntegration.kubeadmConfig.files }}
+{{ toYaml $.Values.providerIntegration.kubeadmConfig.files }}
+{{- end }}
+{{- end }}
+
+{{/* Custom cluster-specific files for all nodes */}}
 {{- define "cluster.internal.kubeadm.files.custom" }}
 {{- if $.Values.internal.advancedConfiguration.files }}
 {{ toYaml $.Values.internal.advancedConfiguration.files }}

--- a/helm/cluster/templates/clusterapi/_helpers_files.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_files.tpl
@@ -112,7 +112,7 @@ and is used to join the node to the teleport cluster.
 {{- end }}
 
 {{- define "cluster.internal.kubeadm.files.custom" }}
-{{- if $.Values.providerIntegration.kubeadmConfig.files }}
-{{ toYaml $.Values.providerIntegration.kubeadmConfig.files }}
+{{- if $.Values.internal.advancedConfiguration.files }}
+{{ toYaml $.Values.internal.advancedConfiguration.files }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/_helpers_postkubeadmcommands.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_postkubeadmcommands.tpl
@@ -1,16 +1,26 @@
 {{/*
-    Template cluster.internal.kubeadm.postKubeadmCommands defines common extra commands to run on all
-    (control plane and workers) nodes after kubeadm runs. It includes prefedined commands and custom
-    commands specified in Helm values field .Values.providerIntegration.kubeadmConfig.postKubeadmCommands.
+    Template cluster.internal.kubeadm.postKubeadmCommands defines common commands to run on all
+    (control plane and workers) nodes after kubeadm runs.
+
+    It includes:
+    - provider-specific commands specified in cluster-<provider> app,
+    - custom cluster-specific commands.
 */}}
 {{- define "cluster.internal.kubeadm.postKubeadmCommands" }}
+{{- include "cluster.internal.kubeadm.postKubeadmCommands.provider" $ }}
 {{- include "cluster.internal.kubeadm.postKubeadmCommands.custom" $ }}
 {{- end }}
 
-{{- define "cluster.internal.kubeadm.postKubeadmCommands.custom" }}
-{{- if $.Values.providerIntegration.kubeadmConfig }}
+{{/* Provider-specific commands to run after kubeadm on all nodes */}}
+{{- define "cluster.internal.kubeadm.postKubeadmCommands.provider" }}
 {{- range $command := $.Values.providerIntegration.kubeadmConfig.postKubeadmCommands }}
 - {{ $command }}
 {{- end }}
+{{- end }}
+
+{{/* Custom cluster-specific commands to run after kubeadm on all nodes */}}
+{{- define "cluster.internal.kubeadm.postKubeadmCommands.custom" }}
+{{- range $command := $.Values.internal.advancedConfiguration.postKubeadmCommands }}
+- {{ $command }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/_helpers_prekubeadmcommands.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_prekubeadmcommands.tpl
@@ -1,12 +1,17 @@
 {{/*
-    Template cluster.internal.kubeadm.preKubeadmCommands defines common extra commands to run on all
-    (control plane and workers) nodes before kubeadm runs. It includes prefedined commands and
-    custom commands specified in Helm values field .Values.providerIntegration.kubeadmConfig.preKubeadmCommands.
+    Template cluster.internal.kubeadm.preKubeadmCommands defines common commands to run on all
+    (control plane and workers) nodes before kubeadm runs.
+
+    It includes:
+    - provider-independent commands defined in cluster chart,
+    - provider-specific commands specified in cluster-<provider> app,
+    - custom cluster-specific commands.
 */}}
 {{- define "cluster.internal.kubeadm.preKubeadmCommands" }}
 {{- include "cluster.internal.kubeadm.preKubeadmCommands.flatcar" $ }}
 {{- include "cluster.internal.kubeadm.preKubeadmCommands.ssh" $ }}
 {{- include "cluster.internal.kubeadm.preKubeadmCommands.proxy" $ }}
+{{- include "cluster.internal.kubeadm.preKubeadmCommands.provider" $ }}
 {{- include "cluster.internal.kubeadm.preKubeadmCommands.custom" $ }}
 {{- end }}
 
@@ -36,10 +41,16 @@
 {{- end }}
 {{- end }}
 
-{{- define "cluster.internal.kubeadm.preKubeadmCommands.custom" }}
-{{- if $.Values.providerIntegration.kubeadmConfig }}
+{{/* Provider-specific commands to run before kubeadm on all nodes */}}
+{{- define "cluster.internal.kubeadm.preKubeadmCommands.provider" }}
 {{- range $command := $.Values.providerIntegration.kubeadmConfig.preKubeadmCommands }}
 - {{ $command }}
 {{- end }}
+{{- end }}
+
+{{/* Custom cluster-specific commands to run before kubeadm on all nodes */}}
+{{- define "cluster.internal.kubeadm.preKubeadmCommands.custom" }}
+{{- range $command := $.Values.internal.advancedConfiguration.preKubeadmCommands }}
+- {{ $command }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_apiserver.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_apiserver.tpl
@@ -49,7 +49,7 @@ extraArgs:
   service-account-lookup: "true"
   service-cluster-ip-range: {{ .Values.global.connectivity.network.services.cidrBlocks | first }}
   tls-cipher-suites: {{ include "cluster.internal.controlPlane.kubeadm.clusterConfiguration.apiServer.tlsCipherSuites" $ }}
-  {{- range $argName, $argValue := ((($.Values.providerIntegration.controlPlane.kubeadmConfig).clusterConfiguration).apiServer).extraArgs }}
+  {{- range $argName, $argValue := $.Values.internal.advancedConfiguration.controlPlane.apiServer.extraArgs }}
   {{ $argName }}: {{ if kindIs "string" $argValue }}{{ $argValue | quote }}{{ else }}{{ $argValue }}{{ end }}
   {{- end }}
 extraVolumes:

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_apiserver.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_apiserver.tpl
@@ -25,8 +25,8 @@ extraArgs:
   cloud-provider: external
   enable-admission-plugins: {{ include "cluster.internal.controlPlane.kubeadm.clusterConfiguration.apiServer.enableAdmissionPlugins" $ }}
   encryption-provider-config: /etc/kubernetes/encryption/config.yaml
-  {{- if $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.etcdPrefix }}
-  etcd-prefix: {{ $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.etcdPrefix }}
+  {{- if $.Values.internal.advancedConfiguration.controlPlane.apiServer.etcdPrefix }}
+  etcd-prefix: {{ $.Values.internal.advancedConfiguration.controlPlane.apiServer.etcdPrefix }}
   {{- end }}
   {{- if .Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates }}
   feature-gates: {{ include "cluster.internal.controlPlane.kubeadm.clusterConfiguration.apiServer.featureGates" $ }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_apiserver.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_apiserver.tpl
@@ -4,8 +4,8 @@ certSANs:
 - 127.0.0.1
 - "api.{{ include "cluster.resource.name" $ }}.{{ required "The baseDomain value is required" $.Values.global.connectivity.baseDomain }}"
 - "apiserver.{{ include "cluster.resource.name" $ }}.{{ required "The baseDomain value is required" $.Values.global.connectivity.baseDomain }}"
-{{- if $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.extraCertificateSANs }}
-{{ toYaml $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.extraCertificateSANs }}
+{{- if $.Values.internal.advancedConfiguration.controlPlane.apiServer.extraCertificateSANs }}
+{{ toYaml $.Values.internal.advancedConfiguration.controlPlane.apiServer.extraCertificateSANs }}
 {{- end }}
 {{- /*
     Timeout for the API server to appear.

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_etcd.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_etcd.tpl
@@ -3,7 +3,7 @@ local:
   extraArgs:
     listen-metrics-urls: "http://0.0.0.0:2381"
     quota-backend-bytes: "8589934592"
-    {{- with $etcdConfig := (($.Values.providerIntegration.controlPlane.kubeadmConfig).clusterConfiguration).etcd }}
+    {{- with $etcdConfig := $.Values.internal.advancedConfiguration.controlPlane.etcd }}
     {{- if $etcdConfig.initialCluster }}
     initial-cluster: {{ $etcdConfig.initialCluster | quote }}
     {{- end }}
@@ -13,7 +13,7 @@ local:
     {{- range $argName, $argValue := $etcdConfig.extraArgs }}
     {{ $argName }}: {{ if kindIs "string" $argValue }}{{ $argValue | quote }}{{ else }}{{ $argValue }}{{ end }}
     {{- end }}
-    {{- if ($etcdConfig.experimental).peerSkipClientSanVerification }}
+    {{- if $etcdConfig.experimental.peerSkipClientSanVerification }}
     experimental-peer-skip-client-san-verification: {{ $etcdConfig.experimental.peerSkipClientSanVerification }}
     {{- end }}
     {{- end }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_files.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_files.tpl
@@ -1,6 +1,7 @@
 {{- define "cluster.internal.controlPlane.kubeadm.files" }}
 {{- include "cluster.internal.kubeadm.files" $ }}
 {{- include "cluster.internal.kubeadm.files.kubernetes" $ }}
+{{- include "cluster.internal.controlPlane.kubeadm.files.provider" $ }}
 {{- include "cluster.internal.controlPlane.kubeadm.files.custom" $ }}
 {{- if $.Values.global.controlPlane.oidc.caPem }}
 - path: /etc/ssl/certs/oidc.pem
@@ -23,6 +24,14 @@
       key: encryption
 {{- end }}
 
+{{/* Provider-specific files for control plane nodes */}}
+{{- define "cluster.internal.controlPlane.kubeadm.files.provider" }}
+{{- if $.Values.providerIntegration.controlPlane.kubeadmConfig.files }}
+{{ toYaml $.Values.providerIntegration.controlPlane.kubeadmConfig.files }}
+{{- end }}
+{{- end }}
+
+{{/* Custom cluster-specific files for control plane nodes */}}
 {{- define "cluster.internal.controlPlane.kubeadm.files.custom" }}
 {{- if $.Values.internal.advancedConfiguration.controlPlane.files }}
 {{ toYaml $.Values.internal.advancedConfiguration.controlPlane.files }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_files.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_files.tpl
@@ -24,7 +24,7 @@
 {{- end }}
 
 {{- define "cluster.internal.controlPlane.kubeadm.files.custom" }}
-{{- if $.Values.providerIntegration.controlPlane.kubeadmConfig.files }}
-{{ toYaml $.Values.providerIntegration.controlPlane.kubeadmConfig.files }}
+{{- if $.Values.internal.advancedConfiguration.controlPlane.files }}
+{{ toYaml $.Values.internal.advancedConfiguration.controlPlane.files }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_initconfiguration.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_initconfiguration.tpl
@@ -4,7 +4,7 @@ skipPhases:
 - addon/coredns
 localAPIEndpoint:
   advertiseAddress: ""
-  bindPort: {{ $.Values.providerIntegration.controlPlane.kubeadmConfig.localAPIEndpoint.bindPort }}
+  bindPort: {{ $.Values.internal.advancedConfiguration.controlPlane.apiServer.bindPort | default 6443 }}
 nodeRegistration:
   kubeletExtraArgs:
     {{- if $.Values.internal.advancedConfiguration.cgroupsv1 }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_joinconfiguration.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_joinconfiguration.tpl
@@ -2,7 +2,7 @@
 discovery: {}
 controlPlane:
   localAPIEndpoint:
-    bindPort: {{ $.Values.providerIntegration.controlPlane.kubeadmConfig.localAPIEndpoint.bindPort }}
+    bindPort: {{ $.Values.internal.advancedConfiguration.controlPlane.apiServer.bindPort | default 6443 }}
 nodeRegistration:
   kubeletExtraArgs:
     {{- if $.Values.internal.advancedConfiguration.cgroupsv1 }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_postkubeadmcommands.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_postkubeadmcommands.tpl
@@ -1,17 +1,28 @@
 {{/*
-    Template cluster.internal.controlPlane.kubeadm.postKubeadmCommands defines extra commands to run
-    on control plane nodes after kubeadm runs. It includes prefedined commands and custom commands
-    specified in Helm values field .Values.providerIntegration.controlPlane.kubeadmConfig.postKubeadmCommands.
+    Template cluster.internal.controlPlane.kubeadm.postKubeadmCommands defines commands to run
+    on control plane nodes after kubeadm runs.
+
+    It includes:
+    - shared postKubeadmCommands that are executed on all nodes,
+    - provider-specific control plane commands specified in cluster-<provider> app,
+    - custom cluster-specific control plane commands.
 */}}
 {{- define "cluster.internal.controlPlane.kubeadm.postKubeadmCommands" }}
 {{- include "cluster.internal.kubeadm.postKubeadmCommands" $ }}
+{{- include "cluster.internal.controlPlane.kubeadm.postKubeadmCommands.provider" $ }}
 {{- include "cluster.internal.controlPlane.kubeadm.postKubeadmCommands.custom" $ }}
 {{- end }}
 
-{{- define "cluster.internal.controlPlane.kubeadm.postKubeadmCommands.custom" }}
-{{- if $.Values.providerIntegration.controlPlane.kubeadmConfig }}
+{{/* Provider-specific commands to run after kubeadm on control plane nodes */}}
+{{- define "cluster.internal.controlPlane.kubeadm.postKubeadmCommands.provider" }}
 {{- range $command := $.Values.providerIntegration.controlPlane.kubeadmConfig.postKubeadmCommands }}
 - {{ $command }}
 {{- end }}
+{{- end }}
+
+{{/* Custom cluster-specific commands to run after kubeadm on control plane nodes */}}
+{{- define "cluster.internal.controlPlane.kubeadm.postKubeadmCommands.custom" }}
+{{- range $command := $.Values.internal.advancedConfiguration.controlPlane.postKubeadmCommands }}
+- {{ $command }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_prekubeadmcommands.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_prekubeadmcommands.tpl
@@ -1,17 +1,28 @@
 {{/*
-    Template cluster.internal.controlPlane.kubeadm.preKubeadmCommands defines extra commands to run
-    on control plane nodes before kubeadm runs. It includes prefedined commands and custom commands
-    specified in Helm values field .Values.providerIntegration.controlPlane.kubeadmConfig.preKubeadmCommands.
+    Template cluster.internal.controlPlane.kubeadm.preKubeadmCommands defines commands to run
+    on control plane nodes before kubeadm runs.
+
+    It includes:
+    - shared preKubeadmCommands that are executed on all nodes,
+    - provider-specific control plane commands specified in cluster-<provider> app,
+    - custom cluster-specific control plane commands.
 */}}
 {{- define "cluster.internal.controlPlane.kubeadm.preKubeadmCommands" }}
 {{- include "cluster.internal.kubeadm.preKubeadmCommands" $ }}
+{{- include "cluster.internal.controlPlane.kubeadm.preKubeadmCommands.provider" $ }}
 {{- include "cluster.internal.controlPlane.kubeadm.preKubeadmCommands.custom" $ }}
 {{- end }}
 
-{{- define "cluster.internal.controlPlane.kubeadm.preKubeadmCommands.custom" }}
-{{- if $.Values.providerIntegration.controlPlane.kubeadmConfig }}
+{{/* Provider-specific commands to run before kubeadm on control plane nodes */}}
+{{- define "cluster.internal.controlPlane.kubeadm.preKubeadmCommands.provider" }}
 {{- range $command := $.Values.providerIntegration.controlPlane.kubeadmConfig.preKubeadmCommands }}
 - {{ $command }}
 {{- end }}
+{{- end }}
+
+{{/* Custom cluster-specific commands to run before kubeadm on control plane nodes */}}
+{{- define "cluster.internal.controlPlane.kubeadm.preKubeadmCommands.custom" }}
+{{- range $command := $.Values.internal.advancedConfiguration.controlPlane.preKubeadmCommands }}
+- {{ $command }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/workers/_helpers_files.tpl
+++ b/helm/cluster/templates/clusterapi/workers/_helpers_files.tpl
@@ -1,8 +1,17 @@
 {{- define "cluster.internal.workers.kubeadm.files" }}
 {{- include "cluster.internal.kubeadm.files" $ }}
+{{- include "cluster.internal.workers.kubeadm.files.provider" $ }}
 {{- include "cluster.internal.workers.kubeadm.files.custom" $ }}
 {{- end }}
 
+{{/* Provider-specific files for worker nodes */}}
+{{- define "cluster.internal.workers.kubeadm.files.provider" }}
+{{- if $.Values.providerIntegration.workers.kubeadmConfig.files }}
+{{ toYaml $.Values.providerIntegration.workers.kubeadmConfig.files }}
+{{- end }}
+{{- end }}
+
+{{/* Custom cluster-specific files for worker nodes */}}
 {{- define "cluster.internal.workers.kubeadm.files.custom" }}
 {{- if $.Values.internal.advancedConfiguration.workers.files }}
 {{ toYaml $.Values.internal.advancedConfiguration.workers.files }}

--- a/helm/cluster/templates/clusterapi/workers/_helpers_files.tpl
+++ b/helm/cluster/templates/clusterapi/workers/_helpers_files.tpl
@@ -4,7 +4,7 @@
 {{- end }}
 
 {{- define "cluster.internal.workers.kubeadm.files.custom" }}
-{{- if $.Values.providerIntegration.workers.kubeadmConfig.files }}
-{{ toYaml $.Values.providerIntegration.workers.kubeadmConfig.files }}
+{{- if $.Values.internal.advancedConfiguration.workers.files }}
+{{ toYaml $.Values.internal.advancedConfiguration.workers.files }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/workers/_helpers_postkubeadmcommands.tpl
+++ b/helm/cluster/templates/clusterapi/workers/_helpers_postkubeadmcommands.tpl
@@ -1,17 +1,28 @@
 {{/*
-    Template cluster.internal.controlPlane.kubeadm.postKubeadmCommands defines extra commands to run
-    on worker nodes after kubeadm runs. It includes prefedined commands and custom commands
-    specified in Helm values field .Values.providerIntegration.workers.kubeadmConfig.postKubeadmCommands.
+    Template cluster.internal.workers.kubeadm.postKubeadmCommands defines commands to run
+    on worker nodes after kubeadm runs.
+
+    It includes:
+    - shared postKubeadmCommands that are executed on all nodes,
+    - provider-specific worker commands specified in cluster-<provider> app,
+    - custom cluster-specific worker commands.
 */}}
 {{- define "cluster.internal.workers.kubeadm.postKubeadmCommands" }}
 {{- include "cluster.internal.kubeadm.postKubeadmCommands" . }}
+{{- include "cluster.internal.workers.kubeadm.postKubeadmCommands.provider" . }}
 {{- include "cluster.internal.workers.kubeadm.postKubeadmCommands.custom" . }}
 {{- end }}
 
-{{- define "cluster.internal.workers.kubeadm.postKubeadmCommands.custom" }}
-{{- if $.Values.providerIntegration.workers.kubeadmConfig }}
+{{/* Provider-specific commands to run after kubeadm on worker nodes */}}
+{{- define "cluster.internal.workers.kubeadm.postKubeadmCommands.provider" }}
 {{- range $command := $.Values.providerIntegration.workers.kubeadmConfig.postKubeadmCommands }}
 - {{ $command }}
 {{- end }}
+{{- end }}
+
+{{/* Custom cluster-specific commands to run after kubeadm on worker nodes */}}
+{{- define "cluster.internal.workers.kubeadm.postKubeadmCommands.custom" }}
+{{- range $command := $.Values.internal.advancedConfiguration.workers.postKubeadmCommands }}
+- {{ $command }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/workers/_helpers_prekubeadmcommands.tpl
+++ b/helm/cluster/templates/clusterapi/workers/_helpers_prekubeadmcommands.tpl
@@ -1,17 +1,28 @@
 {{/*
-    Template cluster.internal.workers.kubeadm.preKubeadmCommands defines extra commands to run
-    on worker nodes before kubeadm runs. It includes prefedined commands and custom commands
-    specified in Helm values field .Values.providerIntegration.workers.kubeadmConfig.preKubeadmCommands.
+    Template cluster.internal.workers.kubeadm.preKubeadmCommands defines commands to run
+    on worker nodes before kubeadm runs.
+
+    It includes:
+    - shared preKubeadmCommands that are executed on all nodes,
+    - provider-specific worker commands specified in cluster-<provider> app,
+    - custom cluster-specific worker commands.
 */}}
 {{- define "cluster.internal.workers.kubeadm.preKubeadmCommands" }}
 {{- include "cluster.internal.kubeadm.preKubeadmCommands" $ }}
+{{- include "cluster.internal.workers.kubeadm.preKubeadmCommands.provider" $ }}
 {{- include "cluster.internal.workers.kubeadm.preKubeadmCommands.custom" $ }}
 {{- end }}
 
-{{- define "cluster.internal.workers.kubeadm.preKubeadmCommands.custom" }}
-{{- if $.Values.providerIntegration.workers.kubeadmConfig }}
+{{/* Provider-specific commands to run before kubeadm on worker nodes */}}
+{{- define "cluster.internal.workers.kubeadm.preKubeadmCommands.provider" }}
 {{- range $command := $.Values.providerIntegration.workers.kubeadmConfig.preKubeadmCommands }}
 - {{ $command }}
 {{- end }}
+{{- end }}
+
+{{/* Custom cluster-specific commands to run before kubeadm on worker nodes */}}
+{{- define "cluster.internal.workers.kubeadm.preKubeadmCommands.custom" }}
+{{- range $command := $.Values.internal.advancedConfiguration.workers.preKubeadmCommands }}
+- {{ $command }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1079,6 +1079,29 @@
                             "title": "CGroups v1",
                             "description": "Force use of CGroups v1 for whole cluster.",
                             "default": false
+                        },
+                        "controlPlane": {
+                            "type": "object",
+                            "title": "Control plane",
+                            "description": "Advanced configuration of control plane components.",
+                            "properties": {
+                                "apiServer": {
+                                    "type": "object",
+                                    "title": "API server",
+                                    "description": "Advanced configuration of API server.",
+                                    "properties": {
+                                        "extraCertificateSANs": {
+                                            "type": "array",
+                                            "title": "Extra certificate SANs",
+                                            "description": "The additional certificate SANs that are appended to the default SANs.",
+                                            "items": {
+                                                "type": "string",
+                                                "title": "Extra certificate SAN"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -1337,15 +1360,6 @@
                                                 "extraArgs": {
                                                     "type": "object",
                                                     "title": "Extra args"
-                                                },
-                                                "extraCertificateSANs": {
-                                                    "type": "array",
-                                                    "title": "Extra certificate SANs",
-                                                    "description": "The additional certificate SANs that are appended to the default SANs.",
-                                                    "items": {
-                                                        "type": "string",
-                                                        "title": "Extra certificate SAN"
-                                                    }
                                                 },
                                                 "featureGates": {
                                                     "type": "array",

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1316,7 +1316,7 @@
                 },
                 "controlPlane": {
                     "type": "object",
-                    "title": "Internal control plane configuration",
+                    "title": "Provider-specific control plane configuration",
                     "required": [
                         "kubeadmConfig",
                         "resources"
@@ -1511,6 +1511,14 @@
                                         }
                                     }
                                 },
+                                "files": {
+                                    "type": "array",
+                                    "title": "Files",
+                                    "description": "These are the files that are included on control plane nodes.",
+                                    "items": {
+                                        "$ref": "#/$defs/fileFromSecret"
+                                    }
+                                },
                                 "ignition": {
                                     "$ref": "#/$defs/ignition"
                                 },
@@ -1576,6 +1584,14 @@
                     "description": "Common kubeadm config for all nodes, including both control plane and workers.",
                     "additionalProperties": false,
                     "properties": {
+                        "files": {
+                            "type": "array",
+                            "title": "Files",
+                            "description": "These are the files that are included on control plane nodes.",
+                            "items": {
+                                "$ref": "#/$defs/fileFromSecret"
+                            }
+                        },
                         "ignition": {
                             "$ref": "#/$defs/ignition"
                         },
@@ -1765,7 +1781,7 @@
                 },
                 "workers": {
                     "type": "object",
-                    "title": "Internal workers configuration",
+                    "title": "Provider-specific workers configuration",
                     "additionalProperties": false,
                     "properties": {
                         "kubeadmConfig": {
@@ -1777,6 +1793,14 @@
                             ],
                             "additionalProperties": false,
                             "properties": {
+                                "files": {
+                                    "type": "array",
+                                    "title": "Files",
+                                    "description": "These are the files that are included on worker nodes.",
+                                    "items": {
+                                        "$ref": "#/$defs/fileFromSecret"
+                                    }
+                                },
                                 "ignition": {
                                     "$ref": "#/$defs/ignition"
                                 },

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1090,6 +1090,11 @@
                                     "title": "API server",
                                     "description": "Advanced configuration of API server.",
                                     "properties": {
+                                        "etcdPrefix": {
+                                            "type": "string",
+                                            "title": "etcd prefix",
+                                            "description": "The prefix to prepend to all resource paths in etcd. If nothing is specified, the API server uses '/registry' prefix by default."
+                                        },
                                         "extraArgs": {
                                             "type": "object",
                                             "title": "Extra CLI args",
@@ -1357,10 +1362,6 @@
                                                             ]
                                                         }
                                                     ]
-                                                },
-                                                "etcdPrefix": {
-                                                    "type": "string",
-                                                    "title": "etcd prefix"
                                                 },
                                                 "featureGates": {
                                                     "type": "array",

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1117,6 +1117,14 @@
                                             }
                                         }
                                     }
+                                },
+                                "files": {
+                                    "type": "array",
+                                    "title": "Files",
+                                    "description": "These are the files that are included on control plane nodes.",
+                                    "items": {
+                                        "$ref": "#/$defs/fileFromSecret"
+                                    }
                                 }
                             }
                         },
@@ -1486,14 +1494,6 @@
                                                 }
                                             }
                                         }
-                                    }
-                                },
-                                "files": {
-                                    "type": "array",
-                                    "title": "Files",
-                                    "description": "These are the files that are included on control plane nodes.",
-                                    "items": {
-                                        "$ref": "#/$defs/fileFromSecret"
                                     }
                                 },
                                 "ignition": {

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1125,6 +1125,12 @@
                                     "items": {
                                         "$ref": "#/$defs/fileFromSecret"
                                     }
+                                },
+                                "postKubeadmCommands": {
+                                    "$ref": "#/$defs/postKubeadmCommands"
+                                },
+                                "preKubeadmCommands": {
+                                    "$ref": "#/$defs/preKubeadmCommands"
                                 }
                             }
                         },
@@ -1135,6 +1141,12 @@
                             "items": {
                                 "$ref": "#/$defs/fileFromSecret"
                             }
+                        },
+                        "postKubeadmCommands": {
+                            "$ref": "#/$defs/postKubeadmCommands"
+                        },
+                        "preKubeadmCommands": {
+                            "$ref": "#/$defs/preKubeadmCommands"
                         },
                         "workers": {
                             "type": "object",
@@ -1148,6 +1160,12 @@
                                     "items": {
                                         "$ref": "#/$defs/fileFromSecret"
                                     }
+                                },
+                                "postKubeadmCommands": {
+                                    "$ref": "#/$defs/postKubeadmCommands"
+                                },
+                                "preKubeadmCommands": {
+                                    "$ref": "#/$defs/preKubeadmCommands"
                                 }
                             }
                         }
@@ -1580,8 +1598,8 @@
                 },
                 "kubeadmConfig": {
                     "type": "object",
-                    "title": "Kubeadm config",
-                    "description": "Common kubeadm config for all nodes, including both control plane and workers.",
+                    "title": "Provider-specific kubeadm config",
+                    "description": "Provider-specific kubeadm config that is common for all nodes, including both control plane and workers.",
                     "additionalProperties": false,
                     "properties": {
                         "files": {

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1121,7 +1121,7 @@
                                 "files": {
                                     "type": "array",
                                     "title": "Files",
-                                    "description": "These are the files that are included on control plane nodes.",
+                                    "description": "Custom cluster-specific files that are deployed to control plane nodes.",
                                     "items": {
                                         "$ref": "#/$defs/fileFromSecret"
                                     }
@@ -1131,7 +1131,7 @@
                         "files": {
                             "type": "array",
                             "title": "Files",
-                            "description": "These are the files that are included on all the nodes.",
+                            "description": "Custom cluster-specific files that are deployed to all nodes.",
                             "items": {
                                 "$ref": "#/$defs/fileFromSecret"
                             }
@@ -1144,7 +1144,7 @@
                                 "files": {
                                     "type": "array",
                                     "title": "Files",
-                                    "description": "These are the files that are included on worker nodes.",
+                                    "description": "Custom cluster-specific files that are deployed to worker nodes.",
                                     "items": {
                                         "$ref": "#/$defs/fileFromSecret"
                                     }
@@ -1514,7 +1514,7 @@
                                 "files": {
                                     "type": "array",
                                     "title": "Files",
-                                    "description": "These are the files that are included on control plane nodes.",
+                                    "description": "Provider-specific files that are deployed to control plane nodes. They are specified in the cluster-<provider> apps.",
                                     "items": {
                                         "$ref": "#/$defs/fileFromSecret"
                                     }
@@ -1587,7 +1587,7 @@
                         "files": {
                             "type": "array",
                             "title": "Files",
-                            "description": "These are the files that are included on control plane nodes.",
+                            "description": "Provider-specific files that are deployed to all nodes. They are specified in the cluster-<provider> apps.",
                             "items": {
                                 "$ref": "#/$defs/fileFromSecret"
                             }
@@ -1796,7 +1796,7 @@
                                 "files": {
                                     "type": "array",
                                     "title": "Files",
-                                    "description": "These are the files that are included on worker nodes.",
+                                    "description": "Provider-specific files that are deployed to worker nodes. They are specified in the cluster-<provider> apps.",
                                     "items": {
                                         "$ref": "#/$defs/fileFromSecret"
                                     }

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1090,6 +1090,13 @@
                                     "title": "API server",
                                     "description": "Advanced configuration of API server.",
                                     "properties": {
+                                        "bindPort": {
+                                            "type": "integer",
+                                            "title": "Bind port",
+                                            "description": "Kubernetes API bind port used for API server pod.",
+                                            "maximum": 65535,
+                                            "minimum": 0
+                                        },
                                         "etcdPrefix": {
                                             "type": "string",
                                             "title": "etcd prefix",
@@ -1290,8 +1297,7 @@
                             "title": "Kubeadm config",
                             "description": "Configuration of control plane nodes.",
                             "required": [
-                                "ignition",
-                                "localAPIEndpoint"
+                                "ignition"
                             ],
                             "additionalProperties": false,
                             "properties": {
@@ -1484,21 +1490,6 @@
                                 },
                                 "ignition": {
                                     "$ref": "#/$defs/ignition"
-                                },
-                                "localAPIEndpoint": {
-                                    "type": "object",
-                                    "title": "Local API endpoint",
-                                    "required": [
-                                        "bindPort"
-                                    ],
-                                    "properties": {
-                                        "bindPort": {
-                                            "type": "integer",
-                                            "title": "Bind port",
-                                            "description": "Kubernetes API bind port used for API server pod.",
-                                            "default": 6443
-                                        }
-                                    }
                                 },
                                 "postKubeadmCommands": {
                                     "$ref": "#/$defs/postKubeadmCommands"

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1118,6 +1118,42 @@
                                         }
                                     }
                                 },
+                                "etcd": {
+                                    "type": "object",
+                                    "title": "etcd",
+                                    "description": "Configuration of etcd",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "experimental": {
+                                            "type": "object",
+                                            "title": "Experimental",
+                                            "properties": {
+                                                "peerSkipClientSanVerification": {
+                                                    "type": "boolean",
+                                                    "title": "Peer skip client SAN verification",
+                                                    "description": "Skip verification of SAN field in client certificate for peer connections."
+                                                }
+                                            }
+                                        },
+                                        "extraArgs": {
+                                            "type": "object",
+                                            "title": "Extra args"
+                                        },
+                                        "initialCluster": {
+                                            "type": "string",
+                                            "title": "Initial cluster",
+                                            "description": "Initial cluster configuration for bootstrapping."
+                                        },
+                                        "initialClusterState": {
+                                            "type": "string",
+                                            "title": "Initial cluster state",
+                                            "enum": [
+                                                "new",
+                                                "existing"
+                                            ]
+                                        }
+                                    }
+                                },
                                 "files": {
                                     "type": "array",
                                     "title": "Files",
@@ -1490,42 +1526,6 @@
                                                 }
                                             },
                                             "default": {}
-                                        },
-                                        "etcd": {
-                                            "type": "object",
-                                            "title": "etcd",
-                                            "description": "Configuration of etcd",
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "experimental": {
-                                                    "type": "object",
-                                                    "title": "Experimental",
-                                                    "properties": {
-                                                        "peerSkipClientSanVerification": {
-                                                            "type": "boolean",
-                                                            "title": "Peer skip client SAN verification",
-                                                            "description": "Skip verification of SAN field in client certificate for peer connections."
-                                                        }
-                                                    }
-                                                },
-                                                "extraArgs": {
-                                                    "type": "object",
-                                                    "title": "Extra args"
-                                                },
-                                                "initialCluster": {
-                                                    "type": "string",
-                                                    "title": "Initial cluster",
-                                                    "description": "Initial cluster configuration for bootstrapping."
-                                                },
-                                                "initialClusterState": {
-                                                    "type": "string",
-                                                    "title": "Initial cluster state",
-                                                    "enum": [
-                                                        "new",
-                                                        "existing"
-                                                    ]
-                                                }
-                                            }
                                         }
                                     }
                                 },

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1135,6 +1135,21 @@
                             "items": {
                                 "$ref": "#/$defs/fileFromSecret"
                             }
+                        },
+                        "workers": {
+                            "type": "object",
+                            "title": "Workers",
+                            "description": "Advanced configuration of worker nodes.",
+                            "properties": {
+                                "files": {
+                                    "type": "array",
+                                    "title": "Files",
+                                    "description": "These are the files that are included on worker nodes.",
+                                    "items": {
+                                        "$ref": "#/$defs/fileFromSecret"
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -1762,14 +1777,6 @@
                             ],
                             "additionalProperties": false,
                             "properties": {
-                                "files": {
-                                    "type": "array",
-                                    "title": "Files",
-                                    "description": "These are the files that are included on worker nodes.",
-                                    "items": {
-                                        "$ref": "#/$defs/fileFromSecret"
-                                    }
-                                },
                                 "ignition": {
                                     "$ref": "#/$defs/ignition"
                                 },

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1119,6 +1119,14 @@
                                     }
                                 }
                             }
+                        },
+                        "files": {
+                            "type": "array",
+                            "title": "Files",
+                            "description": "These are the files that are included on all the nodes.",
+                            "items": {
+                                "$ref": "#/$defs/fileFromSecret"
+                            }
                         }
                     }
                 }
@@ -1553,14 +1561,6 @@
                     "description": "Common kubeadm config for all nodes, including both control plane and workers.",
                     "additionalProperties": false,
                     "properties": {
-                        "files": {
-                            "type": "array",
-                            "title": "Files",
-                            "description": "These are the files that are included on all the nodes.",
-                            "items": {
-                                "$ref": "#/$defs/fileFromSecret"
-                            }
-                        },
                         "ignition": {
                             "$ref": "#/$defs/ignition"
                         },

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1090,10 +1090,15 @@
                                     "title": "API server",
                                     "description": "Advanced configuration of API server.",
                                     "properties": {
+                                        "extraArgs": {
+                                            "type": "object",
+                                            "title": "Extra CLI args",
+                                            "description": "A map with the additional CLI flags that are appended to the default flags. Use with caution, as there is no validation for these values, so you can set incorrect or duplicate flags."
+                                        },
                                         "extraCertificateSANs": {
                                             "type": "array",
                                             "title": "Extra certificate SANs",
-                                            "description": "The additional certificate SANs that are appended to the default SANs.",
+                                            "description": "The additional certificate SANs that are appended to the default SANs. Use with caution, as there is no validation for these values, so you can set incorrect or duplicate certificates.",
                                             "items": {
                                                 "type": "string",
                                                 "title": "Extra certificate SAN"
@@ -1356,10 +1361,6 @@
                                                 "etcdPrefix": {
                                                     "type": "string",
                                                     "title": "etcd prefix"
-                                                },
-                                                "extraArgs": {
-                                                    "type": "object",
-                                                    "title": "Extra args"
                                                 },
                                                 "featureGates": {
                                                     "type": "array",

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -67,8 +67,6 @@ providerIntegration:
           additionalConfig:
             storage: {}
             systemd: {}
-      localAPIEndpoint:
-        bindPort: 6443
     resources:
       controlPlane:
         api:

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -38,6 +38,8 @@ internal:
     cgroupsv1: false
     controlPlane:
       apiServer: {}
+      etcd:
+        experimental: {}
     workers: {}
 providerIntegration:
   bastion:
@@ -61,8 +63,6 @@ providerIntegration:
     kubeadmConfig:
       clusterConfiguration:
         apiServer: {}
-        etcd:
-          experimental: {}
       ignition:
         containerLinuxConfig:
           additionalConfig:

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -36,6 +36,8 @@ global:
 internal:
   advancedConfiguration:
     cgroupsv1: false
+    controlPlane:
+      apiServer: {}
 providerIntegration:
   bastion:
     kubeadmConfig:

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -38,6 +38,7 @@ internal:
     cgroupsv1: false
     controlPlane:
       apiServer: {}
+    workers: {}
 providerIntegration:
   bastion:
     kubeadmConfig:


### PR DESCRIPTION
### What does this PR do?

This PR moves advanced properties that can be customised for every cluster to `.Values.internal.advancedConfiguration`. These advanced properties are currently in `.Values.providerIntegration`, which is incorrect, because `.Values.providerIntegration` is meant to be immutable and set statically (hard-coded) only in Helm `values.yaml` in cluster-\<provider\> apps.

Changes:
- Move `extraCertificateSANs` property to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
- Move API server `extraArgs` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
- Move API server `etcdPrefix` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
- Move API server `bindPort` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
- Add custom `files` config to Helm value to `.Values.internal.advancedConfiguration`.
- Add custom `preKubeadmCommands` config to Helm value to `.Values.internal.advancedConfiguration`.
- Add custom `postKubeadmCommands` config to Helm value to `.Values.internal.advancedConfiguration`.
- Move advanced etcd config to `.Values.internal.advancedConfiguration.controlPlane.etcd`.

### What is the effect of this change to users?

Advanced cluster properties can be set in `.Values.internal.advancedConfiguration`

### How does it look like?

Before:

```yaml
providerIntegration:
  controlPlane:
    kubeadmConfig:
      clusterConfiguration:
        apiServer:
          etcdPrefix: giantswarm.io
          extraArgs:
            allow-privileged: false
            authorization-webhook-version: v1beta1
            delete-collection-workers: 2
            min-request-timeout: 600
          extraCertificateSANs:
          - this-is-extra-cert-san.giantswarm.io
          - another-extra-cert-san.giantswarm.io
        etcd: { ... }
      files:
      - path: /etc/hello/control-plane/node/stuff.yaml
        permissions: "0644"
        contentFrom:
          secret:
            name: cluster-super-secret-control-plane
            key: node-stuff
      localApiEndpoint:
        bindPort: 6443
```

After:

```yaml
internal:
  advancedConfiguration:
    controlPlane:
      apiServer:
        bindPort: 6443
        etcdPrefix: giantswarm.io
        extraArgs:
          allow-privileged: false
          authorization-webhook-version: v1beta1
          delete-collection-workers: 2
          min-request-timeout: 600
        extraCertificateSANs:
        - this-is-extra-cert-san.giantswarm.io
        - another-extra-cert-san.giantswarm.io
      etcd: { ... }
      files:
      - path: /etc/hello/control-plane/node/stuff.yaml
        permissions: "0644"
        contentFrom:
          secret:
            name: cluster-super-secret-control-plane
            key: node-stuff
```

### Any background context you can provide?

We are customising these values via capi-migration-cli tool when migrating vintage AWS clusters to CAPA. Currently capi-migration-cli is setting these values in cluster-aws `Values.internal`, which will stop working when cluster-aws starts to render control plane resources from the cluster chart (https://github.com/giantswarm/cluster-aws/pull/479).

### Do the docs need to be updated?

Auto-generated docs are updated.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
