### PR TITLE
Update cilium-app to v0.21.0 in order to support Cilium ENI mode for CAPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update cilium-app to v0.21.0 in order to support Cilium ENI mode for CAPA
+
 ## [0.11.1] - 2024-02-29
 
 ### Changed

--- a/helm/cluster/templates/apps/cilium.yaml
+++ b/helm/cluster/templates/apps/cilium.yaml
@@ -39,7 +39,7 @@ spec:
       chart: cilium
       # used by renovate
       # repo: giantswarm/cilium-app
-      version: 0.20.1
+      version: 0.21.0
       sourceRef:
         kind: HelmRepository
         name: {{ include "cluster.resource.name" $ }}-default


### PR DESCRIPTION
### What does this PR do?

Includes https://github.com/giantswarm/cilium-app/pull/148, towards https://github.com/giantswarm/roadmap/issues/3183

### What is the effect of this change to users?

None for default clusters. This only applies to ENI mode (certain customers will use that, for CAPA it's in prototype status with https://github.com/giantswarm/cluster-aws/pull/528).

Be aware that a second, unrelated change happened in cilium-app v0.21.0: https://github.com/giantswarm/cilium-app/pull/149.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
