### PR TITLE
Add systemd unit and timer for hourly etcd defrag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add systemd unit and script to compute fairness values for k8s API server in controlplane.
 - Add internal.advancedConfiguration.kubelet to configure system and k8s reserved resources. 
 - Add `rolloutBefore` config to Helm value to `.Values.internal.advancedConfiguration.controlPlane` to enable support for automatic node rollout/certificate renewal
+- Add systemd unit and timer for hourly etcd defragmentation.
 
 ### Changed
 


### PR DESCRIPTION
### What does this PR do?
Adds a systemd unit to defragment the local etcd server.
The unit is disabled by default but it is triggered hourly by a timer (every hour at 53:40 minutes, to stagger it from other hourly cronjobs and help identify issues).

Towards feature parity with vintage (mentioned in https://github.com/giantswarm/giantswarm/issues/27954)

- [x] CHANGELOG.md has been updated (if it exists)
