### PR TITLE
Render filesystems field in ignition config for machine pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Render `KubeadmConfig.spec.containerLinuxConfig.additionalConfig.storage.filesystems` for machine pool workers to be able to configure additional disks.
+
 ## [0.22.0] - 2024-05-07
 
 ### Added

--- a/helm/cluster/templates/clusterapi/workers/_helpers_flatcar.tpl
+++ b/helm/cluster/templates/clusterapi/workers/_helpers_flatcar.tpl
@@ -7,6 +7,8 @@ containerLinuxConfig:
       {{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units.default" $ | indent 6 }}
       {{- include "cluster.internal.workers.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $ | indent 6 }}
     storage:
+      filesystems:
+      {{- include "cluster.internal.workers.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.filesystems" $ | indent 6 }}
       directories:
       {{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.directorties.default" $ | indent 6 }}
       {{- include "cluster.internal.workers.kubeadm.ignition.containerLinuxConfig.additionalConfig.storage.directories" $ | indent 6 }}


### PR DESCRIPTION
### What does this PR do?

- Render `KubeadmConfig.spec.containerLinuxConfig.additionalConfig.storage.filesystems` for machine pool workers to be able to configure additional disks.



Not sure if it was accidentally  not rendered or if this was intention but it is necessary to  configure additional disks for machine pools on AWS - just having similar behavior as for control-plane nodes