### PR TITLE
Update Kubernetes version to 1.25.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update Kubernetes version to v1.25.16.
 - Update CI values to remove features that do not exist anymore in Kubernetes v1.25.
 
+### Fixed
+
+- Remove labels from test Helm template for provider-specific machine template spec that is used in the CI.
+
 ## [0.6.1] - 2024-01-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update Kubernetes version to 1.25.16.
+
 ## [0.6.1] - 2024-01-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update Kubernetes version to 1.25.16.
+- Update Kubernetes version to v1.25.16.
+- Update CI values to remove features that do not exist anymore in Kubernetes v1.25.
 
 ## [0.6.1] - 2024-01-26
 

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -417,7 +417,7 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.kubeadmConfig.postKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
 | `providerIntegration.kubeadmConfig.preKubeadmCommands` | **Pre-kubeadm commands** - Extra commands to run before kubeadm runs.|**Type:** `array`<br/>|
 | `providerIntegration.kubeadmConfig.preKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
-| `providerIntegration.kubernetesVersion` | **Kubernetes version**|**Type:** `string`<br/>**Default:** `"1.24.16"`|
+| `providerIntegration.kubernetesVersion` | **Kubernetes version**|**Type:** `string`<br/>**Default:** `"1.25.16"`|
 | `providerIntegration.pauseProperties` | **Pause properties** - A map of property names and their values that will affect setting pause annotation|**Type:** `object`<br/>|
 | `providerIntegration.pauseProperties.*` |**None**|**Types:** `string, number, integer, boolean`<br/>|
 | `providerIntegration.provider` | **Provider** - The name of the Cluster API provider. The name here must match the name of the provider in cluster-<provider> app name.|**Type:** `string`<br/>|

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -150,7 +150,6 @@ providerIntegration:
         apiServer:
           additionalAdmissionPlugins:
           - AlwaysPullImages
-          - PodSecurityPolicy
           apiAudiences:
             templateName: "cluster.test.kubeadmControlPlane.kubeadmConfigSpec.clusterConfiguration.apiServer.apiAudiences"
           featureGates:
@@ -158,8 +157,6 @@ providerIntegration:
             enabled: true
           - name: DownwardAPIHugePages
             enabled: false
-          - name: TTLAfterFinished
-            enabled: true
           serviceAccountIssuer:
             clusterDomainPrefix: irsa
       files:
@@ -316,7 +313,7 @@ providerIntegration:
     - echo "aws nodes command before kubeadm"
     postKubeadmCommands:
     - echo "aws nodes command after kubeadm"
-  kubernetesVersion: 1.24.10
+  kubernetesVersion: 1.25.16
   pauseProperties:
     global.connectivity.vpcMode: private
   resourcesApi:

--- a/helm/cluster/templates/bastion/_helpers.tpl
+++ b/helm/cluster/templates/bastion/_helpers.tpl
@@ -1,9 +1,4 @@
 {{- define "cluster.test.bastion.machineTemplate.spec" -}}
-template:
-  metadata:
-    cluster.x-k8s.io/role: bastion
-    {{- include "cluster.labels.common" $ | nindent 4 }}
-  spec:
-    foo: 2
-    bar: "b"
+foo: 2
+bar: "b"
 {{- end -}}

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1644,7 +1644,7 @@
                 "kubernetesVersion": {
                     "type": "string",
                     "title": "Kubernetes version",
-                    "default": "1.24.16"
+                    "default": "1.25.16"
                 },
                 "pauseProperties": {
                     "type": "object",

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -84,7 +84,7 @@ providerIntegration:
         additionalConfig:
           storage: {}
           systemd: {}
-  kubernetesVersion: 1.24.16
+  kubernetesVersion: 1.25.16
   resourcesApi:
     bastionResourceEnabled: true
     clusterResourceEnabled: true


### PR DESCRIPTION
### What does this PR do?

This PR updates the Kubernetes version to v1.25.16 🎉

<details>

<summary>Plus a small 🧹 change to fix test Helm template that is used in the CI.</summary>

Remove labels from `<provider>MachineTemplate` spec, because the template should contain only spec without metadata.

Metadata changes with every release, so prevuously, when we hashed the template to construct a resource name, the hash would change with every release, meaning that resource name was changing with every release. Because of this every new release was causing incorrect Helm template rendering diff in the GithHub action.
</details>

### What is the effect of this change to users?

cluster-\<provider\> apps that use cluster chart will use Kubernetes v1.25.16.

### How does it look like?

See diff.

### Any background context you can provide?

Kubernetes version has been updated to 1.25.16 in cluster-aws https://github.com/giantswarm/cluster-aws/pull/481.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
