### PR TITLE
Chart: Make admission plugins configurable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Cleanup HelmRelease Hook Job.
+- Chart: Make admission plugins configurable. ([#118](https://github.com/giantswarm/cluster/pull/118))
+  - Chart: Add `internal.advancedConfiguration.controlPlane.apiServer.additionalAdmissionPlugins`.
+  - Chart: Add `internal.advancedConfiguration.controlPlane.apiServer.admissionConfiguration`.
 
 ### Changed
 

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -130,6 +130,8 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.advancedConfiguration.cgroupsv1` | **CGroups v1** - Force use of CGroups v1 for whole cluster.|**Type:** `boolean`<br/>**Default:** `false`|
 | `internal.advancedConfiguration.controlPlane` | **Control plane** - Advanced configuration of control plane components.|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer` | **API server** - Advanced configuration of API server.|**Type:** `object`<br/>|
+| `internal.advancedConfiguration.controlPlane.apiServer.additionalAdmissionPlugins` | **Additional admission plugins** - A list of plugins to enable, in addition to the default ones that include DefaultStorageClass, DefaultTolerationSeconds, LimitRanger, MutatingAdmissionWebhook, NamespaceLifecycle, PersistentVolumeClaimResize, Priority, ResourceQuota, ServiceAccount and ValidatingAdmissionWebhook.|**Type:** `array`<br/>|
+| `internal.advancedConfiguration.controlPlane.apiServer.additionalAdmissionPlugins[*]` | **Additional admission plugin**|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.auditPolicy` | **Audit policy** - Configuration of the audit policy.|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.auditPolicy.extraRules` | **Additional audit policy rules** - A list of additional audit policy rules.|**Type:** `array`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.auditPolicy.extraRules[*]` | **Additional audit policy rule**|**Type:** `object`<br/>|

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -132,6 +132,11 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.advancedConfiguration.controlPlane.apiServer` | **API server** - Advanced configuration of API server.|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.additionalAdmissionPlugins` | **Additional admission plugins** - A list of plugins to enable, in addition to the default ones that include DefaultStorageClass, DefaultTolerationSeconds, LimitRanger, MutatingAdmissionWebhook, NamespaceLifecycle, PersistentVolumeClaimResize, Priority, ResourceQuota, ServiceAccount and ValidatingAdmissionWebhook.|**Type:** `array`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.additionalAdmissionPlugins[*]` | **Additional admission plugin**|**Type:** `string`<br/>|
+| `internal.advancedConfiguration.controlPlane.apiServer.admissionConfiguration` | **Admission configuration** - Configuration of admission control.|**Type:** `object`<br/>|
+| `internal.advancedConfiguration.controlPlane.apiServer.admissionConfiguration.plugins` | **Admission plugin configurations** - A list of admission plugin configurations.|**Type:** `array`<br/>|
+| `internal.advancedConfiguration.controlPlane.apiServer.admissionConfiguration.plugins[*]` | **Admission plugin configuration** - An admission plugin configuration.|**Type:** `object`<br/>|
+| `internal.advancedConfiguration.controlPlane.apiServer.admissionConfiguration.plugins[*].config` | **Admission plugin configuration** - Configuration of the admission plugin.|**Type:** `string`<br/>|
+| `internal.advancedConfiguration.controlPlane.apiServer.admissionConfiguration.plugins[*].name` | **Admission plugin name** - Name of the admission plugin.|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.auditPolicy` | **Audit policy** - Configuration of the audit policy.|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.auditPolicy.extraRules` | **Additional audit policy rules** - A list of additional audit policy rules.|**Type:** `array`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.auditPolicy.extraRules[*]` | **Additional audit policy rule**|**Type:** `object`<br/>|

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -80,6 +80,8 @@ internal:
     cgroupsv1: true
     controlPlane:
       apiServer:
+        additionalAdmissionPlugins:
+        - AlwaysPullImages
         auditPolicy:
           extraRules:
           - users:

--- a/helm/cluster/files/etc/kubernetes/admission/config.yaml
+++ b/helm/cluster/files/etc/kubernetes/admission/config.yaml
@@ -1,0 +1,11 @@
+{{- with .Values.internal.advancedConfiguration.controlPlane.apiServer.admissionConfiguration -}}
+apiVersion: apiserver.config.k8s.io/v1
+kind: AdmissionConfiguration
+{{- if .plugins }}
+plugins:
+{{- range .plugins }}
+- name: {{ .name }}
+  path: /etc/kubernetes/admission/plugins/{{ .name | lower }}.yaml
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_apiserver.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_apiserver.tpl
@@ -14,6 +14,9 @@ certSANs:
 */}}
 timeoutForControlPlane: 20m
 extraArgs:
+  {{- if .Values.internal.advancedConfiguration.controlPlane.apiServer.admissionConfiguration }}
+  admission-control-config-file: /etc/kubernetes/admission/config.yaml
+  {{- end }}
   {{- if .Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.apiAudiences }}
   api-audiences: {{ include "cluster.internal.controlPlane.kubeadm.clusterConfiguration.apiServer.apiAudiences" $ | trim | quote }}
   {{- end }}
@@ -61,6 +64,13 @@ extraVolumes:
   mountPath: /var/log/apiserver
   readOnly: false
   pathType: DirectoryOrCreate
+{{- if .Values.internal.advancedConfiguration.controlPlane.apiServer.admissionConfiguration }}
+- name: admission
+  hostPath: /etc/kubernetes/admission
+  mountPath: /etc/kubernetes/admission
+  readOnly: true
+  pathType: Directory
+{{- end }}
 - name: policies
   hostPath: /etc/kubernetes/policies
   mountPath: /etc/kubernetes/policies

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_apiserver.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_apiserver.tpl
@@ -82,7 +82,7 @@ extraVolumes:
 {{- end }}
 
 {{- define "cluster.internal.controlPlane.kubeadm.clusterConfiguration.apiServer.enableAdmissionPlugins" }}
-{{- $enableAdmissionPlugins := list
+{{- $defaultPlugins := list
   "DefaultStorageClass"
   "DefaultTolerationSeconds"
   "LimitRanger"
@@ -93,8 +93,9 @@ extraVolumes:
   "ResourceQuota"
   "ServiceAccount"
   "ValidatingAdmissionWebhook" -}}
-{{- $additionalAdmissionPlugins := $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.additionalAdmissionPlugins | default list }}
-{{- concat $enableAdmissionPlugins $additionalAdmissionPlugins | uniq | compact | join "," }}
+{{- $internalPlugins := $.Values.internal.advancedConfiguration.controlPlane.apiServer.additionalAdmissionPlugins | default list }}
+{{- $providerPlugins := $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.additionalAdmissionPlugins | default list }}
+{{- concat $defaultPlugins $internalPlugins $providerPlugins | uniq | compact | join "," }}
 {{- end }}
 
 {{- define "cluster.internal.controlPlane.kubeadm.clusterConfiguration.apiServer.serviceAccountIssuer" }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_files.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_files.tpl
@@ -1,11 +1,29 @@
 {{- define "cluster.internal.controlPlane.kubeadm.files" }}
 {{- include "cluster.internal.kubeadm.files" $ }}
+{{- include "cluster.internal.controlPlane.kubeadm.files.admission" $ }}
 {{- include "cluster.internal.controlPlane.kubeadm.files.audit" $ }}
 {{- include "cluster.internal.controlPlane.kubeadm.files.encryption" $ }}
 {{- include "cluster.internal.controlPlane.kubeadm.files.fairness" $ }}
 {{- include "cluster.internal.controlPlane.kubeadm.files.oidc" $ }}
 {{- include "cluster.internal.controlPlane.kubeadm.files.provider" $ }}
 {{- include "cluster.internal.controlPlane.kubeadm.files.custom" $ }}
+{{- end }}
+
+{{- define "cluster.internal.controlPlane.kubeadm.files.admission" }}
+{{- with .Values.internal.advancedConfiguration.controlPlane.apiServer.admissionConfiguration }}
+- path: /etc/kubernetes/admission/config.yaml
+  permissions: "0644"
+  encoding: base64
+  content: {{ tpl ($.Files.Get "files/etc/kubernetes/admission/config.yaml") $ | b64enc }}
+{{- if .plugins }}
+{{- range .plugins }}
+- path: /etc/kubernetes/admission/plugins/{{ .name | lower }}.yaml
+  permissions: "0644"
+  encoding: base64
+  content: {{ tpl .config $ | b64enc }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{- define "cluster.internal.controlPlane.kubeadm.files.audit" }}

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1232,6 +1232,9 @@
                                     "title": "API server",
                                     "description": "Advanced configuration of API server.",
                                     "properties": {
+                                        "additionalAdmissionPlugins": {
+                                            "$ref": "#/$defs/additionalAdmissionPlugins"
+                                        },
                                         "auditPolicy": {
                                             "type": "object",
                                             "title": "Audit policy",

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1235,6 +1235,41 @@
                                         "additionalAdmissionPlugins": {
                                             "$ref": "#/$defs/additionalAdmissionPlugins"
                                         },
+                                        "admissionConfiguration": {
+                                            "type": "object",
+                                            "title": "Admission configuration",
+                                            "description": "Configuration of admission control.",
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "plugins": {
+                                                    "type": "array",
+                                                    "title": "Admission plugin configurations",
+                                                    "description": "A list of admission plugin configurations.",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "title": "Admission plugin configuration",
+                                                        "description": "An admission plugin configuration.",
+                                                        "required": [
+                                                            "name",
+                                                            "config"
+                                                        ],
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "config": {
+                                                                "type": "string",
+                                                                "title": "Admission plugin configuration",
+                                                                "description": "Configuration of the admission plugin."
+                                                            },
+                                                            "name": {
+                                                                "type": "string",
+                                                                "title": "Admission plugin name",
+                                                                "description": "Name of the admission plugin."
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
                                         "auditPolicy": {
                                             "type": "object",
                                             "title": "Audit policy",

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -45,6 +45,7 @@ internal:
     cgroupsv1: false
     controlPlane:
       apiServer:
+        admissionConfiguration: {}
         auditPolicy: {}
         enablePriorityAndFairness: true
       etcd:


### PR DESCRIPTION
### What does this PR do?

This PR makes admission plugins configurable. This is required for porting the PodNodeSelector admission plugin from Vintage.

### Any background context you can provide?

https://github.com/giantswarm/roadmap/issues/3002

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
