### PR TITLE
Set `--node-ip` kubelet argument also for joining control plane nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add vertical-pod-autoscaler-crd HelmRelease (behind a flag which is disabled by default).
 - Add coredns HelmRelease (behind a flag which is disabled by default).
 
+### Changed
+
+- Set `--node-ip` kubelet argument also for joining control plane nodes. Other nodes already had this setting, and it is important if a node has multiple network interfaces (such as for Cilium ENI mode or AWS VPC CNI). Only the primary IP will be reported in the node status, resulting in `kubectl exec` and other tooling working correctly.
+
 ## [0.8.0] - 2024-02-09
 
 ### Added

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_joinconfiguration.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_joinconfiguration.tpl
@@ -10,6 +10,7 @@ nodeRegistration:
     {{- end }}
     cloud-provider: external
     feature-gates: CronJobTimeZone=true
+    node-ip: ${COREOS_EC2_IPV4_LOCAL}
   name: ${COREOS_EC2_HOSTNAME}
   {{- if $.Values.global.controlPlane.customNodeTaints }}
   {{- if (gt (len $.Values.global.controlPlane.customNodeTaints) 0) }}


### PR DESCRIPTION
### What does this PR do?

Joining control plane nodes, i.e. the 2nd, 3rd and newly rolling nodes didn't have the `--node-ip` kubelet argument. For https://github.com/giantswarm/roadmap/issues/3183 (Cilium ENI mode for AWS), this meant that certain tooling may fail to connect to/through those instances since their kubelet port 10250 would only be available on eth0 (= primary IP), not for example on other network interfaces such as the pod network / pod IPs (eth1 and up in case of ENI mode). Specifically, I observed `kubectl exec` to be broken if it chose the wrong IP of a control plane node, and thus also `cilium connectivity test` would fail since it uses that functionality.

I verified that worker nodes (in machine pools) and the first control plane ("init", not "join" config) have this set correctly.

Tested with my cluster-aws change and works fine.

### What is the effect of this change to users?

`kubectl get node -o yaml | grep InternalIP` shows one result per node instead of listing all ENIs' IPs.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)