### PR TITLE
API Server: Make feature gates configurable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - API Server: Make feature gates configurable. ([#201](https://github.com/giantswarm/cluster/pull/201))\
   - Values: Make `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates` reusable.
   - Values: Add `internal.advancedConfiguration.controlPlane.apiServer.featureGates`.
+  - API Server: Implement `internal.advancedConfiguration.controlPlane.apiServer.featureGates`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add MachineHealthCheck resource template to NodePools.
 - API Server: Make feature gates configurable. ([#201](https://github.com/giantswarm/cluster/pull/201))\
   - Values: Make `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates` reusable.
+  - Values: Add `internal.advancedConfiguration.controlPlane.apiServer.featureGates`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add MachineDeployment resource template.
 - Add MachineHealthCheck resource template to NodePools.
+- API Server: Make feature gates configurable. ([#201](https://github.com/giantswarm/cluster/pull/201))\
+  - Values: Make `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates` reusable.
 
 ### Changed
 

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -535,10 +535,10 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.additionalAdmissionPlugins[*]` | **Additional admission plugin**|**Type:** `string`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.apiAudiences` | **API audiences** - Identifiers of the API. The service account token authenticator will validate that tokens used against the API are bound to at least one of these audiences. If the --service-account-issuer flag is configured and this flag is not, 'api-audiences' field defaults to a single element list containing the issuer URL.||
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.cloudConfig` | **cloud config** - The path of the cloud config file.|**Type:** `string`<br/>|
-| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates` | **Feature gates**|**Type:** `array`<br/>|
-| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates[*]` | **Feature gate**|**Type:** `object`<br/>|
-| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates[*].enabled` | **Enabled**|**Type:** `boolean`<br/>|
-| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates[*].name` | **Name**|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates` | **Feature gates** - A list of feature gates to enable or disable.|**Type:** `array`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates[*]` | **Feature gate** - A feature gate to enable or disable.|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates[*].enabled` | **Enabled** - Wheter to enable or disable the feature gate.|**Type:** `boolean`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates[*].name` | **Name** - Name of the feature gate.|**Type:** `string`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.serviceAccountIssuer` | **Service account issuer** - Configuration of the identifier of the service account token issuer. You must specify either URL or clusterDomainPrefix (only one, not both).||
 | `providerIntegration.controlPlane.kubeadmConfig.diskSetup` | **Disk setup** - Provider-specific disk setup that is deployed to control plane nodes. They are specified in the cluster-<provider> apps.|**Type:** `object`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.diskSetup.filesystems` | **File systems** - Filesystems specifies the list of file systems to setup.|**Type:** `array`<br/>|

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -263,7 +263,7 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.advancedConfiguration.controlPlane.apiServer.extraCertificateSANs[*]` | **Extra certificate SAN**|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.featureGates` | **Feature gates** - A list of feature gates to enable or disable.|**Type:** `array`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.featureGates[*]` | **Feature gate** - A feature gate to enable or disable.|**Type:** `object`<br/>|
-| `internal.advancedConfiguration.controlPlane.apiServer.featureGates[*].enabled` | **Enabled** - Wheter to enable or disable the feature gate.|**Type:** `boolean`<br/>|
+| `internal.advancedConfiguration.controlPlane.apiServer.featureGates[*].enabled` | **Enabled** - Whether to enable or disable the feature gate.|**Type:** `boolean`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.featureGates[*].name` | **Name** - Name of the feature gate.|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.controlPlane.controllerManager` | **Controller manager** - Advanced configuration of controller manager|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.controlPlane.controllerManager.terminatedPodGCThreshold` | **Terminated pod GC threshold** - Number of terminated pods that can exist before the terminated pod garbage collector starts deleting terminated pods. If <= 0, the terminated pod garbage collector is disabled.|**Type:** `integer`<br/>**Default:** `125`|
@@ -541,7 +541,7 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.cloudConfig` | **cloud config** - The path of the cloud config file.|**Type:** `string`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates` | **Feature gates** - A list of feature gates to enable or disable.|**Type:** `array`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates[*]` | **Feature gate** - A feature gate to enable or disable.|**Type:** `object`<br/>|
-| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates[*].enabled` | **Enabled** - Wheter to enable or disable the feature gate.|**Type:** `boolean`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates[*].enabled` | **Enabled** - Whether to enable or disable the feature gate.|**Type:** `boolean`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates[*].name` | **Name** - Name of the feature gate.|**Type:** `string`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.serviceAccountIssuer` | **Service account issuer** - Configuration of the identifier of the service account token issuer. You must specify either URL or clusterDomainPrefix (only one, not both).||
 | `providerIntegration.controlPlane.kubeadmConfig.diskSetup` | **Disk setup** - Provider-specific disk setup that is deployed to control plane nodes. They are specified in the cluster-<provider> apps.|**Type:** `object`<br/>|

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -261,6 +261,10 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.advancedConfiguration.controlPlane.apiServer.extraArgs` | **Extra CLI args** - A map with the additional CLI flags that are appended to the default flags. Use with caution, as there is no validation for these values, so you can set incorrect or duplicate flags.|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.extraCertificateSANs` | **Extra certificate SANs** - The additional certificate SANs that are appended to the default SANs. Use with caution, as there is no validation for these values, so you can set incorrect or duplicate certificates.|**Type:** `array`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.extraCertificateSANs[*]` | **Extra certificate SAN**|**Type:** `string`<br/>|
+| `internal.advancedConfiguration.controlPlane.apiServer.featureGates` | **Feature gates** - A list of feature gates to enable or disable.|**Type:** `array`<br/>|
+| `internal.advancedConfiguration.controlPlane.apiServer.featureGates[*]` | **Feature gate** - A feature gate to enable or disable.|**Type:** `object`<br/>|
+| `internal.advancedConfiguration.controlPlane.apiServer.featureGates[*].enabled` | **Enabled** - Wheter to enable or disable the feature gate.|**Type:** `boolean`<br/>|
+| `internal.advancedConfiguration.controlPlane.apiServer.featureGates[*].name` | **Name** - Name of the feature gate.|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.controlPlane.controllerManager` | **Controller manager** - Advanced configuration of controller manager|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.controlPlane.controllerManager.terminatedPodGCThreshold` | **Terminated pod GC threshold** - Number of terminated pods that can exist before the terminated pod garbage collector starts deleting terminated pods. If <= 0, the terminated pod garbage collector is disabled.|**Type:** `integer`<br/>**Default:** `125`|
 | `internal.advancedConfiguration.controlPlane.etcd` | **etcd** - Configuration of etcd|**Type:** `object`<br/>|

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -193,6 +193,9 @@ internal:
         extraCertificateSANs:
         - this-is-extra-cert-san.giantswarm.io
         - another-extra-cert-san.giantswarm.io
+        featureGates:
+        - name: StatefulSetAutoDeletePVC
+          enabled: true
       etcd:
         quotaBackendBytesGiB: 16
         initialCluster: "default=http://localhost:2380"

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_apiserver.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_apiserver.tpl
@@ -157,9 +157,15 @@ api-audiences-example.giantswarm.io
 {{- end }}
 
 {{- define "cluster.internal.controlPlane.kubeadm.clusterConfiguration.apiServer.featureGates" }}
-{{- $featureGates := list -}}
-{{- range $featureGate := $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates }}
-{{- $featureGates = append $featureGates (printf "%s=%t" $featureGate.name $featureGate.enabled) -}}
+{{- $providerFeatureGates := $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates | default list }}
+{{- $internalFeatureGates := $.Values.internal.advancedConfiguration.controlPlane.apiServer.featureGates | default list }}
+{{- $mergedFeatureGates := dict }}
+{{- range (concat $providerFeatureGates $internalFeatureGates) }}
+{{- $_ := set $mergedFeatureGates (trim .name) .enabled }}
 {{- end }}
-{{- join "," (compact $featureGates) | quote }}
+{{- $featureGates := list }}
+{{- range $name, $enabled := $mergedFeatureGates }}
+{{- $featureGates = append $featureGates (printf "%s=%t" $name $enabled) }}
+{{- end }}
+{{- $featureGates | join "," }}
 {{- end }}

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -111,6 +111,33 @@
                 }
             }
         },
+        "featureGates": {
+            "type": "array",
+            "title": "Feature gates",
+            "description": "A list of feature gates to enable or disable.",
+            "items": {
+                "type": "object",
+                "title": "Feature gate",
+                "description": "A feature gate to enable or disable.",
+                "required": [
+                    "name",
+                    "enabled"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                    "enabled": {
+                        "type": "boolean",
+                        "title": "Enabled",
+                        "description": "Wheter to enable or disable the feature gate."
+                    },
+                    "name": {
+                        "type": "string",
+                        "title": "Name",
+                        "description": "Name of the feature gate."
+                    }
+                }
+            }
+        },
         "fileFromSecret": {
             "type": "object",
             "title": "File from secret",
@@ -2165,27 +2192,7 @@
                                                     "description": "The path of the cloud config file."
                                                 },
                                                 "featureGates": {
-                                                    "type": "array",
-                                                    "title": "Feature gates",
-                                                    "items": {
-                                                        "type": "object",
-                                                        "title": "Feature gate",
-                                                        "required": [
-                                                            "name",
-                                                            "enabled"
-                                                        ],
-                                                        "additionalProperties": false,
-                                                        "properties": {
-                                                            "enabled": {
-                                                                "type": "boolean",
-                                                                "title": "Enabled"
-                                                            },
-                                                            "name": {
-                                                                "type": "string",
-                                                                "title": "Name"
-                                                            }
-                                                        }
-                                                    }
+                                                    "$ref": "#/$defs/featureGates"
                                                 },
                                                 "serviceAccountIssuer": {
                                                     "title": "Service account issuer",

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -128,7 +128,7 @@
                     "enabled": {
                         "type": "boolean",
                         "title": "Enabled",
-                        "description": "Wheter to enable or disable the feature gate."
+                        "description": "Whether to enable or disable the feature gate."
                     },
                     "name": {
                         "type": "string",

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1658,6 +1658,9 @@
                                                 "type": "string",
                                                 "title": "Extra certificate SAN"
                                             }
+                                        },
+                                        "featureGates": {
+                                            "$ref": "#/$defs/featureGates"
                                         }
                                     }
                                 },


### PR DESCRIPTION
### What does this PR do?

This PR makes the list of feature gates passed to the API server configurable not only via provider integration but also via values passed to the cluster chart by users.

### What is the effect of this change to users?

Users now can configure features gates on their own and do not need to depend on the provider specific cluster chart's defaults.

### Any background context you can provide?

Closes https://github.com/giantswarm/roadmap/issues/3333.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
