### PR TITLE
Upgrade cilium-app to v0.24.0 for cilium v1.15.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade cilium-app to v0.24.0 for Cilium [v1.15.4](https://github.com/cilium/cilium/releases/tag/v1.15.4)
+
 ## [0.19.0] - 2024-04-25
 
 - Upgrade cilium-app to v0.23.0 in order to make Cilium ENI mode for CAPA usable (adds subnet and security group selection filters)

--- a/helm/cluster/templates/apps/cilium.yaml
+++ b/helm/cluster/templates/apps/cilium.yaml
@@ -39,7 +39,7 @@ spec:
       chart: cilium
       # used by renovate
       # repo: giantswarm/cilium-app
-      version: 0.23.0
+      version: 0.24.0
       sourceRef:
         kind: HelmRepository
         name: {{ include "cluster.resource.name" $ }}-default


### PR DESCRIPTION
### What does this PR do?

Upgrade the cilium-app to v0.24.0 which contains changes for cilium v1.15.4

https://github.com/giantswarm/giantswarm/issues/30699

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
