### PR TITLE
Revert containerd config changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ⚠️Breaking changes
+
+- Revert https://github.com/giantswarm/cluster/pull/152 because it introduced invalid containerd config which caused containerd to silently partially fail and not apply registry mirrors config.
+
 ## [0.24.0] - 2024-05-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade cilium-app to v0.23.0 in order to make Cilium ENI mode for CAPA usable (adds subnet and security group selection filters)
 - Add OS image to cluster chart schema, so it can be used by cluster-\<provider\> apps.
-- Add an ability to use http registry mirrors
 
 ## [0.18.0] - 2024-03-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### ⚠️Breaking changes
+### ⚠️ Breaking changes
 
 - Revert https://github.com/giantswarm/cluster/pull/152 because it introduced invalid containerd config which caused containerd to silently partially fail and not apply registry mirrors config.
 

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -174,7 +174,7 @@ Advanced configuration of components that are running on all nodes.
 | :----------- | :-------------- | :--------------- |
 | `global.components.containerd` | **Containerd** - Configuration of containerd.|**Type:** `object`<br/>|
 | `global.components.containerd.containerRegistries` | **Container registries** - Endpoints and credentials configuration for container registries.|**Type:** `object`<br/>**Default:** `{"docker.io":[{"endpoint":"registry-1.docker.io"},{"endpoint":"giantswarm.azurecr.io"}]}`|
-| `global.components.containerd.containerRegistries.*` | **Registries** - Container registries and mirroredRegistries|**Type:** `array`<br/>|
+| `global.components.containerd.containerRegistries.*` | **Registries** - Container registries and mirrors|**Type:** `array`<br/>|
 | `global.components.containerd.containerRegistries.*[*]` | **Registry**|**Type:** `object`<br/>|
 | `global.components.containerd.containerRegistries.*[*].credentials` | **Credentials**|**Type:** `object`<br/>|
 | `global.components.containerd.containerRegistries.*[*].credentials.auth` | **Auth** - Base64-encoded string from the concatenation of the username, a colon, and the password.|**Type:** `string`<br/>|
@@ -330,11 +330,6 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.ephemeralConfiguration.apps.PATTERN.catalogOverride` | **Catalog override** - Name of the catalog from which the app is installed.|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`[a-z][a-zA-Z]+`<br/>|
 | `internal.ephemeralConfiguration.apps.PATTERN.disable` | **Disable** - Flag that indicates if the app is disabled and skipped during the cluster deployment.|**Type:** `boolean`<br/>**Key pattern:**<br/>`PATTERN`=`[a-z][a-zA-Z]+`<br/>|
 | `internal.ephemeralConfiguration.apps.PATTERN.versionOverride` | **Version override** - Custom application version that overrides the application version from the release. This is usually a new development version that you want to test, or a newer patch version that you need to deploy in order to put out a production fire in the middle of the night. Use carefully!|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`[a-z][a-zA-Z]+`<br/>|
-| `internal.localRegistryCache` | **Enable local (per WC) cache**|**Type:** `object`<br/>|
-| `internal.localRegistryCache.enabled` |**None**|**Type:** `boolean`<br/>**Default:** `false`|
-| `internal.localRegistryCache.mirroredRegistries` |A list of registries that should be cached|**Type:** `array`<br/>**Default:** `[]`|
-| `internal.localRegistryCache.mirroredRegistries[*]` |**None**|**Type:** `string`<br/>|
-| `internal.localRegistryCache.port` |**None**|**Type:** `integer`<br/>**Default:** `32767`|
 
 ### Metadata
 Properties within the `.global.metadata` object

--- a/helm/cluster/files/etc/containerd/config.toml
+++ b/helm/cluster/files/etc/containerd/config.toml
@@ -24,13 +24,10 @@ SystemdCgroup = {{ if $.Values.internal.advancedConfiguration.cgroupsv1 }}false{
 sandbox_image = "{{ include "cluster.image.registry" $ }}/{{ $.Values.providerIntegration.components.containerd.sandboxContainerImage.name }}:{{ $.Values.providerIntegration.components.containerd.sandboxContainerImage.tag }}"
 
 [plugins."io.containerd.grpc.v1.cri".registry]
-  [plugins."io.containerd.grpc.v1.cri".registry.mirroredRegistries]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
   {{- range $host, $config := $.Values.global.components.containerd.containerRegistries }}
-    [plugins."io.containerd.grpc.v1.cri".registry.mirroredRegistries."{{$host}}"]
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{$host}}"]
       endpoint = [
-        {{- if and $.Values.internal.localRegistryCache.enabled (has $host $.Values.internal.localRegistryCache.mirroredRegistries) -}}
-        "http://127.0.0.1:{{ $.Values.internal.localRegistryCache.port }}",
-        {{- end -}}
         {{- range $value := $config -}}
         "https://{{$value.endpoint}}",
         {{- end -}}

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1086,7 +1086,7 @@
                                     "additionalProperties": {
                                         "type": "array",
                                         "title": "Registries",
-                                        "description": "Container registries and mirroredRegistries",
+                                        "description": "Container registries and mirrors",
                                         "items": {
                                             "type": "object",
                                             "title": "Registry",
@@ -1844,33 +1844,6 @@
                                     "$ref": "#/$defs/appEphemeral"
                                 }
                             }
-                        }
-                    }
-                },
-                "localRegistryCache": {
-                    "type": "object",
-                    "title": "Enable local (per WC) cache",
-                    "required": [
-                        "enabled",
-                        "port"
-                    ],
-                    "additionalProperties": false,
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "default": false
-                        },
-                        "mirroredRegistries": {
-                            "type": "array",
-                            "description": "A list of registries that should be cached",
-                            "items": {
-                                "type": "string"
-                            },
-                            "default": []
-                        },
-                        "port": {
-                            "type": "integer",
-                            "default": 32767
                         }
                     }
                 }

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -87,10 +87,6 @@ internal:
     registry: gsoci.azurecr.io
     workers: {}
   ephemeralConfiguration: {}
-  localRegistryCache:
-    enabled: false
-    mirroredRegistries: []
-    port: 32767
 providerIntegration:
   apps:
     capiNodeLabeler:


### PR DESCRIPTION
### What does this PR do?

Revert https://github.com/giantswarm/cluster/pull/152 because it introduced invalid containerd config which caused containerd to silently partially fail and not apply registry mirrors config.

### What is the effect of this change to users?

containerd config is loaded correctly when creating the clusters.

### Any background context you can provide?

See above description.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
