### PR TITLE
Fix order of preKubeadmCommands for CAPA migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix order of preKubeadmCommands for CAPA migration, custom must be placed before provider commands.
+
+### Changed
+
 - Apply API Server fairness settings using patches.
 - Randomize etcd defragmentation start minute so they are staggered.
 

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_prekubeadmcommands.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_prekubeadmcommands.tpl
@@ -4,14 +4,17 @@
 
     It includes:
     - shared preKubeadmCommands that are executed on all nodes,
-    - provider-specific control plane commands specified in cluster-<provider> app,
     - custom cluster-specific control plane commands.
+    - provider-specific control plane commands specified in cluster-<provider> app,
+
+    For CAPA migration custom preKubeadmCommands have to be before provider-specific commands.
 */}}
+
 {{- define "cluster.internal.controlPlane.kubeadm.preKubeadmCommands" }}
 {{- include "cluster.internal.kubeadm.preKubeadmCommands" $ }}
 {{- include "cluster.internal.controlPlane.kubeadm.preKubeadmCommands.default" $ }}
-{{- include "cluster.internal.controlPlane.kubeadm.preKubeadmCommands.provider" $ }}
 {{- include "cluster.internal.controlPlane.kubeadm.preKubeadmCommands.custom" $ }}
+{{- include "cluster.internal.controlPlane.kubeadm.preKubeadmCommands.provider" $ }}
 {{- end }}
 
 {{/* Default commands to run before kubeadm on control plane nodes */}}


### PR DESCRIPTION
### What does this PR do?

Fixes empty `initial-cluster`

```
  containers:
  - command:
    - etcd
    - --advertise-client-urls=https://10.1.12.59:2379
    - --cert-file=/etc/kubernetes/pki/etcd/server.crt
    - --client-cert-auth=true
    - --data-dir=/var/lib/etcd
    - --experimental-initial-corrupt-check=true
    - --experimental-peer-skip-client-san-verification=true
    - --experimental-watch-progress-notify-interval=5s
    - --initial-advertise-peer-urls=https://10.1.12.59:2380
    - --initial-cluster=
    - --initial-cluster-state=existing
```

```
{"level":"fatal","ts":"2024-02-28T08:25:52.29194Z","caller":"etcdmain/etcd.go:204","msg":"discovery failed","error":"couldn't find local name \"ip-10-1-12-59.eu-central-1.compute.internal\" in the initial cluster configuration","stacktrace":"go.etcd.io/etcd/server/v3/etcdmain.startEtcdOrProxyV2\n\tgo.etcd.io/etcd/server/v3/etcdmain/etcd.go:204\ngo.etcd.io/etcd/server/v3/etcdmain.Main\n\tgo.etcd.io/etcd/server/v3/etcdmain/main.go:40\nmain.main\n\tgo.etcd.io/etcd/server/v3/main.go:31\nruntime.main\n\truntime/proc.go:250"}
```

`/bin/sh /migration/join-existing-cluster.sh` command has to run before `- envsubst < /etc/kubeadm.yml > /etc/kubeadm.yml.tmp`

```
    preKubeadmCommands:
    - envsubst < /etc/kubeadm.yml > /etc/kubeadm.yml.tmp
    - mv /etc/kubeadm.yml.tmp /etc/kubeadm.yml
    - echo "---" >> /etc/kubeadm.yml
    - cat /etc/kubelet-configuration.yaml >> /etc/kubeadm.yml
    - iptables -A PREROUTING -t nat  -p tcp --dport 6443 -j REDIRECT --to-port 443
    - iptables -t nat -A OUTPUT -p tcp --destination 127.0.0.1 --dport 6443 -j REDIRECT
      --to-port 443
    - /bin/sh /migration/join-existing-cluster.sh
```

- [x] CHANGELOG.md has been updated (if it exists)