### PR TITLE
Controller Manager: Make feature gates configurable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - API Server: Implement `internal.advancedConfiguration.controlPlane.apiServer.featureGates`.
 - Controller Manager: Make feature gates configurable. ([#203](https://github.com/giantswarm/cluster/pull/203))\
   - Values: Add `internal.advancedConfiguration.controlPlane.controllerManager.featureGates`.
+  - Values: Add `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.controllerManager.featureGates`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Controller Manager: Make feature gates configurable. ([#203](https://github.com/giantswarm/cluster/pull/203))\
   - Values: Add `internal.advancedConfiguration.controlPlane.controllerManager.featureGates`.
   - Values: Add `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.controllerManager.featureGates`.
+  - Controller Manager: Implement `cluster.internal.controlPlane.kubeadm.clusterConfiguration.controllerManager.featureGates`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Values: Make `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates` reusable.
   - Values: Add `internal.advancedConfiguration.controlPlane.apiServer.featureGates`.
   - API Server: Implement `internal.advancedConfiguration.controlPlane.apiServer.featureGates`.
+- Controller Manager: Make feature gates configurable. ([#203](https://github.com/giantswarm/cluster/pull/203))\
+  - Values: Add `internal.advancedConfiguration.controlPlane.controllerManager.featureGates`.
 
 ### Changed
 

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -548,6 +548,11 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates[*].enabled` | **Enabled** - Whether to enable or disable the feature gate.|**Type:** `boolean`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.featureGates[*].name` | **Name** - Name of the feature gate.|**Type:** `string`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.serviceAccountIssuer` | **Service account issuer** - Configuration of the identifier of the service account token issuer. You must specify either URL or clusterDomainPrefix (only one, not both).||
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.controllerManager` | **Controller manager** - Configuration of controller manager|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.controllerManager.featureGates` | **Feature gates** - A list of feature gates to enable or disable.|**Type:** `array`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.controllerManager.featureGates[*]` | **Feature gate** - A feature gate to enable or disable.|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.controllerManager.featureGates[*].enabled` | **Enabled** - Whether to enable or disable the feature gate.|**Type:** `boolean`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.controllerManager.featureGates[*].name` | **Name** - Name of the feature gate.|**Type:** `string`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.diskSetup` | **Disk setup** - Provider-specific disk setup that is deployed to control plane nodes. They are specified in the cluster-<provider> apps.|**Type:** `object`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.diskSetup.filesystems` | **File systems** - Filesystems specifies the list of file systems to setup.|**Type:** `array`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.diskSetup.filesystems[*]` |**None**|**Type:** `object`<br/>|

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -266,6 +266,10 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.advancedConfiguration.controlPlane.apiServer.featureGates[*].enabled` | **Enabled** - Whether to enable or disable the feature gate.|**Type:** `boolean`<br/>|
 | `internal.advancedConfiguration.controlPlane.apiServer.featureGates[*].name` | **Name** - Name of the feature gate.|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.controlPlane.controllerManager` | **Controller manager** - Advanced configuration of controller manager|**Type:** `object`<br/>|
+| `internal.advancedConfiguration.controlPlane.controllerManager.featureGates` | **Feature gates** - A list of feature gates to enable or disable.|**Type:** `array`<br/>|
+| `internal.advancedConfiguration.controlPlane.controllerManager.featureGates[*]` | **Feature gate** - A feature gate to enable or disable.|**Type:** `object`<br/>|
+| `internal.advancedConfiguration.controlPlane.controllerManager.featureGates[*].enabled` | **Enabled** - Whether to enable or disable the feature gate.|**Type:** `boolean`<br/>|
+| `internal.advancedConfiguration.controlPlane.controllerManager.featureGates[*].name` | **Name** - Name of the feature gate.|**Type:** `string`<br/>|
 | `internal.advancedConfiguration.controlPlane.controllerManager.terminatedPodGCThreshold` | **Terminated pod GC threshold** - Number of terminated pods that can exist before the terminated pod garbage collector starts deleting terminated pods. If <= 0, the terminated pod garbage collector is disabled.|**Type:** `integer`<br/>**Default:** `125`|
 | `internal.advancedConfiguration.controlPlane.etcd` | **etcd** - Configuration of etcd|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.controlPlane.etcd.dataDir` | **Data directory** - The directory for etcd data.|**Type:** `string`<br/>|

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -196,6 +196,10 @@ internal:
         featureGates:
         - name: StatefulSetAutoDeletePVC
           enabled: true
+      controllerManager:
+        featureGates:
+        - name: StatefulSetAutoDeletePVC
+          enabled: true
       etcd:
         quotaBackendBytesGiB: 16
         initialCluster: "default=http://localhost:2380"

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_controllermanager.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_controllermanager.tpl
@@ -9,7 +9,9 @@ extraArgs:
 {{- end }}
   external-cloud-volume-plugin: {{ $.Values.providerIntegration.provider }}
   cluster-cidr: {{ $.Values.global.connectivity.network.pods.cidrBlocks | first }}
-  feature-gates: CronJobTimeZone=true
+  {{- if include "cluster.internal.controlPlane.kubeadm.clusterConfiguration.controllerManager.featureGates" $ }}
+  feature-gates: {{ include "cluster.internal.controlPlane.kubeadm.clusterConfiguration.controllerManager.featureGates" $ }}
+  {{- end }}
   terminated-pod-gc-threshold: {{ $.Values.internal.advancedConfiguration.controlPlane.controllerManager.terminatedPodGCThreshold | quote }}
 {{- if $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.cloudConfig  }}
 extraVolumes:
@@ -18,4 +20,19 @@ extraVolumes:
     mountPath:  {{ $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.cloudConfig  }}
     readOnly: true
 {{- end }}
+{{- end }}
+
+{{- define "cluster.internal.controlPlane.kubeadm.clusterConfiguration.controllerManager.featureGates" }}
+{{- $defaultFeatureGates := list (dict "name" "CronJobTimeZone" "enabled" true) }}
+{{- $providerFeatureGates := $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.controllerManager.featureGates | default list }}
+{{- $internalFeatureGates := $.Values.internal.advancedConfiguration.controlPlane.controllerManager.featureGates | default list }}
+{{- $mergedFeatureGates := dict }}
+{{- range (concat $defaultFeatureGates $providerFeatureGates $internalFeatureGates) }}
+{{- $_ := set $mergedFeatureGates (trim .name) .enabled }}
+{{- end }}
+{{- $featureGates := list }}
+{{- range $name, $enabled := $mergedFeatureGates }}
+{{- $featureGates = append $featureGates (printf "%s=%t" $name $enabled) }}
+{{- end }}
+{{- $featureGates | join "," }}
 {{- end }}

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -2267,6 +2267,16 @@
                                                 }
                                             },
                                             "default": {}
+                                        },
+                                        "controllerManager": {
+                                            "type": "object",
+                                            "title": "Controller manager",
+                                            "description": "Configuration of controller manager",
+                                            "properties": {
+                                                "featureGates": {
+                                                    "$ref": "#/$defs/featureGates"
+                                                }
+                                            }
                                         }
                                     }
                                 },

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1669,6 +1669,9 @@
                                     "title": "Controller manager",
                                     "description": "Advanced configuration of controller manager",
                                     "properties": {
+                                        "featureGates": {
+                                            "$ref": "#/$defs/featureGates"
+                                        },
                                         "terminatedPodGCThreshold": {
                                             "type": "integer",
                                             "title": "Terminated pod GC threshold",

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -149,6 +149,7 @@ providerIntegration:
     kubeadmConfig:
       clusterConfiguration:
         apiServer: {}
+        controllerManager: {}
       diskSetup: {}
       ignition:
         containerLinuxConfig:


### PR DESCRIPTION
### What does this PR do?

This PR makes the list of feature gates passed to the controller manager configurable via values passed to the cluster chart by users.

### What is the effect of this change to users?

Users now can configure features gates on their own.

### Any background context you can provide?

Closes https://github.com/giantswarm/roadmap/issues/3333.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
