### PR TITLE
Add network-online.target as dependency for kubeadm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix wrong indentation for owner field of KubeadmConfig files.
-
+- Fix `unable to select an IP from default routes` error by adding `network-online.target` as dependency for kubeadm service.
 ## [0.27.0] - 2024-05-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix wrong indentation for owner field of KubeadmConfig files.
 - Fix `unable to select an IP from default routes` error by adding `network-online.target` as dependency for kubeadm service.
+
 ## [0.27.0] - 2024-05-28
 
 ### Added

--- a/helm/cluster/templates/clusterapi/_helpers_flatcar.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_flatcar.tpl
@@ -163,6 +163,9 @@
       After=coreos-metadata.service
       # kubeadm must run after containerd - see https://github.com/kubernetes-sigs/image-builder/issues/939.
       After=containerd.service
+      # kubeadm requires having an IP
+      After=network-online.target
+      Wants=network-online.target
       [Service]
       # Ensure kubeadm service has access to kubeadm binary in /opt/bin on Flatcar.
       Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/bin


### PR DESCRIPTION
See https://github.com/giantswarm/cluster-azure/pull/284

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
