### PR TITLE
API Server: Make audit policy rules extendable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add cilium HelmRelease (behind a flag which is disabled by default).
 - Add network-policies HelmRelease and cluster-catalog HelmRepository (behind a flag which is disabled by default).
+- Kubelet: Add `containerLogMaxSize` & `containerLogMaxFiles`. ([#92](https://github.com/giantswarm/cluster/pull/92))
+- API Server: Make audit policy rules extendable. ([#93](https://github.com/giantswarm/cluster/pull/93))
 
 ## [0.9.1] - 2024-02-22
 
@@ -26,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add vertical-pod-autoscaler-crd HelmRelease (behind a flag which is disabled by default).
 - Add coredns HelmRelease (behind a flag which is disabled by default).
 - Support prepending cluster name to file secret name
-- Kubelet: Add `containerLogMaxSize` & `containerLogMaxFiles`. ([#92](https://github.com/giantswarm/cluster/pull/92))
 
 ### Changed
 

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -130,6 +130,9 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.advancedConfiguration.cgroupsv1` | **CGroups v1** - Force use of CGroups v1 for whole cluster.|**Type:** `boolean`<br/>**Default:** `false`|
 | `internal.advancedConfiguration.controlPlane` | **Control plane** - Advanced configuration of control plane components.|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer` | **API server** - Advanced configuration of API server.|**Type:** `object`<br/>|
+| `internal.advancedConfiguration.controlPlane.apiServer.auditPolicy` | **Audit policy** - Configuration of the audit policy.|**Type:** `object`<br/>|
+| `internal.advancedConfiguration.controlPlane.apiServer.auditPolicy.extraRules` | **Additional audit policy rules** - A list of additional audit policy rules.|**Type:** `array`<br/>|
+| `internal.advancedConfiguration.controlPlane.apiServer.auditPolicy.extraRules[*]` | **Additional audit policy rule**|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.bindPort` | **Bind port** - Kubernetes API bind port used for API server pod.|**Type:** `integer`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.enablePriorityAndFairness` | **Enable priority and fairness** - If true and the APIPriorityAndFairness feature gate is enabled, replace the max-in-flight handler with an enhanced one that queues and dispatches with priority and fairness.|**Type:** `boolean`<br/>**Default:** `false`|
 | `internal.advancedConfiguration.controlPlane.apiServer.etcdPrefix` | **etcd prefix** - The prefix to prepend to all resource paths in etcd. If nothing is specified, the API server uses '/registry' prefix by default.|**Type:** `string`<br/>|

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -80,6 +80,19 @@ internal:
     cgroupsv1: true
     controlPlane:
       apiServer:
+        auditPolicy:
+          extraRules:
+          - users:
+            - system:unsecured
+            verbs:
+            - get
+            resources:
+            - group: ""
+              resources:
+              - configmaps
+            namespaces:
+            - kube-system
+            level: Request
         bindPort: 6443
         etcdPrefix: giantswarm.io
         extraArgs:

--- a/helm/cluster/files/etc/kubernetes/policies/audit-policy.yaml
+++ b/helm/cluster/files/etc/kubernetes/policies/audit-policy.yaml
@@ -1,6 +1,9 @@
 apiVersion: audit.k8s.io/v1
 kind: Policy
 rules:
+  {{- with $.Values.internal.advancedConfiguration.controlPlane.apiServer.auditPolicy.extraRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
   # The following requests were manually identified as high-volume and low-risk,
   # so drop them.
   - level: None

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_files.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_files.tpl
@@ -15,7 +15,7 @@
 - path: /etc/kubernetes/policies/audit-policy.yaml
   permissions: "0600"
   encoding: base64
-  content: {{ $.Files.Get "files/etc/kubernetes/policies/audit-policy.yaml" | b64enc }}
+  content: {{ tpl ($.Files.Get "files/etc/kubernetes/policies/audit-policy.yaml") . | b64enc }}
 - path: /etc/kubernetes/encryption/config.yaml
   permissions: "0600"
   contentFrom:

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1223,6 +1223,23 @@
                                     "title": "API server",
                                     "description": "Advanced configuration of API server.",
                                     "properties": {
+                                        "auditPolicy": {
+                                            "type": "object",
+                                            "title": "Audit policy",
+                                            "description": "Configuration of the audit policy.",
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "extraRules": {
+                                                    "type": "array",
+                                                    "title": "Additional audit policy rules",
+                                                    "description": "A list of additional audit policy rules.",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "title": "Additional audit policy rule"
+                                                    }
+                                                }
+                                            }
+                                        },
                                         "bindPort": {
                                             "type": "integer",
                                             "title": "Bind port",

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -45,6 +45,7 @@ internal:
     cgroupsv1: false
     controlPlane:
       apiServer:
+        auditPolicy: {}
         enablePriorityAndFairness: false
       etcd:
         experimental: {}


### PR DESCRIPTION
### What does this PR do?

This PR makes the audit policy rules we already define extendable by customer defined rules.

### What is the effect of this change to users?

The user can define additional audit policy rules which get added to the top of the list of default rules in the audit policy file.

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/3002.

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
