### PR TITLE
Allow any app configurations from parent chart in schema

### DIFF
--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -24,6 +24,13 @@ Configuration of apps that are part of the cluster.
 
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
+| `global.apps.PATTERN` | **App** - Configuration of an default app that is part of the cluster.|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`[a-z][a-zA-Z]+`<br/>|
+| `global.apps.PATTERN.extraConfigs` | **Extra config maps or secrets** - Extra config maps or secrets that will be used to customize to the app. The desired values must be under configmap or secret key 'values'. The values are merged in the order given, with the later values overwriting earlier, and then inline values overwriting those. Resources must be in the same namespace as the cluster.|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`[a-z][a-zA-Z]+`<br/>|
+| `global.apps.PATTERN.extraConfigs[*]` | **Config map or secret**|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`[a-z][a-zA-Z]+`<br/>|
+| `global.apps.PATTERN.extraConfigs[*].kind` | **Kind** - Specifies whether the resource is a config map or a secret.|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`[a-z][a-zA-Z]+`<br/>|
+| `global.apps.PATTERN.extraConfigs[*].name` | **Name** - Name of the config map or secret. The object must exist in the same namespace as the cluster App.|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`[a-z][a-zA-Z]+`<br/>|
+| `global.apps.PATTERN.extraConfigs[*].optional` | **Optional** - Optional marks this ValuesReference as optional. When set, a not found error for the values reference is ignored, but any ValuesKey, TargetPath or transient error will still result in a reconciliation failure.|**Type:** `boolean`<br/>**Key pattern:**<br/>`PATTERN`=`[a-z][a-zA-Z]+`<br/>|
+| `global.apps.PATTERN.values` | **Values** - Values to be passed to the app. Values will have higher priority than values from configmaps.|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`[a-z][a-zA-Z]+`<br/>|
 | `global.apps.coreDns` | **App** - Configuration of an default app that is part of the cluster.|**Type:** `object`<br/>|
 | `global.apps.coreDns.extraConfigs` | **Extra config maps or secrets** - Extra config maps or secrets that will be used to customize to the app. The desired values must be under configmap or secret key 'values'. The values are merged in the order given, with the later values overwriting earlier, and then inline values overwriting those. Resources must be in the same namespace as the cluster.|**Type:** `array`<br/>|
 | `global.apps.coreDns.extraConfigs[*]` | **Config map or secret**|**Type:** `object`<br/>|

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -724,6 +724,14 @@
                     "title": "Apps",
                     "description": "Configuration of apps that are part of the cluster.",
                     "additionalProperties": false,
+                    "patternProperties": {
+                        "[a-z][a-zA-Z]+": {
+                            "$ref": "#/$defs/app",
+                            "type": "object",
+                            "title": "App configurations from parent chart",
+                            "description": "Not used in this chart. This is here to keep the schemas compatible."
+                        }
+                    },
                     "properties": {
                         "coreDns": {
                             "$ref": "#/$defs/app",


### PR DESCRIPTION
### What does this PR do?

Related to https://github.com/giantswarm/roadmap/issues/3183, but required in general in order to update `cluster-aws` to `cluster-v0.8.0` (I think). The parent chart, e.g. `cluster-aws` can have provider-specific apps such as `awsCloudControllerManager`, `awsEbsCsiDriver` or `cilium`, and since `global.apps.*` is shared with the `cluster` chart, its schema must allow those keys.

### What is the effect of this change to users?

`additionalProperties=false` won't catch typos anymore since any app name is now allowed (e.g. `global.apps.coreDns` vs. `global.apps.CoReDnS` can't be caught). If that's not desired, we have to explicitly list every possible provider-specific app here, or move those to another key such as `global.providerSpecificApps`.

### Should this change be mentioned in the release notes?

Implementation detail, so I did not consider a public changelog entry. Should I, for our own sake?

- [ ] CHANGELOG.md has been updated (if it exists)
