### PR TITLE
Restart containerd before kubeadm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Restart containerd before kubeadm command.
 
-
-
 ## [0.24.0] - 2024-05-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Restart containerd before kubeadm command.
+
+
+
 ## [0.24.0] - 2024-05-10
 
 ### Added

--- a/helm/cluster/templates/clusterapi/_helpers_prekubeadmcommands.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_prekubeadmcommands.tpl
@@ -18,6 +18,7 @@
 {{- define "cluster.internal.kubeadm.preKubeadmCommands.flatcar" }}
 - envsubst < /etc/kubeadm.yml > /etc/kubeadm.yml.tmp
 - mv /etc/kubeadm.yml.tmp /etc/kubeadm.yml
+- systemctl restart containerd
 {{- end }}
 
 {{- define "cluster.internal.kubeadm.preKubeadmCommands.ssh" }}


### PR DESCRIPTION
### What does this PR do?

Towards https://github.com/giantswarm/giantswarm/issues/30770

I observed a problem in kubeadm services because of race condition between containerd and kubeadm services. This fixes the issue.

- [x] Manually tested for CAPZ.
- [x] Testing [here](https://github.com/giantswarm/cluster-aws/pull/621) for CAPA.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
