### PR TITLE
Fixes crictl ps --name regex for etcd pod in etcd3-defragmentation.service

### DIFF
--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_flatcar.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_flatcar.tpl
@@ -46,7 +46,7 @@ containerLinuxConfig:
     Requires=containerd.service kubelet.service
     [Service]
     Type=oneshot
-    ExecStart=/bin/sh -c "crictl exec $(crictl ps --name=etcd -q) etcdctl \
+    ExecStart=/bin/sh -c "crictl exec $(crictl ps --name=^etcd$ -q) etcdctl \
       --cacert=/etc/kubernetes/pki/etcd/ca.crt \
       --cert=/etc/kubernetes/pki/etcd/peer.crt \
       --key=/etc/kubernetes/pki/etcd/peer.key \


### PR DESCRIPTION
### What does this PR do?

Fixes the etcd3 defrag service: `crictl ps --name` is a regex, and in clusters where there is another pod that has "etcd" in the name (e.g., `etcd-kubernetes-resources-count-exporter`), in some cases we didn't get the etcd pod id from crictl, causing the service to fail (no other impact on the cluster though).
This makes sure we get the right pod.
