### PR TITLE
Support prepending cluster name to file secret name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add default HelmRepositories (behind a flag which is disabled by default).
 - Add vertical-pod-autoscaler-crd HelmRelease (behind a flag which is disabled by default).
 - Add coredns HelmRelease (behind a flag which is disabled by default).
+- Support prepending cluster name to file secret name
 
 ## [0.8.0] - 2024-02-09
 
 ### Added
 
 - Add systemd unit and script to compute fairness values for k8s API server in controlplane.
-- Add internal.advancedConfiguration.kubelet to configure system and k8s reserved resources. 
+- Add internal.advancedConfiguration.kubelet to configure system and k8s reserved resources.
 - Add `rolloutBefore` config to Helm value to `.Values.internal.advancedConfiguration.controlPlane` to enable support for automatic node rollout/certificate renewal
 - Add systemd unit and timer for hourly etcd defragmentation.
 
@@ -149,7 +150,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed containerd configuration for newer flatcar versions. 
+- Fixed containerd configuration for newer flatcar versions.
 
 ## [0.1.0] - 2023-12-19
 

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -133,6 +133,7 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.advancedConfiguration.controlPlane.files[*].contentFrom.secret` | **Secret** - Kubernetes Secret resource with the file content.|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.controlPlane.files[*].contentFrom.secret.key` | **Key** - Secret key where the file content is.|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.controlPlane.files[*].contentFrom.secret.name` | **Name** - Name of the Secret resource.|**Type:** `string`<br/>|
+| `internal.advancedConfiguration.controlPlane.files[*].contentFrom.secret.prependClusterNameAsPrefix` | **Prepend cluster name as name prefix** - Prepend cluster name as name prefix in order to use a unique secret name.|**Type:** `boolean`<br/>|
 | `internal.advancedConfiguration.controlPlane.files[*].path` | **Path** - File path on the node.|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.controlPlane.files[*].permissions` | **Permissions** - File permissions in form 0644|**Type:** `string`<br/>**Default:** `"0644"`|
 | `internal.advancedConfiguration.controlPlane.postKubeadmCommands` | **Post-kubeadm commands** - Extra commands to run after kubeadm runs.|**Type:** `array`<br/>|
@@ -147,6 +148,7 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.advancedConfiguration.files[*].contentFrom.secret` | **Secret** - Kubernetes Secret resource with the file content.|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.files[*].contentFrom.secret.key` | **Key** - Secret key where the file content is.|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.files[*].contentFrom.secret.name` | **Name** - Name of the Secret resource.|**Type:** `string`<br/>|
+| `internal.advancedConfiguration.files[*].contentFrom.secret.prependClusterNameAsPrefix` | **Prepend cluster name as name prefix** - Prepend cluster name as name prefix in order to use a unique secret name.|**Type:** `boolean`<br/>|
 | `internal.advancedConfiguration.files[*].path` | **Path** - File path on the node.|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.files[*].permissions` | **Permissions** - File permissions in form 0644|**Type:** `string`<br/>**Default:** `"0644"`|
 | `internal.advancedConfiguration.kubelet` | **Kubelet configuration** - Kubelet configuration settings for the whole cluster.|**Type:** `object`<br/>|
@@ -168,6 +170,7 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.advancedConfiguration.workers.files[*].contentFrom.secret` | **Secret** - Kubernetes Secret resource with the file content.|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.workers.files[*].contentFrom.secret.key` | **Key** - Secret key where the file content is.|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.workers.files[*].contentFrom.secret.name` | **Name** - Name of the Secret resource.|**Type:** `string`<br/>|
+| `internal.advancedConfiguration.workers.files[*].contentFrom.secret.prependClusterNameAsPrefix` | **Prepend cluster name as name prefix** - Prepend cluster name as name prefix in order to use a unique secret name.|**Type:** `boolean`<br/>|
 | `internal.advancedConfiguration.workers.files[*].path` | **Path** - File path on the node.|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.workers.files[*].permissions` | **Permissions** - File permissions in form 0644|**Type:** `string`<br/>**Default:** `"0644"`|
 | `internal.advancedConfiguration.workers.postKubeadmCommands` | **Post-kubeadm commands** - Extra commands to run after kubeadm runs.|**Type:** `array`<br/>|
@@ -317,6 +320,7 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.controlPlane.kubeadmConfig.files[*].contentFrom.secret` | **Secret** - Kubernetes Secret resource with the file content.|**Type:** `object`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.files[*].contentFrom.secret.key` | **Key** - Secret key where the file content is.|**Type:** `string`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.files[*].contentFrom.secret.name` | **Name** - Name of the Secret resource.|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.files[*].contentFrom.secret.prependClusterNameAsPrefix` | **Prepend cluster name as name prefix** - Prepend cluster name as name prefix in order to use a unique secret name.|**Type:** `boolean`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.files[*].path` | **Path** - File path on the node.|**Type:** `string`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.files[*].permissions` | **Permissions** - File permissions in form 0644|**Type:** `string`<br/>**Default:** `"0644"`|
 | `providerIntegration.controlPlane.kubeadmConfig.ignition` | **Ignition** - Ignition-specific configuration.|**Type:** `object`<br/>|
@@ -392,6 +396,7 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.kubeadmConfig.files[*].contentFrom.secret` | **Secret** - Kubernetes Secret resource with the file content.|**Type:** `object`<br/>|
 | `providerIntegration.kubeadmConfig.files[*].contentFrom.secret.key` | **Key** - Secret key where the file content is.|**Type:** `string`<br/>|
 | `providerIntegration.kubeadmConfig.files[*].contentFrom.secret.name` | **Name** - Name of the Secret resource.|**Type:** `string`<br/>|
+| `providerIntegration.kubeadmConfig.files[*].contentFrom.secret.prependClusterNameAsPrefix` | **Prepend cluster name as name prefix** - Prepend cluster name as name prefix in order to use a unique secret name.|**Type:** `boolean`<br/>|
 | `providerIntegration.kubeadmConfig.files[*].path` | **Path** - File path on the node.|**Type:** `string`<br/>|
 | `providerIntegration.kubeadmConfig.files[*].permissions` | **Permissions** - File permissions in form 0644|**Type:** `string`<br/>**Default:** `"0644"`|
 | `providerIntegration.kubeadmConfig.ignition` | **Ignition** - Ignition-specific configuration.|**Type:** `object`<br/>|
@@ -493,6 +498,7 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.workers.kubeadmConfig.files[*].contentFrom.secret` | **Secret** - Kubernetes Secret resource with the file content.|**Type:** `object`<br/>|
 | `providerIntegration.workers.kubeadmConfig.files[*].contentFrom.secret.key` | **Key** - Secret key where the file content is.|**Type:** `string`<br/>|
 | `providerIntegration.workers.kubeadmConfig.files[*].contentFrom.secret.name` | **Name** - Name of the Secret resource.|**Type:** `string`<br/>|
+| `providerIntegration.workers.kubeadmConfig.files[*].contentFrom.secret.prependClusterNameAsPrefix` | **Prepend cluster name as name prefix** - Prepend cluster name as name prefix in order to use a unique secret name.|**Type:** `boolean`<br/>|
 | `providerIntegration.workers.kubeadmConfig.files[*].path` | **Path** - File path on the node.|**Type:** `string`<br/>|
 | `providerIntegration.workers.kubeadmConfig.files[*].permissions` | **Permissions** - File permissions in form 0644|**Type:** `string`<br/>**Default:** `"0644"`|
 | `providerIntegration.workers.kubeadmConfig.ignition` | **Ignition** - Ignition-specific configuration.|**Type:** `object`<br/>|

--- a/helm/cluster/templates/clusterapi/_helpers_files.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_files.tpl
@@ -139,7 +139,7 @@ and is used to join the node to the teleport cluster.
 {{- $clusterName := required "clusterName is required for cluster.processFiles function call" .clusterName }}
 {{- $outFiles := list }}
 {{- range $file := .files }}
-{{- if eq (default false (index $file "contentFrom" "secret" "prependClusterNameAsPrefix")) true }}
+{{- if default false (index $file "contentFrom" "secret" "prependClusterNameAsPrefix") }}
 {{- $secret := (index $file "contentFrom" "secret") }}
 {{- $secretName := (required "Secret name must be given" (index $secret "name")) }}
 {{- $_ := set $secret "name" (printf "%s-%s" $clusterName $secretName) }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_files.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_files.tpl
@@ -31,13 +31,13 @@
 {{/* Provider-specific files for control plane nodes */}}
 {{- define "cluster.internal.controlPlane.kubeadm.files.provider" }}
 {{- if $.Values.providerIntegration.controlPlane.kubeadmConfig.files }}
-{{ toYaml $.Values.providerIntegration.controlPlane.kubeadmConfig.files }}
+{{ include "cluster.processFiles" (dict "files" $.Values.providerIntegration.controlPlane.kubeadmConfig.files "clusterName" (include "cluster.resource.name" $)) }}
 {{- end }}
 {{- end }}
 
 {{/* Custom cluster-specific files for control plane nodes */}}
 {{- define "cluster.internal.controlPlane.kubeadm.files.custom" }}
 {{- if $.Values.internal.advancedConfiguration.controlPlane.files }}
-{{ toYaml $.Values.internal.advancedConfiguration.controlPlane.files }}
+{{ include "cluster.processFiles" (dict "files" $.Values.internal.advancedConfiguration.controlPlane.files "clusterName" (include "cluster.resource.name" $)) }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/workers/_helpers_files.tpl
+++ b/helm/cluster/templates/clusterapi/workers/_helpers_files.tpl
@@ -7,13 +7,13 @@
 {{/* Provider-specific files for worker nodes */}}
 {{- define "cluster.internal.workers.kubeadm.files.provider" }}
 {{- if $.Values.providerIntegration.workers.kubeadmConfig.files }}
-{{ toYaml $.Values.providerIntegration.workers.kubeadmConfig.files }}
+{{ include "cluster.processFiles" (dict "files" $.Values.providerIntegration.workers.kubeadmConfig.files "clusterName" (include "cluster.resource.name" $)) }}
 {{- end }}
 {{- end }}
 
 {{/* Custom cluster-specific files for worker nodes */}}
 {{- define "cluster.internal.workers.kubeadm.files.custom" }}
 {{- if $.Values.internal.advancedConfiguration.workers.files }}
-{{ toYaml $.Values.internal.advancedConfiguration.workers.files }}
+{{ include "cluster.processFiles" (dict "files" $.Values.internal.advancedConfiguration.workers.files "clusterName" (include "cluster.resource.name" $)) }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -110,6 +110,11 @@
                                     "type": "string",
                                     "title": "Name",
                                     "description": "Name of the Secret resource."
+                                },
+                                "prependClusterNameAsPrefix": {
+                                    "type": "boolean",
+                                    "title": "Prepend cluster name as name prefix",
+                                    "description": "Prepend cluster name as name prefix in order to use a unique secret name."
                                 }
                             }
                         }


### PR DESCRIPTION
### What does this PR do?

Towards https://github.com/giantswarm/roadmap/issues/3183

Tested together with my cluster-aws change to introduce ENI mode for Cilium.

That requires configuring a certain dynamic config file on the host. We found that using the `contentFrom` (= from Secret) feature was the only reasonable option to pass the file content to the `cluster` chart.

### What is the effect of this change to users?

None, since the new field is optional. A value of `contentFrom.secret.prependClusterNameAsPrefix=true` transforms the secret name. This is because the parent chart (e.g. `cluster-aws`) cannot pass dynamic values down that easily, so prepending the already-known cluster name is an easy solution. We have many objects whose name is `<cluster name>-something`, so this is quite usual.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)