### PR TITLE
Fix cluster.connectivity.proxy.noProxy template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix "cluster.connectivity.proxy.noProxy" template to correctly render values from specified template.
+
 ## [0.3.0] - 2024-01-22
 
 ### Changed

--- a/helm/cluster/templates/clusterapi/_helpers.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers.tpl
@@ -51,7 +51,8 @@
 {{- end }}
 {{- /* Add provider-specific NO_PROXY values from template */}}
 {{- if $providerIntegration.connectivity.proxy.noProxy.templateName }}
-{{- range $noProxyAddress := include $providerIntegration.connectivity.proxy.noProxy.templateName $ | fromYamlArray }}
+{{- $values := dict "global" $global }}
+{{- range $noProxyAddress := include $providerIntegration.connectivity.proxy.noProxy.templateName (dict "Values" $values) | fromYamlArray }}
 {{- $noProxyList = append $noProxyList $noProxyAddress -}}
 {{- end }}
 {{- end }}
@@ -67,7 +68,7 @@
 {{- end }}
 
 {{- define "cluster.test.internal.kubeadm.proxy.anotherNoProxyList" }}
-- some.noproxy.address.giantswarm.io
+- some.noproxy.{{ $.Values.global.metadata.name }}.{{ $.Values.global.connectivity.baseDomain }}
 - another.noproxy.address.giantswarm.io
 {{- end }}
 


### PR DESCRIPTION
### What does this PR do?

Fix "cluster.connectivity.proxy.noProxy" template to correctly render values from specified template (a bug was introduced in https://github.com/giantswarm/cluster/pull/50).

### What is the effect of this change to users?

NO_PROXY is correctly rendered.

### Any background context you can provide?

https://github.com/giantswarm/cluster-aws/pull/479#discussion_r1455411843

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
