### PR TITLE
Randomize etcd defragmentation start so they are staggered.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Apply API Server fairness settings using patches.
+- Randomize etcd defragmentation start minute so they are staggered.
 
 ## [0.10.0] - 2024-02-22
 

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_flatcar.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_flatcar.tpl
@@ -49,7 +49,9 @@ containerLinuxConfig:
     [Unit]
     Description=Execute etcd3-defragmentation hourly
     [Timer]
-    OnCalendar=*-*-* *:53:40
+    OnCalendar=hourly
+    RandomizedDelaySec=55m
+    FixedRandomDelay=true
     Unit=etcd3-defragmentation.service
     [Install]
     WantedBy=multi-user.target


### PR DESCRIPTION
### What does this PR do?

Adds a random, fixed delay to etcd defragmentation service start to prevent them being synchronized.

### Any background context you can provide?
Towards https://github.com/giantswarm/giantswarm/issues/29868

- [x] CHANGELOG.md has been updated (if it exists)
