### PR TITLE
downgrade k8s version to previous patch version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Downgrade Kubernetes version to v1.25.15.
+
 ## [0.9.1] - 2024-02-22
 
 ### Changed

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -461,7 +461,7 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.kubeadmConfig.postKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
 | `providerIntegration.kubeadmConfig.preKubeadmCommands` | **Pre-kubeadm commands** - Extra commands to run before kubeadm runs.|**Type:** `array`<br/>|
 | `providerIntegration.kubeadmConfig.preKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
-| `providerIntegration.kubernetesVersion` | **Kubernetes version**|**Type:** `string`<br/>**Default:** `"1.25.16"`|
+| `providerIntegration.kubernetesVersion` | **Kubernetes version**|**Type:** `string`<br/>**Default:** `"1.25.15"`|
 | `providerIntegration.pauseProperties` | **Pause properties** - A map of property names and their values that will affect setting pause annotation|**Type:** `object`<br/>|
 | `providerIntegration.pauseProperties.*` |**None**|**Types:** `string, number, integer, boolean`<br/>|
 | `providerIntegration.provider` | **Provider** - The name of the Cluster API provider. The name here must match the name of the provider in cluster-<provider> app name.|**Type:** `string`<br/>|

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1817,7 +1817,7 @@
                 "kubernetesVersion": {
                     "type": "string",
                     "title": "Kubernetes version",
-                    "default": "1.25.16"
+                    "default": "1.25.15"
                 },
                 "pauseProperties": {
                     "type": "object",

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -98,7 +98,7 @@ providerIntegration:
         additionalConfig:
           storage: {}
           systemd: {}
-  kubernetesVersion: 1.25.16
+  kubernetesVersion: 1.25.15
   resourcesApi:
     bastionResourceEnabled: true
     clusterResourceEnabled: true


### PR DESCRIPTION
### What does this PR do?

This PR downgrades K8s version to previous patch release as we want to build a new flatcar image for current version without overriding existing clusters.

### What is the effect of this change to users?

### How does it look like?

(Please add anything that represents the change visually. Screenshots, output, logs, ...)

### Any background context you can provide?

Towards https://github.com/giantswarm/giantswarm/issues/29892

Also see https://github.com/giantswarm/giantswarm/issues/29892#issuecomment-1958966726

### What is needed from the reviewers?

### Do the docs need to be updated?

No

### Should this change be mentioned in the release notes?

Yes

- [ ] CHANGELOG.md has been updated (if it exists)
