### PR TITLE
Update teleport node labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update teleport node labels - add `ins=` label and remove `cluster=` label condition check, such that MC nodes have this label.
+
 ## [0.17.0] - 2024-03-28
 
 ### Changed

--- a/helm/cluster/files/etc/teleport.yaml
+++ b/helm/cluster/files/etc/teleport.yaml
@@ -22,11 +22,9 @@ ssh_service:
     command: [/opt/teleport-node-role.sh]
     period: 1m0s
   labels:
+    ins: {{ .Values.global.managementCluster }}
     mc: {{ .Values.global.managementCluster }}
-    {{- $clusterName := include "cluster.resource.name" $ }}
-    {{- if ne .Values.global.managementCluster $clusterName }}
     cluster: {{ include "cluster.resource.name" $ }}
-    {{- end }}
     baseDomain: {{ .Values.global.connectivity.baseDomain }}
 proxy_service:
   enabled: "no"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30398

### What does this PR do?
- Add new `ins=` label to all nodes, same value as mc= label
- Removes conditional check for `cluster=` label for MC nodes

### What is the effect of this change to users?
- No changes.

### How does it look like?

(Please add anything that represents the change visually. Screenshots, output, logs, ...)

### Any background context you can provide?
Currently, our labels doesn't support listing only MC nodes, because cluster= label is not present on MC nodes, only WC nodes and mc= label is common on all nodes.

In Web UI, we can filter by setting cluster="" but same doesn't work on Terminal tsh client.

```
$ tsh ssh root@mc=gazelle,cluster=
ERROR: invalid label spec: 'mc=gazelle,cluster=', should be 'key=value'

$ tsh ssh root@mc=gazelle,cluster=""
ERROR: invalid label spec: 'mc=gazelle,cluster=', should be 'key=value'
```

(Please link public issues or summarize if not public.)

### What is needed from the reviewers?
Just review.

### Do the docs need to be updated?
Yes, teleport [intranet documents here](https://intranet.giantswarm.io/docs/support-and-ops/teleport/node-access/), so we mention new `ins` and `cluster=` label for MCs.

### Should this change be mentioned in the release notes?
No

- [x] CHANGELOG.md has been updated (if it exists)
