### PR TITLE
API Server: Fix feature flag condition.

### DIFF
--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_apiserver.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_apiserver.tpl
@@ -37,7 +37,7 @@ extraArgs:
   {{- if $.Values.internal.advancedConfiguration.controlPlane.apiServer.etcdPrefix }}
   etcd-prefix: {{ $.Values.internal.advancedConfiguration.controlPlane.apiServer.etcdPrefix }}
   {{- end }}
-  {{- if .Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates }}
+  {{- if include "cluster.internal.controlPlane.kubeadm.clusterConfiguration.apiServer.featureGates" $ }}
   feature-gates: {{ include "cluster.internal.controlPlane.kubeadm.clusterConfiguration.apiServer.featureGates" $ }}
   {{- end }}
   kubelet-preferred-address-types: InternalIP
@@ -112,9 +112,9 @@ extraVolumes:
   "ResourceQuota"
   "ServiceAccount"
   "ValidatingAdmissionWebhook" -}}
-{{- $internalPlugins := $.Values.internal.advancedConfiguration.controlPlane.apiServer.additionalAdmissionPlugins | default list }}
 {{- $providerPlugins := $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.additionalAdmissionPlugins | default list }}
-{{- concat $defaultPlugins $internalPlugins $providerPlugins | uniq | compact | join "," }}
+{{- $internalPlugins := $.Values.internal.advancedConfiguration.controlPlane.apiServer.additionalAdmissionPlugins | default list }}
+{{- concat $defaultPlugins $providerPlugins $internalPlugins | compact | uniq | join "," }}
 {{- end }}
 
 {{- define "cluster.internal.controlPlane.kubeadm.clusterConfiguration.apiServer.serviceAccountIssuer" }}


### PR DESCRIPTION
Also improve order of additional admission plugins.

### What does this PR do?

This PR makes the feature flag condition also check for `cluster` chart defined feature flags. Additionally it correctly orders the way additional admission plugins are being concatenated, even though this doesn't change the output because they are not overriding each other - at least not yet.

### What is the effect of this change to users?

### How does it look like?

(Please add anything that represents the change visually. Screenshots, output, logs, ...)

### Any background context you can provide?

Follow-up of https://github.com/giantswarm/cluster/pull/201.

### Should this change be mentioned in the release notes?

- [ ] CHANGELOG.md has been updated (if it exists)
