### PR TITLE
Fix order of preKubeadmCommands for CAPA migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix order of preKubeadmCommands for CAPA migration, custom must be placed before any preKubadmCommands.
+-
 ## [0.11.0] - 2024-02-28
 
 ### Fixed

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_prekubeadmcommands.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_prekubeadmcommands.tpl
@@ -7,13 +7,13 @@
     - custom cluster-specific control plane commands.
     - provider-specific control plane commands specified in cluster-<provider> app,
 
-    For CAPA migration custom preKubeadmCommands have to be before provider-specific commands.
+    For CAPA migration custom preKubeadmCommands have to be before any other commands.
 */}}
 
 {{- define "cluster.internal.controlPlane.kubeadm.preKubeadmCommands" }}
+{{- include "cluster.internal.controlPlane.kubeadm.preKubeadmCommands.custom" $ }}
 {{- include "cluster.internal.kubeadm.preKubeadmCommands" $ }}
 {{- include "cluster.internal.controlPlane.kubeadm.preKubeadmCommands.default" $ }}
-{{- include "cluster.internal.controlPlane.kubeadm.preKubeadmCommands.custom" $ }}
 {{- include "cluster.internal.controlPlane.kubeadm.preKubeadmCommands.provider" $ }}
 {{- end }}
 


### PR DESCRIPTION
- [x] CHANGELOG.md has been updated (if it exists)