### PR TITLE
Overridde default audit rules as in Vintage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Overridden default audit rules as in Vintage clusters.
 
-
 ## [0.7.1] - 2024-01-31
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add internal.advancedConfiguration.kubelet to configure system and k8s reserved resources. 
 - Add `rolloutBefore` config to Helm value to `.Values.internal.advancedConfiguration.controlPlane` to enable support for automatic node rollout/certificate renewal
 
+### Changed
+
+- Overridden default audit rules as in Vintage clusters.
+
+
 ## [0.7.1] - 2024-01-31
 
 ### Fixed

--- a/helm/cluster/files/etc/audit/rules.d/99-default.rules
+++ b/helm/cluster/files/etc/audit/rules.d/99-default.rules
@@ -1,0 +1,3 @@
+# Overridden by Giant Swarm.
+-a exit,always -F arch=b64 -S execve -k auditing
+-a exit,always -F arch=b32 -S execve -k auditing

--- a/helm/cluster/templates/clusterapi/_helpers_files.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_files.tpl
@@ -7,6 +7,7 @@
 {{- include "cluster.internal.kubeadm.files.kubelet" $ }}
 {{- include "cluster.internal.kubeadm.files.proxy" $ }}
 {{- include "cluster.internal.kubeadm.files.teleport" $ }}
+{{- include "cluster.internal.kubeadm.files.auditrules" $ }}
 {{- include "cluster.internal.kubeadm.files.provider" $ }}
 {{- include "cluster.internal.kubeadm.files.custom" $ }}
 {{- end }}
@@ -110,6 +111,14 @@ and is used to join the node to the teleport cluster.
   encoding: base64
   content: {{ tpl ($.Files.Get "files/etc/teleport.yaml") . | b64enc }}
 {{- end }}
+{{- end }}
+
+{{/* Audit rules for all nodes */}}
+{{- define "cluster.internal.kubeadm.files.auditrules" }}
+- path: /etc/audit/rules.d/99-default.rules
+  permissions: "0640"
+  encoding: base64
+  content: {{ $.Files.Get "files/etc/audit/rules.d/99-default.rules" | b64enc }}
 {{- end }}
 
 {{/* Provider-specific files for all nodes */}}


### PR DESCRIPTION
### What does this PR do?
Towards: https://github.com/giantswarm/giantswarm/issues/27954

Overrides the default audit rules as happens in Vintage clusters

### Any background context you can provide?

Customers were using our overriden audit configuration, so we need feature parity in CAPI.

- [x] CHANGELOG.md has been updated (if it exists)
