### PR TITLE
Add etcd quota backend bytes config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add custom `files` config to Helm value to `.Values.internal.advancedConfiguration`.
 - Add custom `preKubeadmCommands` config to Helm value to `.Values.internal.advancedConfiguration`.
 - Add custom `postKubeadmCommands` config to Helm value to `.Values.internal.advancedConfiguration`.
+- Add `quotaBackendBytes` etcd config to Helm value `.Values.internal.advancedConfiguration.etcd`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add custom `files` config to Helm value to `.Values.internal.advancedConfiguration`.
 - Add custom `preKubeadmCommands` config to Helm value to `.Values.internal.advancedConfiguration`.
 - Add custom `postKubeadmCommands` config to Helm value to `.Values.internal.advancedConfiguration`.
-- Add `quotaBackendBytes` etcd config to Helm value `.Values.internal.advancedConfiguration.etcd`.
+- Add `quotaBackendBytesGiB` etcd config to Helm value `.Values.internal.advancedConfiguration.etcd`.
 
 ### Changed
 

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -107,6 +107,7 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.advancedConfiguration.controlPlane.etcd.extraArgs` | **Extra args**|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.controlPlane.etcd.initialCluster` | **Initial cluster** - Initial cluster configuration for bootstrapping.|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.controlPlane.etcd.initialClusterState` | **Initial cluster state**|**Type:** `string`<br/>|
+| `internal.advancedConfiguration.controlPlane.etcd.quotaBackendBytes` | **Quota backend bytes** - Raise the etcd default backend bytes limit up to 16GiB.|**Type:** `string`<br/>**Default:** `"8589934592"`|
 | `internal.advancedConfiguration.controlPlane.files` | **Files** - Custom cluster-specific files that are deployed to control plane nodes.|**Type:** `array`<br/>|
 | `internal.advancedConfiguration.controlPlane.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.controlPlane.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -107,7 +107,7 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.advancedConfiguration.controlPlane.etcd.extraArgs` | **Extra args**|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.controlPlane.etcd.initialCluster` | **Initial cluster** - Initial cluster configuration for bootstrapping.|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.controlPlane.etcd.initialClusterState` | **Initial cluster state**|**Type:** `string`<br/>|
-| `internal.advancedConfiguration.controlPlane.etcd.quotaBackendBytes` | **Quota backend bytes** - Raise the etcd default backend bytes limit up to 16GiB.|**Type:** `string`<br/>**Default:** `"8589934592"`|
+| `internal.advancedConfiguration.controlPlane.etcd.quotaBackendBytesGiB` | **Quota backend bytes in GiB** - Raise the etcd default backend bytes limit up to 16GiB.|**Type:** `integer`<br/>**Default:** `8`|
 | `internal.advancedConfiguration.controlPlane.files` | **Files** - Custom cluster-specific files that are deployed to control plane nodes.|**Type:** `array`<br/>|
 | `internal.advancedConfiguration.controlPlane.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.controlPlane.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -73,7 +73,7 @@ internal:
         - this-is-extra-cert-san.giantswarm.io
         - another-extra-cert-san.giantswarm.io
       etcd:
-        quotaBackendBytes: 34359738368
+        quotaBackendBytes: "34359738368"
         initialCluster: "default=http://localhost:2380"
         initialClusterState: "existing"
         extraArgs:

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -73,6 +73,7 @@ internal:
         - this-is-extra-cert-san.giantswarm.io
         - another-extra-cert-san.giantswarm.io
       etcd:
+        backendQuotaBytes: 17179869184
         initialCluster: "default=http://localhost:2380"
         initialClusterState: "existing"
         extraArgs:

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -73,7 +73,7 @@ internal:
         - this-is-extra-cert-san.giantswarm.io
         - another-extra-cert-san.giantswarm.io
       etcd:
-        quotaBackendBytes: "34359738368"
+        quotaBackendBytesGiB: 32
         initialCluster: "default=http://localhost:2380"
         initialClusterState: "existing"
         extraArgs:

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -73,7 +73,7 @@ internal:
         - this-is-extra-cert-san.giantswarm.io
         - another-extra-cert-san.giantswarm.io
       etcd:
-        backendQuotaBytes: 17179869184
+        quotaBackendBytes: 34359738368
         initialCluster: "default=http://localhost:2380"
         initialClusterState: "existing"
         extraArgs:

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -73,7 +73,7 @@ internal:
         - this-is-extra-cert-san.giantswarm.io
         - another-extra-cert-san.giantswarm.io
       etcd:
-        quotaBackendBytesGiB: 32
+        quotaBackendBytesGiB: 16
         initialCluster: "default=http://localhost:2380"
         initialClusterState: "existing"
         extraArgs:

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_etcd.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_etcd.tpl
@@ -2,8 +2,12 @@
 local:
   extraArgs:
     listen-metrics-urls: "http://0.0.0.0:2381"
-    quota-backend-bytes: "8589934592"
     {{- with $etcdConfig := $.Values.internal.advancedConfiguration.controlPlane.etcd }}
+    {{- if gt (int $etcdConfig.quotaBackendBytes) 17179869184 }}
+    quota-backend-bytes: 17179869184
+    {{- else }}
+    quota-backend-bytes: {{ int $etcdConfig.quotaBackendBytes }}
+    {{- end }}
     {{- if $etcdConfig.initialCluster }}
     initial-cluster: {{ $etcdConfig.initialCluster | quote }}
     {{- end }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_etcd.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_etcd.tpl
@@ -3,11 +3,7 @@ local:
   extraArgs:
     listen-metrics-urls: "http://0.0.0.0:2381"
     {{- with $etcdConfig := $.Values.internal.advancedConfiguration.controlPlane.etcd }}
-    {{- if gt (int $etcdConfig.quotaBackendBytesGiB) 16 }}
-    quota-backend-bytes: 17179869184
-    {{- else }}
     quota-backend-bytes: {{ mul $etcdConfig.quotaBackendBytesGiB 1024 1024 1024 }}
-    {{- end }}
     {{- if $etcdConfig.initialCluster }}
     initial-cluster: {{ $etcdConfig.initialCluster | quote }}
     {{- end }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_etcd.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_etcd.tpl
@@ -3,10 +3,10 @@ local:
   extraArgs:
     listen-metrics-urls: "http://0.0.0.0:2381"
     {{- with $etcdConfig := $.Values.internal.advancedConfiguration.controlPlane.etcd }}
-    {{- if gt (int $etcdConfig.quotaBackendBytes) 17179869184 }}
+    {{- if gt (int $etcdConfig.quotaBackendBytesGiB) 16 }}
     quota-backend-bytes: 17179869184
     {{- else }}
-    quota-backend-bytes: {{ int $etcdConfig.quotaBackendBytes }}
+    quota-backend-bytes: {{ mul $etcdConfig.quotaBackendBytesGiB 1024 1024 1024 }}
     {{- end }}
     {{- if $etcdConfig.initialCluster }}
     initial-cluster: {{ $etcdConfig.initialCluster | quote }}

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1152,11 +1152,11 @@
                                                 "existing"
                                             ]
                                         },
-                                        "quotaBackendBytes": {
-                                            "type": "string",
-                                            "title": "Quota backend bytes",
+                                        "quotaBackendBytesGiB": {
+                                            "type": "integer",
+                                            "title": "Quota backend bytes in GiB",
                                             "description": "Raise the etcd default backend bytes limit up to 16GiB.",
-                                            "default": "8589934592"
+                                            "default": 8
                                         }
                                     }
                                 },

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1156,7 +1156,9 @@
                                             "type": "integer",
                                             "title": "Quota backend bytes in GiB",
                                             "description": "Raise the etcd default backend bytes limit up to 16GiB.",
-                                            "default": 8
+                                            "default": 8,
+                                            "maximum": 16,
+                                            "minimum": 8
                                         }
                                     }
                                 },

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1151,6 +1151,12 @@
                                                 "new",
                                                 "existing"
                                             ]
+                                        },
+                                        "quotaBackendBytes": {
+                                            "type": "string",
+                                            "title": "Quota backend bytes",
+                                            "description": "Raise the etcd default backend bytes limit up to 16GiB.",
+                                            "default": "8589934592"
                                         }
                                     }
                                 },

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -40,6 +40,7 @@ internal:
       apiServer: {}
       etcd:
         experimental: {}
+        quotaBackendBytes: "8589934592"
     workers: {}
 providerIntegration:
   bastion:

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -40,7 +40,7 @@ internal:
       apiServer: {}
       etcd:
         experimental: {}
-        quotaBackendBytes: "8589934592"
+        quotaBackendBytesGiB: 8
     workers: {}
 providerIntegration:
   bastion:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/2977

We want to add the possibility to adjust the etcd quota backend bytes up to 16GiB.