### PR TITLE
Use gsoci.azurecr.io registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move API server `etcdPrefix` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
 - Move API server `bindPort` Helm value to `.Values.internal.advancedConfiguration.controlPlane.apiServer`.
 - Move advanced etcd config to `.Values.internal.advancedConfiguration.controlPlane.etcd`.
+- Use `gsoci.azurecr.io` for `kubeadm` container images (ported from https://github.com/giantswarm/cluster-aws/pull/482).
+- Use `gsoci.azurecr.io` for sandbox container image (pause container) (ported from https://github.com/giantswarm/cluster-aws/pull/482).
+
+### Fixed
+
+- Fix typo in sandbox container scheme (ported from https://github.com/giantswarm/cluster-aws/pull/486).
 
 ## [0.3.1] - 2024-01-23
 

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -248,9 +248,9 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.clusterAnnotationsTemplateName` | **Cluster annotations template name** - The name of the template that renders provider-specific annotations for the Cluster resource|**Type:** `string`<br/>|
 | `providerIntegration.components` | **Components** - Internal configuration of various components that form the Kubernetes cluster.|**Type:** `object`<br/>|
 | `providerIntegration.components.containerd` | **Containerd** - Configuration of containerd.|**Type:** `object`<br/>|
-| `providerIntegration.components.containerd.sandboxContainerImage` | **Kubectl image**|**Type:** `object`<br/>|
+| `providerIntegration.components.containerd.sandboxContainerImage` | **Sandbox image** - The image used by sandbox / pause container|**Type:** `object`<br/>|
 | `providerIntegration.components.containerd.sandboxContainerImage.name` | **Repository**|**Type:** `string`<br/>**Default:** `"giantswarm/pause"`|
-| `providerIntegration.components.containerd.sandboxContainerImage.registry` | **Registry**|**Type:** `string`<br/>**Default:** `"quay.io"`|
+| `providerIntegration.components.containerd.sandboxContainerImage.registry` | **Registry**|**Type:** `string`<br/>**Default:** `"gsoci.azurecr.io"`|
 | `providerIntegration.components.containerd.sandboxContainerImage.tag` | **Tag**|**Type:** `string`<br/>**Default:** `"3.9"`|
 | `providerIntegration.components.systemd` | **systemd**||
 | `providerIntegration.connectivity` | **Connectivity** - Internal connectivity configuration.|**Type:** `object`<br/>|

--- a/helm/cluster/templates/clusterapi/controlplane/kubeadmcontrolplane.yaml
+++ b/helm/cluster/templates/clusterapi/controlplane/kubeadmcontrolplane.yaml
@@ -27,7 +27,7 @@ spec:
     clusterConfiguration:
       # Avoid accessibility issues (e.g. on private clusters) and potential future rate limits for
       # the default `registry.k8s.io`.
-      imageRepository: docker.io/giantswarm
+      imageRepository: gsoci.azurecr.io/giantswarm
       # API server configuration
       apiServer:
         {{- include "cluster.internal.controlPlane.kubeadm.clusterConfiguration.apiServer" $ | indent 8 }}

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1269,7 +1269,8 @@
                             "properties": {
                                 "sandboxContainerImage": {
                                     "type": "object",
-                                    "title": "Kubectl image",
+                                    "title": "Sandbox image",
+                                    "description": "The image used by sandbox / pause container",
                                     "required": [
                                         "name",
                                         "registry",
@@ -1284,7 +1285,7 @@
                                         "registry": {
                                             "type": "string",
                                             "title": "Registry",
-                                            "default": "quay.io"
+                                            "default": "gsoci.azurecr.io"
                                         },
                                         "tag": {
                                             "type": "string",

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -53,7 +53,7 @@ providerIntegration:
     containerd:
       sandboxContainerImage:
         name: giantswarm/pause
-        registry: quay.io
+        registry: gsoci.azurecr.io
         tag: "3.9"
   connectivity:
     proxy:


### PR DESCRIPTION
### What does this PR do?

This got merged in cluster-aws https://github.com/giantswarm/cluster-aws/pull/482, so we need the same change now in the cluster chart as well, so we don't revert cluster-aws change when we merge https://github.com/giantswarm/cluster-aws/pull/479 because cluster chart is still using the old registries.

### How does it look like?

See diff.

### Any background context you can provide?

- https://github.com/giantswarm/cluster-aws/pull/479
- https://github.com/giantswarm/cluster-aws/pull/482
- https://github.com/giantswarm/roadmap/issues/3108

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [ ] CHANGELOG.md has been updated (if it exists)
