### PR TITLE
Update network-policy app to v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update network-policies-app to v0.1.0.
+
 ## [0.16.0] - 2024-03-26
 
 ### Changed

--- a/helm/cluster/templates/apps/network-policies.yaml
+++ b/helm/cluster/templates/apps/network-policies.yaml
@@ -23,7 +23,7 @@ spec:
   chart:
     spec:
       chart: network-policies
-      version: 0.0.4
+      version: 0.1.0
       sourceRef:
         kind: HelmRepository
         name: {{ include "cluster.resource.name" $ }}-cluster


### PR DESCRIPTION
### What does this PR do?

Update network-policy app to v0.1.0

### What is the effect of this change to users?

None

### How does it look like?

Same

### Any background context you can provide?

For https://github.com/giantswarm/roadmap/issues/3261

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
