### PR TITLE
update cilium to v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update network-policies-app to v0.1.0.
+- Update cilium to v0.22.0. This version includes schemas and the extra-policies deletion job.
 
 ## [0.16.0] - 2024-03-26
 

--- a/helm/cluster/templates/apps/cilium.yaml
+++ b/helm/cluster/templates/apps/cilium.yaml
@@ -39,7 +39,7 @@ spec:
       chart: cilium
       # used by renovate
       # repo: giantswarm/cilium-app
-      version: 0.21.0
+      version: 0.22.0
       sourceRef:
         kind: HelmRepository
         name: {{ include "cluster.resource.name" $ }}-default


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

### What does this PR do?

Update the cilium app to v0.22.0

### What is the effect of this change to users?

None

### Any background context you can provide?

Needed for https://github.com/giantswarm/roadmap/issues/3261

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
