### PR TITLE
Upgrade cilium-app to v0.23.0 in order to make Cilium ENI mode for CAPA usable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Upgrade cilium-app to v0.23.0 in order to make Cilium ENI mode for CAPA usable (adds subnet and security group selection filters)
+
 ## [0.18.0] - 2024-03-28
 
 ### Changed

--- a/helm/cluster/templates/apps/cilium.yaml
+++ b/helm/cluster/templates/apps/cilium.yaml
@@ -39,7 +39,7 @@ spec:
       chart: cilium
       # used by renovate
       # repo: giantswarm/cilium-app
-      version: 0.22.0
+      version: 0.23.0
       sourceRef:
         kind: HelmRepository
         name: {{ include "cluster.resource.name" $ }}-default


### PR DESCRIPTION
### What does this PR do?

Towards https://github.com/giantswarm/roadmap/issues/2563

This includes https://github.com/giantswarm/cilium-app/pull/179.

### What is the effect of this change to users?

Cilium ENI mode is behind a feature toggle and nobody is using it with CAPA yet, so no visible changes.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)