### PR TITLE
Fix MachineHealthCheck annotation rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix MachineHealthCheck annotation rendering when custom annotations are not set.
+
 ## [0.7.0] - 2024-01-30
 
 ### Changed

--- a/Makefile.development.mk
+++ b/Makefile.development.mk
@@ -7,10 +7,16 @@ ensure-schema-gen:
 
 ##@ Build
 
+TEST_CASE ?=
+ifdef TEST_CASE
+CI_FILE = "ci/test-$(TEST_CASE)-values.yaml"
+else
+CI_FILE ?= "ci/ci-values.yaml"
+endif
+
 .PHONY: template
 template: ## Output the rendered Helm template
 	$(eval CHART_DIR := "helm/cluster")
-	$(eval CI_FILE := "ci/ci-values.yaml")
 	$(eval HELM_RELEASE_NAME := $(shell yq .global.metadata.name ${CHART_DIR}/${CI_FILE}))
 	@cd ${CHART_DIR} && \
 		helm template -f ${CI_FILE} --debug ${HELM_RELEASE_NAME} .

--- a/helm/cluster/ci/test-required-values.yaml
+++ b/helm/cluster/ci/test-required-values.yaml
@@ -14,7 +14,7 @@ providerIntegration:
       group: infrastructure.cluster.x-k8s.io
       kind: GiantCluster
       version: v1beta1
-    machineHealthCheckResourceEnabled: false
+    machineHealthCheckResourceEnabled: true
     machinePoolResourcesEnabled: false
     nodePoolKind: MachinePool
   controlPlane:

--- a/helm/cluster/templates/clusterapi/controlplane/machinehealthcheck.yaml
+++ b/helm/cluster/templates/clusterapi/controlplane/machinehealthcheck.yaml
@@ -4,12 +4,11 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck
 metadata:
+  {{- $annotations := include "cluster.annotations.custom" $ }}
+  {{- if $annotations }}
   annotations:
-    {{- if $.Values.global.metadata.annotations }}
-    {{- range $key, $val := $.Values.global.metadata.annotations }}
-    {{ $key }}: {{ $val | quote }}
-    {{- end }}
-    {{- end }}
+    {{- $annotations | indent 4 }}
+  {{- end }}
   labels:
     {{- include "cluster.labels.common" $ | nindent 4 }}
     {{- if $.Values.global.metadata.labels }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3047

### What does this PR do?

Fix MachineHealthCheck annotation rendering issue discovered in https://github.com/giantswarm/cluster-aws/pull/497

### What is the effect of this change to users?

MachineHealthCheck annotation rendering works correctly when custom annotations are not specified.

### How does it look like?

See diff.

### Any background context you can provide?

https://github.com/giantswarm/cluster-aws/pull/497

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
