### PR TITLE
Allow to set SELinux mode through `global.components.selinux.mode`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Allow to set cloud-config path.
+- Allow to set SELinux mode through `global.components.selinux.mode`.
 
 ### Changed
 

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -76,6 +76,8 @@ Advanced configuration of components that are running on all nodes.
 | `global.components.containerd.containerRegistries.*[*].credentials.password` | **Password** - Used to authenticate for the registry with username/password.|**Type:** `string`<br/>|
 | `global.components.containerd.containerRegistries.*[*].credentials.username` | **Username** - Used to authenticate for the registry with username/password.|**Type:** `string`<br/>|
 | `global.components.containerd.containerRegistries.*[*].endpoint` | **Endpoint** - Endpoint for the container registry.|**Type:** `string`<br/>|
+| `global.components.selinux` | **SELinux** - Configuration of SELinux.|**Type:** `object`<br/>|
+| `global.components.selinux.mode` | **SELinux mode** - Configure SELinux mode: 'enforcing', 'permissive' or 'disabled'.|**Type:** `string`<br/>**Default:** `"permissive"`|
 
 ### Connectivity
 Properties within the `.global.connectivity` object

--- a/helm/cluster/files/etc/selinux/config
+++ b/helm/cluster/files/etc/selinux/config
@@ -1,0 +1,15 @@
+# This file controls the state of SELinux on the system on boot.
+
+# SELINUX can take one of these three values:
+#       enforcing - SELinux security policy is enforced.
+#       permissive - SELinux prints warnings instead of enforcing.
+#       disabled - No SELinux policy is loaded.
+SELINUX={{ $.Values.global.components.selinux.mode }}
+
+# SELINUXTYPE can take one of these four values:
+#       targeted - Only targeted network daemons are protected.
+#       strict   - Full SELinux protection.
+#       mls      - Full SELinux protection with Multi-Level Security
+#       mcs      - Full SELinux protection with Multi-Category Security
+#                  (mls, but only one sensitivity level)
+SELINUXTYPE=mcs

--- a/helm/cluster/templates/clusterapi/_helpers_files.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_files.tpl
@@ -1,5 +1,6 @@
 {{- define "cluster.internal.kubeadm.files" }}
 {{- include "cluster.internal.kubeadm.files.sysctl" $ }}
+{{- include "cluster.internal.kubeadm.files.selinux" $ }}
 {{- include "cluster.internal.kubeadm.files.systemd" $ }}
 {{- include "cluster.internal.kubeadm.files.cgroupv1" $ }}
 {{- include "cluster.internal.kubeadm.files.ssh" $ }}
@@ -17,6 +18,13 @@
   permissions: "0644"
   encoding: base64
   content: {{ $.Files.Get "files/etc/sysctl.d/hardening.conf" | b64enc }}
+{{- end }}
+
+{{- define "cluster.internal.kubeadm.files.selinux" }}
+- path: /etc/selinux/config
+  permissions: "0644"
+  encoding: base64
+  content: {{ tpl ($.Files.Get "files/etc/selinux/config") . | b64enc }}
 {{- end }}
 
 {{- define "cluster.internal.kubeadm.files.systemd" }}

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -862,6 +862,28 @@
                                     }
                                 }
                             }
+                        },
+                        "selinux": {
+                            "type": "object",
+                            "title": "SELinux",
+                            "description": "Configuration of SELinux.",
+                            "required": [
+                                "mode"
+                            ],
+                            "additionalProperties": false,
+                            "properties": {
+                                "mode": {
+                                    "type": "string",
+                                    "title": "SELinux mode",
+                                    "description": "Configure SELinux mode: 'enforcing', 'permissive' or 'disabled'.",
+                                    "enum": [
+                                        "enforcing",
+                                        "permissive",
+                                        "disabled"
+                                    ],
+                                    "default": "permissive"
+                                }
+                            }
                         }
                     }
                 },

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -12,6 +12,8 @@ global:
         docker.io:
           - endpoint: registry-1.docker.io
           - endpoint: giantswarm.azurecr.io
+    selinux:
+      mode: permissive
   connectivity:
     bastion:
       enabled: true


### PR DESCRIPTION
### What does this PR do?

Towards: https://github.com/giantswarm/giantswarm/issues/30605

Allows to set SELinux mode (enforcing, permissive or disabled) through `global.components.selinux.mode`.
Default value is `permissive` (current flatcar default).


- [x] CHANGELOG.md has been updated
