### PR TITLE
Fix etcd extraArgs type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Quote all etcd extra args, so they are correctly set as strings.
+
 ## [0.6.0] - 2024-01-25
 
 ### Added
@@ -17,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.0] - 2024-01-25
 
+### Added
+- Add `quotaBackendBytesGiB` etcd config to Helm value `.Values.internal.advancedConfiguration.etcd`.
+
 ## [0.4.0] - 2024-01-24
 
 ### Added
@@ -24,7 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add custom `files` config to Helm value to `.Values.internal.advancedConfiguration`.
 - Add custom `preKubeadmCommands` config to Helm value to `.Values.internal.advancedConfiguration`.
 - Add custom `postKubeadmCommands` config to Helm value to `.Values.internal.advancedConfiguration`.
-- Add `quotaBackendBytesGiB` etcd config to Helm value `.Values.internal.advancedConfiguration.etcd`.
 
 ### Changed
 

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_etcd.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_etcd.tpl
@@ -1,9 +1,13 @@
 {{- define "cluster.internal.controlPlane.kubeadm.clusterConfiguration.etcd" }}
 local:
   extraArgs:
+    {{-/*
+      All extraArgs must be strings, as the extraArg object is a map[string]string so numbers
+      and booleans must be quoted here.
+    */}}
     listen-metrics-urls: "http://0.0.0.0:2381"
     {{- with $etcdConfig := $.Values.internal.advancedConfiguration.controlPlane.etcd }}
-    quota-backend-bytes: {{ mul $etcdConfig.quotaBackendBytesGiB 1024 1024 1024 }}
+    quota-backend-bytes: {{ mul $etcdConfig.quotaBackendBytesGiB 1024 1024 1024 | quote }}
     {{- if $etcdConfig.initialCluster }}
     initial-cluster: {{ $etcdConfig.initialCluster | quote }}
     {{- end }}
@@ -11,10 +15,10 @@ local:
     initial-cluster-state: {{ $etcdConfig.initialClusterState | quote }}
     {{- end }}
     {{- range $argName, $argValue := $etcdConfig.extraArgs }}
-    {{ $argName }}: {{ if kindIs "string" $argValue }}{{ $argValue | quote }}{{ else }}{{ $argValue }}{{ end }}
+    {{ $argName }}: {{ $argValue | quote }}
     {{- end }}
     {{- if $etcdConfig.experimental.peerSkipClientSanVerification }}
-    experimental-peer-skip-client-san-verification: {{ $etcdConfig.experimental.peerSkipClientSanVerification }}
+    experimental-peer-skip-client-san-verification: {{ $etcdConfig.experimental.peerSkipClientSanVerification | quote }}
     {{- end }}
     {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_etcd.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_etcd.tpl
@@ -1,7 +1,7 @@
 {{- define "cluster.internal.controlPlane.kubeadm.clusterConfiguration.etcd" }}
 local:
   extraArgs:
-    {{/*
+    {{- /*
       All extraArgs must be strings, as the extraArg object is a map[string]string so numbers
       and booleans must be quoted here.
     */}}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_etcd.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_etcd.tpl
@@ -1,7 +1,7 @@
 {{- define "cluster.internal.controlPlane.kubeadm.clusterConfiguration.etcd" }}
 local:
   extraArgs:
-    {{-/*
+    {{/*
       All extraArgs must be strings, as the extraArg object is a map[string]string so numbers
       and booleans must be quoted here.
     */}}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3047

### What does this PR do?

Quote all etcd extra args, so they are correctly set as strings.

### How does it look like?

Before:
```yaml
local:
  extraArgs:
    listen-metrics-urls: "http://0.0.0.0:2381/"
    quota-backend-bytes: 17179869184
    initial-cluster: "default=http://localhost:2380/"
    initial-cluster-state: "existing"
    max-snapshots: 3
    snapshot-count: 50000
    experimental-peer-skip-client-san-verification: true
```

After:

```yaml
local:
  extraArgs:
    listen-metrics-urls: "http://0.0.0.0:2381"
    quota-backend-bytes: "17179869184"
    initial-cluster: "default=http://localhost:2380"
    initial-cluster-state: "existing"
    max-snapshots: "3"
    snapshot-count: "50000"
    experimental-peer-skip-client-san-verification: "true"
```
### Any background context you can provide?

We found this bug in failed e2e tests https://github.com/giantswarm/cluster-aws/pull/479.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
