### PR TITLE
Fix node pool templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Overridden default audit rules as in Vintage clusters.
 
+### Fixed
+
+- Fix MachinePool templates, so that AWSMachinePool correctly performs rolling updates (ported from https://github.com/giantswarm/cluster-aws/pull/457).
+
 ## [0.7.1] - 2024-01-31
 
 ### Fixed

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -179,17 +179,17 @@ Properties within the `.global.nodePools` object
 | `global.nodePools.PATTERN` | **Node pool**|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 | `global.nodePools.PATTERN.annotations` | **Annotations** - These annotations are added to all Kubernetes resources defining this node pool.|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 | `global.nodePools.PATTERN.annotations.PATTERN_2` | **Annotation**|**Type:** `string`<br/>**Key patterns:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>`PATTERN_2`=`^([a-zA-Z0-9\.-]{1,253}/)?[a-zA-Z0-9\._-]{1,63}$`<br/>|
+| `global.nodePools.PATTERN.customNodeLabels` | **Node labels** - Labels that are passed to kubelet argument 'node-labels'.|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
+| `global.nodePools.PATTERN.customNodeLabels.*` |**None**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
+| `global.nodePools.PATTERN.customNodeTaints` | **Custom node taints**|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
+| `global.nodePools.PATTERN.customNodeTaints[*]` |**None**|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
+| `global.nodePools.PATTERN.customNodeTaints[*].effect` | **Effect**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
+| `global.nodePools.PATTERN.customNodeTaints[*].key` | **Key**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
+| `global.nodePools.PATTERN.customNodeTaints[*].value` | **Value**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 | `global.nodePools.PATTERN.labels` | **Labels** - These labels are added to all Kubernetes resources defining this node pool.|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 | `global.nodePools.PATTERN.labels.PATTERN_2` | **Label**|**Type:** `string`<br/>**Key patterns:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>`PATTERN_2`=`^[a-zA-Z0-9/\._-]+$`<br/>**Value pattern:** `^[a-zA-Z0-9\._-]+$`<br/>|
 | `global.nodePools.PATTERN.maxSize` | **Max size** - Maximum number of node pool nodes|**Type:** `integer`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 | `global.nodePools.PATTERN.minSize` | **Min size** - Minimum number of node pool nodes|**Type:** `integer`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
-| `global.nodePools.PATTERN.nodeLabels` | **Node labels** - Labels that are passed to kubelet argument 'node-labels'.|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
-| `global.nodePools.PATTERN.nodeLabels.*` |**None**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
-| `global.nodePools.PATTERN.nodeTaints` | **Custom node taints**|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
-| `global.nodePools.PATTERN.nodeTaints[*]` |**None**|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
-| `global.nodePools.PATTERN.nodeTaints[*].effect` | **Effect**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
-| `global.nodePools.PATTERN.nodeTaints[*].key` | **Key**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
-| `global.nodePools.PATTERN.nodeTaints[*].value` | **Value**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 | `global.nodePools.PATTERN.replicas` | **Replicas** - The number of node pool nodes.|**Type:** `integer`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 
 ### Other global

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -181,6 +181,8 @@ Properties within the `.global.nodePools` object
 | `global.nodePools.PATTERN.annotations.PATTERN_2` | **Annotation**|**Type:** `string`<br/>**Key patterns:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>`PATTERN_2`=`^([a-zA-Z0-9\.-]{1,253}/)?[a-zA-Z0-9\._-]{1,63}$`<br/>|
 | `global.nodePools.PATTERN.labels` | **Labels** - These labels are added to all Kubernetes resources defining this node pool.|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 | `global.nodePools.PATTERN.labels.PATTERN_2` | **Label**|**Type:** `string`<br/>**Key patterns:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>`PATTERN_2`=`^[a-zA-Z0-9/\._-]+$`<br/>**Value pattern:** `^[a-zA-Z0-9\._-]+$`<br/>|
+| `global.nodePools.PATTERN.maxSize` | **Max size** - Maximum number of node pool nodes|**Type:** `integer`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
+| `global.nodePools.PATTERN.minSize` | **Min size** - Minimum number of node pool nodes|**Type:** `integer`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 | `global.nodePools.PATTERN.nodeLabels` | **Node labels** - Labels that are passed to kubelet argument 'node-labels'.|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 | `global.nodePools.PATTERN.nodeLabels.*` |**None**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 | `global.nodePools.PATTERN.nodeTaints` | **Custom node taints**|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -179,9 +179,9 @@ Properties within the `.global.nodePools` object
 | `global.nodePools.PATTERN` | **Node pool**|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 | `global.nodePools.PATTERN.annotations` | **Annotations** - These annotations are added to all Kubernetes resources defining this node pool.|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 | `global.nodePools.PATTERN.annotations.PATTERN_2` | **Annotation**|**Type:** `string`<br/>**Key patterns:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>`PATTERN_2`=`^([a-zA-Z0-9\.-]{1,253}/)?[a-zA-Z0-9\._-]{1,63}$`<br/>|
-| `global.nodePools.PATTERN.customNodeLabels` | **Node labels** - Labels that are passed to kubelet argument 'node-labels'.|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
-| `global.nodePools.PATTERN.customNodeLabels.*` |**None**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
-| `global.nodePools.PATTERN.customNodeTaints` | **Custom node taints**|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
+| `global.nodePools.PATTERN.customNodeLabels` | **Node labels. Deprecated: use nodeLabels instead.** - Labels that are passed to kubelet argument 'node-labels'.|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
+| `global.nodePools.PATTERN.customNodeLabels[*]` | **Label**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
+| `global.nodePools.PATTERN.customNodeTaints` | **Custom node taints. Deprecated: use nodeTaints instead.**|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 | `global.nodePools.PATTERN.customNodeTaints[*]` |**None**|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 | `global.nodePools.PATTERN.customNodeTaints[*].effect` | **Effect**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 | `global.nodePools.PATTERN.customNodeTaints[*].key` | **Key**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
@@ -448,6 +448,22 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.teleport.proxyAddr` | **Teleport proxy address**|**Type:** `string`<br/>**Default:** `"teleport.giantswarm.io:443"`|
 | `providerIntegration.teleport.version` | **Teleport version**|**Type:** `string`<br/>**Default:** `"14.1.3"`|
 | `providerIntegration.workers` | **Provider-specific workers configuration**|**Type:** `object`<br/>|
+| `providerIntegration.workers.defaultNodePools` | **Default node pools**|**Type:** `object`<br/>|
+| `providerIntegration.workers.defaultNodePools.PATTERN` | **Node pool**|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
+| `providerIntegration.workers.defaultNodePools.PATTERN.annotations` | **Annotations** - These annotations are added to all Kubernetes resources defining this node pool.|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
+| `providerIntegration.workers.defaultNodePools.PATTERN.annotations.PATTERN_2` | **Annotation**|**Type:** `string`<br/>**Key patterns:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>`PATTERN_2`=`^([a-zA-Z0-9\.-]{1,253}/)?[a-zA-Z0-9\._-]{1,63}$`<br/>|
+| `providerIntegration.workers.defaultNodePools.PATTERN.customNodeLabels` | **Node labels. Deprecated: use nodeLabels instead.** - Labels that are passed to kubelet argument 'node-labels'.|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
+| `providerIntegration.workers.defaultNodePools.PATTERN.customNodeLabels[*]` | **Label**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
+| `providerIntegration.workers.defaultNodePools.PATTERN.customNodeTaints` | **Custom node taints. Deprecated: use nodeTaints instead.**|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
+| `providerIntegration.workers.defaultNodePools.PATTERN.customNodeTaints[*]` |**None**|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
+| `providerIntegration.workers.defaultNodePools.PATTERN.customNodeTaints[*].effect` | **Effect**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
+| `providerIntegration.workers.defaultNodePools.PATTERN.customNodeTaints[*].key` | **Key**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
+| `providerIntegration.workers.defaultNodePools.PATTERN.customNodeTaints[*].value` | **Value**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
+| `providerIntegration.workers.defaultNodePools.PATTERN.labels` | **Labels** - These labels are added to all Kubernetes resources defining this node pool.|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
+| `providerIntegration.workers.defaultNodePools.PATTERN.labels.PATTERN_2` | **Label**|**Type:** `string`<br/>**Key patterns:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>`PATTERN_2`=`^[a-zA-Z0-9/\._-]+$`<br/>**Value pattern:** `^[a-zA-Z0-9\._-]+$`<br/>|
+| `providerIntegration.workers.defaultNodePools.PATTERN.maxSize` | **Max size** - Maximum number of node pool nodes|**Type:** `integer`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
+| `providerIntegration.workers.defaultNodePools.PATTERN.minSize` | **Min size** - Minimum number of node pool nodes|**Type:** `integer`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
+| `providerIntegration.workers.defaultNodePools.PATTERN.replicas` | **Replicas** - The number of node pool nodes.|**Type:** `integer`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 | `providerIntegration.workers.kubeadmConfig` | **Kubeadm config** - Configuration of workers nodes.|**Type:** `object`<br/>|
 | `providerIntegration.workers.kubeadmConfig.files` | **Files** - Provider-specific files that are deployed to worker nodes. They are specified in the cluster-<provider> apps.|**Type:** `array`<br/>|
 | `providerIntegration.workers.kubeadmConfig.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -39,7 +39,7 @@ global:
       annotations:
         for-robots-in-nodepool: "cm9ib3RzIGFyZSBvcGVyYXRpbmcgb24gdGhpcyBub2RlIHBvb2wK"
       customNodeLabels:
-        workload-type: ai
+      - workload-type=ai
       customNodeTaints:
       - key: supernodepool
         value: hello
@@ -47,7 +47,7 @@ global:
     verybignodepool-1234:
       replicas: 100
       customNodeLabels:
-        workload-type: robots
+      - workload-type=robots
   components:
     containerd:
       containerRegistries:
@@ -348,6 +348,12 @@ providerIntegration:
   teleport:
     enabled: true
   workers:
+    defaultNodePools:
+      def00:
+        customNodeLabels:
+        - label=default
+        maxSize: 3
+        minSize: 3
     kubeadmConfig:
       files:
       - path: /etc/aws/worker/node/file.yaml

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -38,15 +38,15 @@ global:
         nodepool-workload-type: ai
       annotations:
         for-robots-in-nodepool: "cm9ib3RzIGFyZSBvcGVyYXRpbmcgb24gdGhpcyBub2RlIHBvb2wK"
-      nodeLabels:
+      customNodeLabels:
         workload-type: ai
-      nodeTaints:
+      customNodeTaints:
       - key: supernodepool
         value: hello
         effect: NoSchedule
     verybignodepool-1234:
       replicas: 100
-      nodeLabels:
+      customNodeLabels:
         workload-type: robots
   components:
     containerd:

--- a/helm/cluster/ci/test-required-values.yaml
+++ b/helm/cluster/ci/test-required-values.yaml
@@ -22,6 +22,10 @@ providerIntegration:
     machineHealthCheckResourceEnabled: true
     machinePoolResourcesEnabled: true
     nodePoolKind: MachinePool
+    infrastructureMachinePool:
+      group: infrastructure.cluster.x-k8s.io
+      version: v1beta1
+      kind: GiantMachinePool
   controlPlane:
     resources:
       infrastructureMachineTemplate:

--- a/helm/cluster/ci/test-required-values.yaml
+++ b/helm/cluster/ci/test-required-values.yaml
@@ -4,6 +4,11 @@ global:
     organization: giantswarm
   connectivity:
     baseDomain: example.gigantic.io
+  nodePools:
+    def00:
+      replicas: 3
+    verybignodepool-1234:
+      replicas: 100
 providerIntegration:
   provider: aws
   resourcesApi:
@@ -15,7 +20,7 @@ providerIntegration:
       kind: GiantCluster
       version: v1beta1
     machineHealthCheckResourceEnabled: true
-    machinePoolResourcesEnabled: false
+    machinePoolResourcesEnabled: true
     nodePoolKind: MachinePool
   controlPlane:
     resources:

--- a/helm/cluster/ci/test-required-values.yaml
+++ b/helm/cluster/ci/test-required-values.yaml
@@ -34,3 +34,10 @@ providerIntegration:
         kind: GiantMachineTemplate
         version: v1beta1
       infrastructureMachineTemplateSpecTemplateName: cluster.internal.test.controlPlane.machineTemplate.spec
+  workers:
+    defaultNodePools:
+      def00:
+        customNodeLabels:
+        - label=default
+        maxSize: 3
+        minSize: 3

--- a/helm/cluster/ci/test-required-values.yaml
+++ b/helm/cluster/ci/test-required-values.yaml
@@ -6,7 +6,8 @@ global:
     baseDomain: example.gigantic.io
   nodePools:
     def00:
-      replicas: 3
+      minSize: 3
+      maxSize: 20
     verybignodepool-1234:
       replicas: 100
 providerIntegration:

--- a/helm/cluster/templates/clusterapi/_helpers_flatcar.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_flatcar.tpl
@@ -155,8 +155,10 @@
       Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/bin
       # To make metadata environment variables available for pre-kubeadm commands.
       EnvironmentFile=/run/metadata/*
+      {{- if eq (lower $.nodeRole) "controlplane" }}
       # Read environment variables for apiserver fairness configuration
       EnvironmentFile=/etc/apiserver-environment
+      {{- end }}
 - name: containerd.service
   enabled: true
   contents: |

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_flatcar.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_flatcar.tpl
@@ -3,6 +3,7 @@ containerLinuxConfig:
   additionalConfig: |
     systemd:
       units:
+      {{- $_ := set $ "nodeRole" "controlplane" }}
       {{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units.default" $ | indent 6 }}
       {{- include "cluster.internal.controlPlane.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units.default" $ | indent 6 }}
       {{- include "cluster.internal.controlPlane.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $ | indent 6 }}

--- a/helm/cluster/templates/clusterapi/workers/_helpers.tpl
+++ b/helm/cluster/templates/clusterapi/workers/_helpers.tpl
@@ -1,0 +1,25 @@
+{{- define "cluster.internal.workers.kubeadmConfig.spec.hash" -}}
+{{ $spec := include "cluster.internal.workers.kubeadmConfig.spec" $ }}{{ regexReplaceAll `^\s*#.*$` $spec "" | sha256sum | trunc 5 }}
+{{- end -}}
+
+{{- define "cluster.internal.workers.kubeadmConfig.spec"}}
+format: ignition
+ignition:
+  {{- include "cluster.internal.workers.kubeadm.ignition" $ | indent 4 }}
+joinConfiguration:
+  {{- include "cluster.internal.workers.kubeadm.joinConfiguration" $ | indent 4 }}
+preKubeadmCommands:
+{{- include "cluster.internal.workers.kubeadm.preKubeadmCommands" $ | indent 2 }}
+{{- $postKubeadmCommands := include "cluster.internal.workers.kubeadm.postKubeadmCommands" $ }}
+{{- if $postKubeadmCommands }}
+postKubeadmCommands:
+{{- $postKubeadmCommands | indent 2 }}
+{{- end }}
+{{- $users := include "cluster.internal.kubeadm.users" $ }}
+{{- if $users }}
+users:
+{{- $users | indent 2 }}
+{{- end }}
+files:
+{{- include "cluster.internal.workers.kubeadm.files" $ | indent 2 }}
+{{- end }}

--- a/helm/cluster/templates/clusterapi/workers/_helpers_flatcar.tpl
+++ b/helm/cluster/templates/clusterapi/workers/_helpers_flatcar.tpl
@@ -3,6 +3,7 @@ containerLinuxConfig:
   additionalConfig: |
     systemd:
       units:
+      {{- $_ := set $ "nodeRole" "worker" }}
       {{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units.default" $ | indent 6 }}
       {{- include "cluster.internal.workers.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $ | indent 6 }}
     storage:

--- a/helm/cluster/templates/clusterapi/workers/_helpers_flatcar.tpl
+++ b/helm/cluster/templates/clusterapi/workers/_helpers_flatcar.tpl
@@ -7,6 +7,7 @@ containerLinuxConfig:
       {{- include "cluster.internal.workers.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $ | indent 6 }}
     storage:
       directories:
+      {{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.directorties.default" $ | indent 6 }}
       {{- include "cluster.internal.workers.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.directories" $ | indent 6 }}
 {{- end }}
 

--- a/helm/cluster/templates/clusterapi/workers/_helpers_joinconfiguration.tpl
+++ b/helm/cluster/templates/clusterapi/workers/_helpers_joinconfiguration.tpl
@@ -6,7 +6,7 @@
     .config: node pool config, a value from $.Values.global.nodepools map.
 */}}
 {{- define "cluster.internal.workers.kubeadm.joinConfiguration" }}
-{{- with $machinePool := .nodePool }}
+{{- with $nodePool := required "nodePool must be set" .nodePool }}
 nodeRegistration:
   name: ${COREOS_EC2_HOSTNAME}
   kubeletExtraArgs:
@@ -17,11 +17,11 @@ nodeRegistration:
     feature-gates: CronJobTimeZone=true
     healthz-bind-address: 0.0.0.0
     node-ip: ${COREOS_EC2_IPV4_LOCAL}
-    node-labels: role=worker,giantswarm.io/machine-pool={{ include "cluster.resource.name" $ }}-{{ $machinePool.name }},{{- join "," $machinePool.config.customNodeLabels }}
+    node-labels: role=worker,giantswarm.io/machine-pool={{ include "cluster.resource.name" $ }}-{{ $nodePool.name }},{{- join "," $nodePool.config.customNodeLabels }}
     v: "2"
-  {{- if $machinePool.config.customNodeTaints }}
+  {{- if $nodePool.config.customNodeTaints }}
   taints:
-  {{- range $machinePool.config.customNodeTaints }}
+  {{- range $nodePool.config.customNodeTaints }}
   - key: {{ .key | quote }}
     value: {{ .value | quote }}
     effect: {{ .effect | quote }}

--- a/helm/cluster/templates/clusterapi/workers/_helpers_joinconfiguration.tpl
+++ b/helm/cluster/templates/clusterapi/workers/_helpers_joinconfiguration.tpl
@@ -17,16 +17,14 @@ nodeRegistration:
     feature-gates: CronJobTimeZone=true
     healthz-bind-address: 0.0.0.0
     node-ip: ${COREOS_EC2_IPV4_LOCAL}
-    node-labels: role=worker,giantswarm.io/machine-pool={{ include "cluster.resource.name" $ }}-{{ $machinePool.name }},{{- join "," $machinePool.config.nodeLabels }}
+    node-labels: role=worker,giantswarm.io/machine-pool={{ include "cluster.resource.name" $ }}-{{ $machinePool.name }},{{- join "," $machinePool.config.customNodeLabels }}
     v: "2"
-  {{- if $machinePool.config.nodeTaints }}
-  {{- if (gt (len $machinePool.config.nodeTaints) 0) }}
+  {{- if $machinePool.config.customNodeTaints }}
   taints:
-  {{- range $machinePool.config.nodeTaints }}
+  {{- range $machinePool.config.customNodeTaints }}
   - key: {{ .key | quote }}
     value: {{ .value | quote }}
     effect: {{ .effect | quote }}
-  {{- end }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/workers/kubeadmconfig.yaml
+++ b/helm/cluster/templates/clusterapi/workers/kubeadmconfig.yaml
@@ -1,6 +1,22 @@
+{{/*
+CAPA reconciliation currently has a shortcoming that doesn't lead to rolling AWSMachinePool nodes
+if the referenced `KubeadmConfig` changes (such as `KubeadmConfig.spec.{files,preKubeadmCommands,...}`).
+While not solved by our long-term involvement in this bug, we hash `KubeadmConfig.spec` and rename
+the `KubeadmConfig` name since that enforces a new bootstrap secret name, triggering a rollout of
+nodes in CAPA's `AWSMachinePool` reconciler. Mind that CAPI also has a bug where CAPA only
+gets triggered after a few minutes.
+
+All of this is detailed in https://github.com/giantswarm/roadmap/issues/2217 and
+https://github.com/kubernetes-sigs/cluster-api/issues/8858, so please follow
+the issues to find out when we can get rid of our own checksum workaround.
+
+Full-line comments are excluded from the hash so that simple changes will not lead to
+node rollouts and thus possibly interruped workloads for customers.
+*/}}
 {{- if $.Values.providerIntegration.resourcesApi.machinePoolResourcesEnabled }}
 {{- if eq $.Values.providerIntegration.resourcesApi.nodePoolKind "MachinePool" }}
 {{- range $nodePoolName, $nodePoolConfig := $.Values.global.nodePools }}
+{{- $_ := set $ "nodePool" (dict "name" $nodePoolName "config" $nodePoolConfig) }}
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfig
 metadata:
@@ -23,26 +39,7 @@ metadata:
     {{- end }}
   name: {{ include "cluster.resource.name" $ }}-{{ $nodePoolName }}
   namespace: {{ $.Release.Namespace }}
-spec:
-  format: ignition
-  ignition:
-    {{- include "cluster.internal.workers.kubeadm.ignition" $ | indent 4 }}
-  joinConfiguration:
-    {{- include "cluster.internal.workers.kubeadm.joinConfiguration" (dict "Values" $.Values "Release" $.Release "nodePool" (dict "name" $nodePoolName "config" $nodePoolConfig)) | indent 4 }}
-  preKubeadmCommands:
-  {{- include "cluster.internal.workers.kubeadm.preKubeadmCommands" $ | indent 2 }}
-  {{- $postKubeadmCommands := include "cluster.internal.workers.kubeadm.postKubeadmCommands" $ }}
-  {{- if $postKubeadmCommands }}
-  postKubeadmCommands:
-  {{- $postKubeadmCommands | indent 2 }}
-  {{- end }}
-  {{- $users := include "cluster.internal.kubeadm.users" $ }}
-  {{- if $users }}
-  users:
-  {{- $users | indent 2 }}
-  {{- end }}
-  files:
-  {{- include "cluster.internal.workers.kubeadm.files" $ | indent 2 }}
+spec: {{- include "cluster.internal.workers.kubeadmConfig.spec" $ | nindent 2 }}
 ---
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/workers/kubeadmconfig.yaml
+++ b/helm/cluster/templates/clusterapi/workers/kubeadmconfig.yaml
@@ -15,7 +15,7 @@ node rollouts and thus possibly interruped workloads for customers.
 */}}
 {{- if $.Values.providerIntegration.resourcesApi.machinePoolResourcesEnabled }}
 {{- if eq $.Values.providerIntegration.resourcesApi.nodePoolKind "MachinePool" }}
-{{- range $nodePoolName, $nodePoolConfig := $.Values.global.nodePools }}
+{{- range $nodePoolName, $nodePoolConfig := $.Values.global.nodePools | default $.Values.providerIntegration.workers.defaultNodePools }}
 {{- $_ := set $ "nodePool" (dict "name" $nodePoolName "config" $nodePoolConfig) }}
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfig

--- a/helm/cluster/templates/clusterapi/workers/kubeadmconfig.yaml
+++ b/helm/cluster/templates/clusterapi/workers/kubeadmconfig.yaml
@@ -37,7 +37,7 @@ metadata:
     {{ $key }}: {{ $val | quote }}
     {{- end }}
     {{- end }}
-  name: {{ include "cluster.resource.name" $ }}-{{ $nodePoolName }}
+  name: {{ include "cluster.resource.name" $ }}-{{ $nodePoolName }}-{{ include "cluster.internal.workers.kubeadmConfig.spec.hash" $ }}
   namespace: {{ $.Release.Namespace }}
 spec: {{- include "cluster.internal.workers.kubeadmConfig.spec" $ | nindent 2 }}
 ---

--- a/helm/cluster/templates/clusterapi/workers/machinepool.yaml
+++ b/helm/cluster/templates/clusterapi/workers/machinepool.yaml
@@ -1,6 +1,7 @@
 {{- if $.Values.providerIntegration.resourcesApi.machinePoolResourcesEnabled }}
 {{- if eq $.Values.providerIntegration.resourcesApi.nodePoolKind "MachinePool" }}
 {{- range $nodePoolName, $nodePoolConfig := $.Values.global.nodePools | default $.Values.providerIntegration.workers.defaultNodePools }}
+{{- $_ := set $ "nodePool" (dict "name" $nodePoolName "config" $nodePoolConfig) }}
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:

--- a/helm/cluster/templates/clusterapi/workers/machinepool.yaml
+++ b/helm/cluster/templates/clusterapi/workers/machinepool.yaml
@@ -1,11 +1,10 @@
 {{- if $.Values.providerIntegration.resourcesApi.machinePoolResourcesEnabled }}
 {{- if eq $.Values.providerIntegration.resourcesApi.nodePoolKind "MachinePool" }}
-{{- range $nodePoolName, $nodePoolConfig := $.Values.global.nodePools }}
+{{- range $nodePoolName, $nodePoolConfig := $.Values.global.nodePools | default $.Values.providerIntegration.workers.defaultNodePools }}
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
   annotations:
-    helm.sh/resource-policy: keep
     machine-pool.giantswarm.io/name: {{ include "cluster.resource.name" $ }}-{{ $nodePoolName }}
     cluster.x-k8s.io/replicas-managed-by: "external-autoscaler"
     {{- include "cluster.annotations.custom" $ | indent 4 }}

--- a/helm/cluster/templates/clusterapi/workers/machinepool.yaml
+++ b/helm/cluster/templates/clusterapi/workers/machinepool.yaml
@@ -27,7 +27,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   clusterName: {{ include "cluster.resource.name" $ }}
-  replicas: {{ $nodePoolConfig.replicas }}
+  replicas: {{ $nodePoolConfig.minSize | default $nodePoolConfig.replicas }}
   template:
     spec:
       bootstrap:

--- a/helm/cluster/templates/clusterapi/workers/machinepool.yaml
+++ b/helm/cluster/templates/clusterapi/workers/machinepool.yaml
@@ -34,7 +34,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfig
-          name: {{ include "cluster.resource.name" $ }}-{{ $nodePoolName }}
+          name: {{ include "cluster.resource.name" $ }}-{{ $nodePoolName }}-{{ include "cluster.internal.workers.kubeadmConfig.spec.hash" $ }}
       clusterName: {{ include "cluster.resource.name" $ }}
       infrastructureRef:
         apiVersion: {{ $.Values.providerIntegration.resourcesApi.infrastructureMachinePool.group }}/{{ $.Values.providerIntegration.resourcesApi.infrastructureMachinePool.version }}

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1007,6 +1007,20 @@
                                         }
                                     }
                                 },
+                                "maxSize": {
+                                    "type": "integer",
+                                    "title": "Max size",
+                                    "description": "Maximum number of node pool nodes",
+                                    "maximum": 1000,
+                                    "minimum": 0
+                                },
+                                "minSize": {
+                                    "type": "integer",
+                                    "title": "Min size",
+                                    "description": "Minimum number of node pool nodes",
+                                    "maximum": 1000,
+                                    "minimum": 0
+                                },
                                 "nodeLabels": {
                                     "type": "object",
                                     "title": "Node labels",

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -992,36 +992,7 @@
                                         }
                                     }
                                 },
-                                "labels": {
-                                    "type": "object",
-                                    "title": "Labels",
-                                    "description": "These labels are added to all Kubernetes resources defining this node pool.",
-                                    "additionalProperties": false,
-                                    "patternProperties": {
-                                        "^[a-zA-Z0-9/\\._-]+$": {
-                                            "type": "string",
-                                            "title": "Label",
-                                            "maxLength": 63,
-                                            "minLength": 0,
-                                            "pattern": "^[a-zA-Z0-9\\._-]+$"
-                                        }
-                                    }
-                                },
-                                "maxSize": {
-                                    "type": "integer",
-                                    "title": "Max size",
-                                    "description": "Maximum number of node pool nodes",
-                                    "maximum": 1000,
-                                    "minimum": 0
-                                },
-                                "minSize": {
-                                    "type": "integer",
-                                    "title": "Min size",
-                                    "description": "Minimum number of node pool nodes",
-                                    "maximum": 1000,
-                                    "minimum": 0
-                                },
-                                "nodeLabels": {
+                                "customNodeLabels": {
                                     "type": "object",
                                     "title": "Node labels",
                                     "description": "Labels that are passed to kubelet argument 'node-labels'.",
@@ -1029,7 +1000,7 @@
                                         "type": "string"
                                     }
                                 },
-                                "nodeTaints": {
+                                "customNodeTaints": {
                                     "type": "array",
                                     "title": "Custom node taints",
                                     "items": {
@@ -1060,6 +1031,35 @@
                                             }
                                         }
                                     }
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "title": "Labels",
+                                    "description": "These labels are added to all Kubernetes resources defining this node pool.",
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                        "^[a-zA-Z0-9/\\._-]+$": {
+                                            "type": "string",
+                                            "title": "Label",
+                                            "maxLength": 63,
+                                            "minLength": 0,
+                                            "pattern": "^[a-zA-Z0-9\\._-]+$"
+                                        }
+                                    }
+                                },
+                                "maxSize": {
+                                    "type": "integer",
+                                    "title": "Max size",
+                                    "description": "Maximum number of node pool nodes",
+                                    "maximum": 1000,
+                                    "minimum": 0
+                                },
+                                "minSize": {
+                                    "type": "integer",
+                                    "title": "Min size",
+                                    "description": "Minimum number of node pool nodes",
+                                    "maximum": 1000,
+                                    "minimum": 0
                                 },
                                 "replicas": {
                                     "type": "integer",

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -430,6 +430,102 @@
                 }
             }
         },
+        "nodePool": {
+            "type": "object",
+            "title": "Node pool",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "title": "Annotations",
+                    "description": "These annotations are added to all Kubernetes resources defining this node pool.",
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^([a-zA-Z0-9\\.-]{1,253}/)?[a-zA-Z0-9\\._-]{1,63}$": {
+                            "type": "string",
+                            "title": "Annotation",
+                            "minLength": 1
+                        }
+                    }
+                },
+                "customNodeLabels": {
+                    "type": "array",
+                    "title": "Node labels. Deprecated: use nodeLabels instead.",
+                    "description": "Labels that are passed to kubelet argument 'node-labels'.",
+                    "items": {
+                        "type": "string",
+                        "title": "Label"
+                    }
+                },
+                "customNodeTaints": {
+                    "type": "array",
+                    "title": "Custom node taints. Deprecated: use nodeTaints instead.",
+                    "items": {
+                        "type": "object",
+                        "required": [
+                            "effect",
+                            "key",
+                            "value"
+                        ],
+                        "additionalProperties": false,
+                        "properties": {
+                            "effect": {
+                                "type": "string",
+                                "title": "Effect",
+                                "enum": [
+                                    "NoSchedule",
+                                    "PreferNoSchedule",
+                                    "NoExecute"
+                                ]
+                            },
+                            "key": {
+                                "type": "string",
+                                "title": "Key"
+                            },
+                            "value": {
+                                "type": "string",
+                                "title": "Value"
+                            }
+                        }
+                    }
+                },
+                "labels": {
+                    "type": "object",
+                    "title": "Labels",
+                    "description": "These labels are added to all Kubernetes resources defining this node pool.",
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9/\\._-]+$": {
+                            "type": "string",
+                            "title": "Label",
+                            "maxLength": 63,
+                            "minLength": 0,
+                            "pattern": "^[a-zA-Z0-9\\._-]+$"
+                        }
+                    }
+                },
+                "maxSize": {
+                    "type": "integer",
+                    "title": "Max size",
+                    "description": "Maximum number of node pool nodes",
+                    "maximum": 1000,
+                    "minimum": 0
+                },
+                "minSize": {
+                    "type": "integer",
+                    "title": "Min size",
+                    "description": "Minimum number of node pool nodes",
+                    "maximum": 1000,
+                    "minimum": 0
+                },
+                "replicas": {
+                    "type": "integer",
+                    "title": "Replicas",
+                    "description": "The number of node pool nodes.",
+                    "maximum": 1000,
+                    "minimum": 0
+                }
+            }
+        },
         "postKubeadmCommands": {
             "type": "array",
             "title": "Post-kubeadm commands",
@@ -976,99 +1072,7 @@
                     "additionalProperties": false,
                     "patternProperties": {
                         "^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$": {
-                            "type": "object",
-                            "title": "Node pool",
-                            "properties": {
-                                "annotations": {
-                                    "type": "object",
-                                    "title": "Annotations",
-                                    "description": "These annotations are added to all Kubernetes resources defining this node pool.",
-                                    "additionalProperties": false,
-                                    "patternProperties": {
-                                        "^([a-zA-Z0-9\\.-]{1,253}/)?[a-zA-Z0-9\\._-]{1,63}$": {
-                                            "type": "string",
-                                            "title": "Annotation",
-                                            "minLength": 1
-                                        }
-                                    }
-                                },
-                                "customNodeLabels": {
-                                    "type": "object",
-                                    "title": "Node labels",
-                                    "description": "Labels that are passed to kubelet argument 'node-labels'.",
-                                    "additionalProperties": {
-                                        "type": "string"
-                                    }
-                                },
-                                "customNodeTaints": {
-                                    "type": "array",
-                                    "title": "Custom node taints",
-                                    "items": {
-                                        "type": "object",
-                                        "required": [
-                                            "effect",
-                                            "key",
-                                            "value"
-                                        ],
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "effect": {
-                                                "type": "string",
-                                                "title": "Effect",
-                                                "enum": [
-                                                    "NoSchedule",
-                                                    "PreferNoSchedule",
-                                                    "NoExecute"
-                                                ]
-                                            },
-                                            "key": {
-                                                "type": "string",
-                                                "title": "Key"
-                                            },
-                                            "value": {
-                                                "type": "string",
-                                                "title": "Value"
-                                            }
-                                        }
-                                    }
-                                },
-                                "labels": {
-                                    "type": "object",
-                                    "title": "Labels",
-                                    "description": "These labels are added to all Kubernetes resources defining this node pool.",
-                                    "additionalProperties": false,
-                                    "patternProperties": {
-                                        "^[a-zA-Z0-9/\\._-]+$": {
-                                            "type": "string",
-                                            "title": "Label",
-                                            "maxLength": 63,
-                                            "minLength": 0,
-                                            "pattern": "^[a-zA-Z0-9\\._-]+$"
-                                        }
-                                    }
-                                },
-                                "maxSize": {
-                                    "type": "integer",
-                                    "title": "Max size",
-                                    "description": "Maximum number of node pool nodes",
-                                    "maximum": 1000,
-                                    "minimum": 0
-                                },
-                                "minSize": {
-                                    "type": "integer",
-                                    "title": "Min size",
-                                    "description": "Minimum number of node pool nodes",
-                                    "maximum": 1000,
-                                    "minimum": 0
-                                },
-                                "replicas": {
-                                    "type": "integer",
-                                    "title": "Replicas",
-                                    "description": "The number of node pool nodes.",
-                                    "maximum": 1000,
-                                    "minimum": 0
-                                }
-                            }
+                            "$ref": "#/$defs/nodePool"
                         }
                     }
                 },
@@ -1906,8 +1910,21 @@
                 "workers": {
                     "type": "object",
                     "title": "Provider-specific workers configuration",
+                    "required": [
+                        "defaultNodePools"
+                    ],
                     "additionalProperties": false,
                     "properties": {
+                        "defaultNodePools": {
+                            "type": "object",
+                            "title": "Default node pools",
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$": {
+                                    "$ref": "#/$defs/nodePool"
+                                }
+                            }
+                        },
                         "kubeadmConfig": {
                             "type": "object",
                             "title": "Kubeadm config",


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3194

### What does this PR do?

This PR ports cluster-aws node pool fix from https://github.com/giantswarm/cluster-aws/pull/457.

Other fixes:
- Include `/var/lib/kubelet` directly by default in Ignition on worker nodes.
- Include `/etc/apiserver-environment` environment file in `kubeadm` systemd unit only on control plane nodes.

### What is the effect of this change to users?

Node pools will roll correctly when an upgrade that requires that is performed.

### How does it look like?

See diff.

### Any background context you can provide?

- https://github.com/giantswarm/cluster-aws/pull/457
- https://github.com/giantswarm/roadmap/issues/3194

### Should this change be mentioned in the release notes?

- [ ] CHANGELOG.md has been updated (if it exists)
