### PR TITLE
Added support for RolloutBefore field in KubeadmControlPlane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `rolloutBefore` config to Helm value to `.Values.global.controlPlane` to enable support for automatic certificate renewal
+- Add `rolloutBefore` config to Helm value to `.Values.internal.advancedConfiguration.controlPlane` to enable support for automatic node rollout/certificate renewal
 
 ## [0.7.1] - 2024-01-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `rolloutBefore` config to Helm value to `.Values.global.controlPlane` to enable support for automatic certificate renewal
+
 ## [0.7.1] - 2024-01-31
 
 ### Fixed

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -85,8 +85,8 @@ Configuration of the control plane.
 | `global.controlPlane.oidc.issuerUrl` | **Issuer URL** - Exact issuer URL that will be included in identity tokens.|**Type:** `string`<br/>|
 | `global.controlPlane.oidc.usernameClaim` | **Username claim**|**Type:** `string`<br/>|
 | `global.controlPlane.replicas` | **Replicas** - The number of control plane nodes.|**Type:** `integer`<br/>**Default:** `3`|
-| `global.controlPlane.rolloutBefore` | **Rollout Before** - Rollout Before is a field to indicate a rollout should be performed if the specified criteria is met|**Type:** `object`<br/>|
-| `global.controlPlane.rolloutBefore.certificatesExpiryDays` | **Certificate expiry days** - Indicates a rollout needs to be performed if the certificates of the machine will expire within the specified days|**Type:** `integer`<br/>**Default:** `180`|
+| `global.controlPlane.rolloutBefore` | **Rollout Before** - Rollout Before is a field to indicate a rollout should be performed if the specified criteria is met.|**Type:** `object`<br/>|
+| `global.controlPlane.rolloutBefore.certificatesExpiryDays` | **Certificate expiry days** - Indicates a rollout needs to be performed if the certificates of the machine will expire within the specified days.|**Type:** `integer`<br/>**Default:** `180`|
 
 ### Internal
 Properties within the `.internal` top-level object

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -85,6 +85,8 @@ Configuration of the control plane.
 | `global.controlPlane.oidc.issuerUrl` | **Issuer URL** - Exact issuer URL that will be included in identity tokens.|**Type:** `string`<br/>|
 | `global.controlPlane.oidc.usernameClaim` | **Username claim**|**Type:** `string`<br/>|
 | `global.controlPlane.replicas` | **Replicas** - The number of control plane nodes.|**Type:** `integer`<br/>**Default:** `3`|
+| `global.controlPlane.rolloutBefore` | **Rollout Before** - Rollout Before is a field to indicate a rollout should be performed if the specified criteria is met|**Type:** `object`<br/>|
+| `global.controlPlane.rolloutBefore.certificatesExpiryDays` | **Certificate expiry days** - Indicates a rollout needs to be performed if the certificates of the machine will expire within the specified days|**Type:** `integer`<br/>**Default:** `180`|
 
 ### Internal
 Properties within the `.internal` top-level object

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -85,8 +85,6 @@ Configuration of the control plane.
 | `global.controlPlane.oidc.issuerUrl` | **Issuer URL** - Exact issuer URL that will be included in identity tokens.|**Type:** `string`<br/>|
 | `global.controlPlane.oidc.usernameClaim` | **Username claim**|**Type:** `string`<br/>|
 | `global.controlPlane.replicas` | **Replicas** - The number of control plane nodes.|**Type:** `integer`<br/>**Default:** `3`|
-| `global.controlPlane.rolloutBefore` | **Rollout Before** - Rollout Before is a field to indicate a rollout should be performed if the specified criteria is met.|**Type:** `object`<br/>|
-| `global.controlPlane.rolloutBefore.certificatesExpiryDays` | **Certificate expiry days** - Indicates a rollout needs to be performed if the certificates of the machine will expire within the specified days.|**Type:** `integer`<br/>**Default:** `180`|
 
 ### Internal
 Properties within the `.internal` top-level object
@@ -122,6 +120,8 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.advancedConfiguration.controlPlane.postKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.controlPlane.preKubeadmCommands` | **Pre-kubeadm commands** - Extra commands to run before kubeadm runs.|**Type:** `array`<br/>|
 | `internal.advancedConfiguration.controlPlane.preKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
+| `internal.advancedConfiguration.controlPlane.rolloutBefore` | **Rollout Before** - Rollout Before is a field to indicate a rollout should be performed if the specified criteria is met.|**Type:** `object`<br/>|
+| `internal.advancedConfiguration.controlPlane.rolloutBefore.certificatesExpiryDays` | **Certificate expiry days** - Indicates a rollout needs to be performed if the certificates of the machine will expire within the specified days.|**Type:** `integer`<br/>**Default:** `180`|
 | `internal.advancedConfiguration.files` | **Files** - Custom cluster-specific files that are deployed to all nodes.|**Type:** `array`<br/>|
 | `internal.advancedConfiguration.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|

--- a/helm/cluster/templates/clusterapi/controlplane/kubeadmcontrolplane.yaml
+++ b/helm/cluster/templates/clusterapi/controlplane/kubeadmcontrolplane.yaml
@@ -58,5 +58,7 @@ spec:
     {{- $users | indent 4 }}
     {{- end }}
   replicas: {{ .Values.global.controlPlane.replicas }}
+  rolloutBefore:
+    {{- toYaml $.Values.global.controlPlane.rolloutBefore | nindent 4 }}
   version: v{{ trimPrefix "v" .Values.providerIntegration.kubernetesVersion }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/controlplane/kubeadmcontrolplane.yaml
+++ b/helm/cluster/templates/clusterapi/controlplane/kubeadmcontrolplane.yaml
@@ -57,8 +57,8 @@ spec:
     users:
     {{- $users | indent 4 }}
     {{- end }}
-  replicas: {{ .Values.global.controlPlane.replicas }}
+  replicas: {{ .Values.internal.advancedConfiguration.controlPlane.replicas }}
   rolloutBefore:
-    {{- toYaml $.Values.global.controlPlane.rolloutBefore | nindent 4 }}
+    {{- toYaml $.Values.internal.advancedConfiguration.controlPlane.rolloutBefore | nindent 4 }}
   version: v{{ trimPrefix "v" .Values.providerIntegration.kubernetesVersion }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/controlplane/kubeadmcontrolplane.yaml
+++ b/helm/cluster/templates/clusterapi/controlplane/kubeadmcontrolplane.yaml
@@ -57,7 +57,7 @@ spec:
     users:
     {{- $users | indent 4 }}
     {{- end }}
-  replicas: {{ .Values.internal.advancedConfiguration.controlPlane.replicas }}
+  replicas: {{ .Values.global.controlPlane.replicas }}
   rolloutBefore:
     {{- toYaml $.Values.internal.advancedConfiguration.controlPlane.rolloutBefore | nindent 4 }}
   version: v{{ trimPrefix "v" .Values.providerIntegration.kubernetesVersion }}

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -894,7 +894,9 @@
                             "type": "object",
                             "title": "Rollout Before",
                             "description": "Rollout Before is a field to indicate a rollout should be performed if the specified criteria is met",
-                            "required": ["certificatesExpiryDays"],
+                            "required": [
+                                "certificatesExpiryDays"
+                            ],
                             "properties": {
                                 "certificatesExpiryDays": {
                                     "type": "integer",

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -893,7 +893,7 @@
                         "rolloutBefore": {
                             "type": "object",
                             "title": "Rollout Before",
-                            "description": "Rollout Before is a field to indicate a rollout should be performed if the specified criteria is met",
+                            "description": "Rollout Before is a field to indicate a rollout should be performed if the specified criteria is met.",
                             "required": [
                                 "certificatesExpiryDays"
                             ],
@@ -901,7 +901,7 @@
                                 "certificatesExpiryDays": {
                                     "type": "integer",
                                     "title": "Certificate expiry days",
-                                    "description": "Indicates a rollout needs to be performed if the certificates of the machine will expire within the specified days",
+                                    "description": "Indicates a rollout needs to be performed if the certificates of the machine will expire within the specified days.",
                                     "default": 180
                                 }
                             }

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -789,8 +789,7 @@
                     "description": "Configuration of the control plane.",
                     "required": [
                         "machineHealthCheck",
-                        "replicas",
-                        "rolloutBefore"
+                        "replicas"
                     ],
                     "properties": {
                         "apiServerPort": {
@@ -889,22 +888,6 @@
                                 5
                             ],
                             "default": 3
-                        },
-                        "rolloutBefore": {
-                            "type": "object",
-                            "title": "Rollout Before",
-                            "description": "Rollout Before is a field to indicate a rollout should be performed if the specified criteria is met.",
-                            "required": [
-                                "certificatesExpiryDays"
-                            ],
-                            "properties": {
-                                "certificatesExpiryDays": {
-                                    "type": "integer",
-                                    "title": "Certificate expiry days",
-                                    "description": "Indicates a rollout needs to be performed if the certificates of the machine will expire within the specified days.",
-                                    "default": 180
-                                }
-                            }
                         }
                     }
                 },
@@ -1112,6 +1095,9 @@
                             "type": "object",
                             "title": "Control plane",
                             "description": "Advanced configuration of control plane components.",
+                            "required": [
+                                "rolloutBefore"
+                            ],
                             "properties": {
                                 "apiServer": {
                                     "type": "object",
@@ -1203,6 +1189,24 @@
                                 },
                                 "preKubeadmCommands": {
                                     "$ref": "#/$defs/preKubeadmCommands"
+                                },
+                                "rolloutBefore": {
+                                    "type": "object",
+                                    "title": "Rollout Before",
+                                    "description": "Rollout Before is a field to indicate a rollout should be performed if the specified criteria is met.",
+                                    "required": [
+                                        "certificatesExpiryDays"
+                                    ],
+                                    "properties": {
+                                        "certificatesExpiryDays": {
+                                            "type": "integer",
+                                            "title": "Certificate expiry days",
+                                            "description": "Indicates a rollout needs to be performed if the certificates of the machine will expire within the specified days.",
+                                            "default": 180,
+                                            "maximum": 364,
+                                            "minimum": 30
+                                        }
+                                    }
                                 }
                             }
                         },

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -789,7 +789,8 @@
                     "description": "Configuration of the control plane.",
                     "required": [
                         "machineHealthCheck",
-                        "replicas"
+                        "replicas",
+                        "rolloutBefore"
                     ],
                     "properties": {
                         "apiServerPort": {
@@ -888,6 +889,20 @@
                                 5
                             ],
                             "default": 3
+                        },
+                        "rolloutBefore": {
+                            "type": "object",
+                            "title": "Rollout Before",
+                            "description": "Rollout Before is a field to indicate a rollout should be performed if the specified criteria is met",
+                            "required": ["certificatesExpiryDays"],
+                            "properties": {
+                                "certificatesExpiryDays": {
+                                    "type": "integer",
+                                    "title": "Certificate expiry days",
+                                    "description": "Indicates a rollout needs to be performed if the certificates of the machine will expire within the specified days",
+                                    "default": 180
+                                }
+                            }
                         }
                     }
                 },

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -30,6 +30,8 @@ global:
       unhealthyUnknownTimeout: 10m0s
     oidc: {}
     replicas: 3
+    rolloutBefore:
+      certificatesExpiryDays: 180
   metadata:
     preventDeletion: false
     servicePriority: highest

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -30,8 +30,6 @@ global:
       unhealthyUnknownTimeout: 10m0s
     oidc: {}
     replicas: 3
-    rolloutBefore:
-      certificatesExpiryDays: 180
   metadata:
     preventDeletion: false
     servicePriority: highest
@@ -45,6 +43,8 @@ internal:
       etcd:
         experimental: {}
         quotaBackendBytesGiB: 8
+      rolloutBefore:
+        certificatesExpiryDays: 180
     workers: {}
 providerIntegration:
   bastion:


### PR DESCRIPTION
### What does this PR do?

This PR introduces a new field in the Helm values called `rolloutBefore`. It can be used to control how many days before the expiration of control plane certificates should the control plane nodes be rolled. This mechanism is used by CAPI to ensure that control plane certificates are renewed automatically.

### What is the effect of this change to users?

It ensures that certificates on control plane nodes are rotated automatically.

### How does it look like?

There is a new field available in Values:

```yaml
internal:
  advancedConfiguration:
    controlPlane:
      rolloutBefore: # this structure is taken from CAPI
        certificatesExpiryDays: 180 # 180 is the default value
```

It is added to the `KubeadmControlPlane` CR.

### Any background context you can provide?

Towards: https://github.com/giantswarm/roadmap/issues/3147

### What is needed from the reviewers?

Check if the new property located in the correct section of the Helm Values and possibly also test that it works.

### Do the docs need to be updated?

Yes

### Should this change be mentioned in the release notes?

Probably yes

- [x] CHANGELOG.md has been updated (if it exists)
