### PR TITLE
Kubelet: Add `containerLogMaxSize` & `containerLogMaxFiles`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add vertical-pod-autoscaler-crd HelmRelease (behind a flag which is disabled by default).
 - Add coredns HelmRelease (behind a flag which is disabled by default).
 - Support prepending cluster name to file secret name
+- Kubelet: Add `containerLogMaxSize` & `containerLogMaxFiles`. ([#92](https://github.com/giantswarm/cluster/pull/92))
 
 ### Changed
 

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -168,6 +168,8 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.advancedConfiguration.files[*].path` | **Path** - File path on the node.|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.files[*].permissions` | **Permissions** - File permissions in form 0644|**Type:** `string`<br/>**Default:** `"0644"`|
 | `internal.advancedConfiguration.kubelet` | **Kubelet configuration** - Kubelet configuration settings for the whole cluster.|**Type:** `object`<br/>|
+| `internal.advancedConfiguration.kubelet.containerLogMaxFiles` | **Maximum number of container log files** - Specifies the maximum number of container log files that can be present for a container.|**Type:** `integer`<br/>**Default:** `0`|
+| `internal.advancedConfiguration.kubelet.containerLogMaxSize` | **Maximum size of the container log** - Specifies the maximum size of the container log file before it is rotated. For example: "5Mi" or "256Ki".|**Type:** `string`<br/>**Default:** `""`|
 | `internal.advancedConfiguration.kubelet.kubeReserved` | **Kube reserved resources configuration** - Resources configuration for Kubernetes system services.|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.kubelet.kubeReserved.cpu` | **Kube reserved CPU** - CPU reserved for Kubernetes system services.|**Type:** `string`<br/>**Default:** `"350m"`|
 | `internal.advancedConfiguration.kubelet.kubeReserved.ephemeralStorage` | **Kube reserved ephemeral storage** - Ephemeral storage reserved for kubernetes system services.|**Type:** `string`<br/>**Default:** `"1024Mi"`|

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -141,6 +141,8 @@ internal:
       kubeReserved:
         cpu: 350m
         memory: 384Mi
+      containerLogMaxSize: 30Mi
+      containerLogMaxFiles: 2
 providerIntegration:
   apps:
     cilium:

--- a/helm/cluster/files/etc/kubernetes/patches/kubeletconfiguration.yaml
+++ b/helm/cluster/files/etc/kubernetes/patches/kubeletconfiguration.yaml
@@ -45,3 +45,9 @@ serializeImagePulls: false
 streamingConnectionIdleTimeout: 1h
 allowedUnsafeSysctls:
 - "net.*"
+{{- if $.Values.internal.advancedConfiguration.kubelet.containerLogMaxSize }}
+containerLogMaxSize: {{ $.Values.internal.advancedConfiguration.kubelet.containerLogMaxSize }}
+{{- end }}
+{{- if $.Values.internal.advancedConfiguration.kubelet.containerLogMaxFiles }}
+containerLogMaxFiles: {{ $.Values.internal.advancedConfiguration.kubelet.containerLogMaxFiles }}
+{{- end }}

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1348,6 +1348,18 @@
                             "title": "Kubelet configuration",
                             "description": "Kubelet configuration settings for the whole cluster.",
                             "properties": {
+                                "containerLogMaxFiles": {
+                                    "type": "integer",
+                                    "title": "Maximum number of container log files",
+                                    "description": "Specifies the maximum number of container log files that can be present for a container.",
+                                    "default": 0
+                                },
+                                "containerLogMaxSize": {
+                                    "type": "string",
+                                    "title": "Maximum size of the container log",
+                                    "description": "Specifies the maximum size of the container log file before it is rotated. For example: \"5Mi\" or \"256Ki\".",
+                                    "default": ""
+                                },
                                 "kubeReserved": {
                                     "type": "object",
                                     "title": "Kube reserved resources configuration",

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -52,6 +52,8 @@ internal:
       rolloutBefore:
         certificatesExpiryDays: 180
     kubelet:
+      containerLogMaxFiles: 0
+      containerLogMaxSize: ""
       kubeReserved:
         cpu: 350m
         ephemeralStorage: 1024Mi


### PR DESCRIPTION
### What does this PR do?

This PR makes `containerLogMaxSize` & `containerLogMaxFiles` of Kubelet configurable.

### What is the effect of this change to users?

None. Both parameters are not being rendered by default. If they are set, they affect the log rotation behavior of Kubelet.

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/3002.

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
