### PR TITLE
containerd: Append content hash to configuration secret name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `disable` to disable rendering and deployment of the app.
 - `chartName` is now optional when specifying app details in `helm/cluster/files/apps/<app name>.yaml` or `helm/cluster/files/helmreleases/<app name>.yaml`, and if it is not specified, `appName` property value will be used.
 - `catalog` is now optional when specifying app details in `helm/cluster/files/apps/<app name>.yaml` or `helm/cluster/files/helmreleases/<app name>.yaml`, and if it is not specified, `"default"` value will be used.
+- containerd: Append content hash to configuration secret name. ([#158](https://github.com/giantswarm/cluster/pull/158))\
+  This ensures nodes roll whenever containerd configuration is changed.\
+  **NOTE:** This also causes nodes to roll when upgrading to this version.
 
 ### ⚠️ Breaking changes for cluster-$provider apps
 

--- a/helm/cluster/templates/clusterapi/_helpers_files.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_files.tpl
@@ -64,8 +64,8 @@
   permissions: "0644"
   contentFrom:
     secret:
-      name: {{ include "cluster.resource.name" $ }}-registry-configuration {{/* TODO: rename *-registry-configuration to -containerd-configuration */}}
-      key: registry-config.toml {{/* TODO: rename *-registry-config.toml to -containerd-config.toml */}}
+      name: {{ include "cluster.resource.name" $ }}-containerd-{{ include "cluster.data.hash" (dict "data" (tpl ($.Files.Get "files/etc/containerd/config.toml") $) "salt" $.Values.providerIntegration.hashSalt) }}
+      key: config.toml
 {{- end }}
 
 {{- define "cluster.internal.kubeadm.files.kubelet" }}

--- a/helm/cluster/templates/containerd.yaml
+++ b/helm/cluster/templates/containerd.yaml
@@ -1,0 +1,8 @@
+{{- if or $.Values.providerIntegration.resourcesApi.controlPlaneResourceEnabled $.Values.providerIntegration.resourcesApi.machinePoolResourcesEnabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "cluster.resource.name" $ }}-containerd-{{ include "cluster.data.hash" (dict "data" (tpl ($.Files.Get "files/etc/containerd/config.toml") $) "salt" $.Values.providerIntegration.hashSalt) }}
+data:
+  config.toml: {{ tpl ($.Files.Get "files/etc/containerd/config.toml") $ | b64enc | quote }}
+{{- end }}

--- a/helm/cluster/templates/containerd_config.yaml
+++ b/helm/cluster/templates/containerd_config.yaml
@@ -1,8 +1,0 @@
-{{- if or $.Values.providerIntegration.resourcesApi.controlPlaneResourceEnabled $.Values.providerIntegration.resourcesApi.machinePoolResourcesEnabled }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "cluster.resource.name" $ }}-registry-configuration
-data:
-  registry-config.toml: {{ tpl ($.Files.Get "files/etc/containerd/config.toml") $ | b64enc | quote }}
-{{- end }}


### PR DESCRIPTION
### What does this PR do?

It adds hashes to the names of secrets referenced by `contentFrom` so Cluster API notices them changed rolls nodes.

### What is the effect of this change to users?

Nodes getting rolled, so no patch.

### Any background context you can provide?

https://github.com/giantswarm/roadmap/issues/3414

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
