### PR TITLE
Add OS image to cluster chart schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Upgrade cilium-app to v0.23.0 in order to make Cilium ENI mode for CAPA usable (adds subnet and security group selection filters)
+- Add OS image to cluster chart schema, so it can be used by cluster-\<provider\> apps.
 
 ## [0.18.0] - 2024-03-28
 

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -498,6 +498,11 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.kubeadmConfig.preKubeadmCommands` | **Pre-kubeadm commands** - Extra commands to run before kubeadm runs.|**Type:** `array`<br/>|
 | `providerIntegration.kubeadmConfig.preKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
 | `providerIntegration.kubernetesVersion` | **Kubernetes version**|**Type:** `string`<br/>**Default:** `"1.25.16"`|
+| `providerIntegration.osImage` | **OS image** - OS image properties|**Type:** `object`<br/>|
+| `providerIntegration.osImage.channel` | **Channel**|**Type:** `string`<br/>**Default:** `"stable"`|
+| `providerIntegration.osImage.name` | **Name**|**Type:** `string`<br/>|
+| `providerIntegration.osImage.variant` | **Variant**|**Type:** `string`<br/>|
+| `providerIntegration.osImage.version` | **Version**|**Type:** `string`<br/>|
 | `providerIntegration.pauseProperties` | **Pause properties** - A map of property names and their values that will affect setting pause annotation|**Type:** `object`<br/>|
 | `providerIntegration.pauseProperties.*` |**None**|**Types:** `string, number, integer, boolean`<br/>|
 | `providerIntegration.provider` | **Provider** - The name of the Cluster API provider. The name here must match the name of the provider in cluster-<provider> app name.|**Type:** `string`<br/>|

--- a/helm/cluster/templates/clusterapi/controlplane/kubeadmcontrolplane.yaml
+++ b/helm/cluster/templates/clusterapi/controlplane/kubeadmcontrolplane.yaml
@@ -19,8 +19,8 @@ spec:
     infrastructureRef:
       apiVersion: {{ $.Values.providerIntegration.controlPlane.resources.infrastructureMachineTemplate.group }}/{{ $.Values.providerIntegration.controlPlane.resources.infrastructureMachineTemplate.version }}
       kind: {{ $.Values.providerIntegration.controlPlane.resources.infrastructureMachineTemplate.kind }}
-      {{- $_ := set $ "osImage" $.Values.providerIntegration.osImage -}}
-      {{- $_ = set $ "kubernetesVersion" $.Values.providerIntegration.kubernetesVersion -}}
+      {{- $_ := set $ "osImage" $.Values.providerIntegration.osImage }}
+      {{- $_ = set $ "kubernetesVersion" $.Values.providerIntegration.kubernetesVersion }}
       name: {{ include "cluster.resource.name" $ }}-control-plane-{{ include "cluster.data.hash" (dict "data" (include $.Values.providerIntegration.controlPlane.resources.infrastructureMachineTemplateSpecTemplateName $) "salt" $.Values.providerIntegration.hashSalt) }}
   kubeadmConfigSpec:
     format: ignition

--- a/helm/cluster/templates/clusterapi/controlplane/kubeadmcontrolplane.yaml
+++ b/helm/cluster/templates/clusterapi/controlplane/kubeadmcontrolplane.yaml
@@ -19,6 +19,8 @@ spec:
     infrastructureRef:
       apiVersion: {{ $.Values.providerIntegration.controlPlane.resources.infrastructureMachineTemplate.group }}/{{ $.Values.providerIntegration.controlPlane.resources.infrastructureMachineTemplate.version }}
       kind: {{ $.Values.providerIntegration.controlPlane.resources.infrastructureMachineTemplate.kind }}
+      {{- $_ := set $ "osImage" $.Values.providerIntegration.osImage -}}
+      {{- $_ = set $ "kubernetesVersion" $.Values.providerIntegration.kubernetesVersion -}}
       name: {{ include "cluster.resource.name" $ }}-control-plane-{{ include "cluster.data.hash" (dict "data" (include $.Values.providerIntegration.controlPlane.resources.infrastructureMachineTemplateSpecTemplateName $) "salt" $.Values.providerIntegration.hashSalt) }}
   kubeadmConfigSpec:
     format: ignition

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1967,6 +1967,36 @@
                     "title": "Kubernetes version",
                     "default": "1.25.16"
                 },
+                "osImage": {
+                    "type": "object",
+                    "title": "OS image",
+                    "description": "OS image properties",
+                    "properties": {
+                        "channel": {
+                            "type": "string",
+                            "title": "Channel",
+                            "enum": [
+                                "stable",
+                                "beta",
+                                "alpha",
+                                "lts"
+                            ],
+                            "default": "stable"
+                        },
+                        "name": {
+                            "type": "string",
+                            "title": "Name"
+                        },
+                        "variant": {
+                            "type": "string",
+                            "title": "Variant"
+                        },
+                        "version": {
+                            "type": "string",
+                            "title": "Version"
+                        }
+                    }
+                },
                 "pauseProperties": {
                     "type": "object",
                     "title": "Pause properties",

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -112,6 +112,8 @@ providerIntegration:
           storage: {}
           systemd: {}
   kubernetesVersion: 1.25.16
+  osImage:
+    channel: stable
   registry: {}
   resourcesApi:
     bastionResourceEnabled: true


### PR DESCRIPTION
### What does this PR do?

Add OS image to cluster chart schema, so it can be used by cluster-\<provider\> apps.

### How does it look like?

See diff.

### Any background context you can provide?

We don't want to have OS image publicly configurable, but we do want to configure it during development and testing.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
