### PR TITLE
Revert "Update dependency giantswarm/vertical-pod-autoscaler-crd to v3.1.0 (#147)"

### DIFF
--- a/helm/cluster/templates/apps/vertical-pod-autoscaler-crd.yaml
+++ b/helm/cluster/templates/apps/vertical-pod-autoscaler-crd.yaml
@@ -20,7 +20,7 @@ spec:
       chart: vertical-pod-autoscaler-crd
       # used by renovate
       # repo: giantswarm/vertical-pod-autoscaler-crd
-      version: 3.1.0
+      version: 3.0.0
       sourceRef:
         kind: HelmRepository
         name: {{ include "cluster.resource.name" $ }}-default


### PR DESCRIPTION
This reverts commit a294eaedf238a94f1f820146567738801347c5d8 (done by renovate).

We have found issues with the corresponding version of VPA (v1.1.0) and want to bump the CRDs again later.

### What does this PR do?

See problem with newer VPA in https://github.com/giantswarm/roadmap/issues/3421 ([chat](https://gigantic.slack.com/archives/C04TGHDEF/p1713876311738559)).

This unblocks me for releasing `cluster`.

### What is the effect of this change to users?

None – this wasn't released yet.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists) => renovate didn't add something
