### PR TITLE
Updates cluster-autoscaler-app to 1.27.3-gs9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update cluster-autoscaler-app to 1.27.3-gs9.
+
 ## [0.26.0] - 2024-05-16
 
 ### Added

--- a/helm/cluster/files/apps/cluster-autoscaler.yaml
+++ b/helm/cluster/files/apps/cluster-autoscaler.yaml
@@ -9,4 +9,4 @@ dependsOn: kyverno
 namespace: kube-system
 # used by renovate
 # repo: giantswarm/cluster-autoscaler-app
-version: 1.27.3-gs8
+version: 1.27.3-gs9


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30671

Updates cluster-autoscaler-app to 1.27.3-gs9 to use new CPU requests.
