### PR TITLE
Fixed typo on cleanup helmreleases role that prevented patching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Typo on role in Cleanup HelmReleases Hook Job.
+- Typo on role in Cleanup HelmReleases Hook Job role.
 
 ## [0.13.0] - 2024-03-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Typo on role in Cleanup HelmReleases Hook Job.
+
 ## [0.13.0] - 2024-03-06
 
 ### Added

--- a/helm/cluster/templates/apps/cleanup-helmreleases-hook-job.yaml
+++ b/helm/cluster/templates/apps/cleanup-helmreleases-hook-job.yaml
@@ -45,7 +45,7 @@ metadata:
 rules:
   - apiGroups: ["helm.toolkit.fluxcd.io"]
     resources: ["helmreleases"]
-    verbs: ["get", "list", patch"]
+    verbs: ["get", "list", "patch"]
   - apiGroups: ["source.toolkit.fluxcd.io"]
     resources: ["helmcharts"]
     verbs: ["get", "list", "patch"]


### PR DESCRIPTION
### What does this PR do?

Fixes a small typo on the role for the cleanup-helmreleases-hook job that prevented it from being able to patch helmreleases, i.e.:

```
+ kubectl patch -n org-daniel helmrelease.helm.toolkit.fluxcd.io/dan01-network-policies --type=merge -p {"metadata": {"finalizers": []}}
Error from server (Forbidden): helmreleases.helm.toolkit.fluxcd.io "dan01-network-policies" is forbidden: User "system:serviceaccount:org-daniel:dan01-cleanup-helmreleases-hook" cannot patch resource "helmreleases" in API group "helm.toolkit.fluxcd.io" in the namespace "org-daniel"
```

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
