### PR TITLE
fix app chart names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `prometheus-blackbox-exporter` and `k8s-audit-metrics` apps to use the correct chart name.
+
 ## [0.30.0] - 2024-06-06
 
 ### Added

--- a/helm/cluster/files/apps/k8s-audit-metrics.yaml
+++ b/helm/cluster/files/apps/k8s-audit-metrics.yaml
@@ -1,10 +1,10 @@
 appName: k8s-audit-metrics
-chartName: k8s-audit-metrics-app
+chartName: k8s-audit-metrics
 configKey: k8sAuditMetrics
 clusterValues:
   configMap: true
   secret: false
 namespace: kube-system
 # used by renovate
-# repo: giantswarm/k8s-audit-metrics-app
+# repo: giantswarm/k8s-audit-metrics
 version: 0.9.0

--- a/helm/cluster/files/apps/prometheus-blackbox-exporter.yaml
+++ b/helm/cluster/files/apps/prometheus-blackbox-exporter.yaml
@@ -1,5 +1,5 @@
 appName: prometheus-blackbox-exporter
-chartName: prometheus-blackbox-exporter-app
+chartName: prometheus-blackbox-exporter
 configKey: prometheusBlackboxExporter
 dependsOn: prometheus-operator-crd
 clusterValues:
@@ -7,5 +7,5 @@ clusterValues:
   secret: false
 namespace: kube-system
 # used by renovate
-# repo: giantswarm/prometheus-blackbox-exporter-app
+# repo: giantswarm/prometheus-blackbox-exporter
 version: 0.4.1


### PR DESCRIPTION
### What does this PR do?

Fix `prometheus-blackbox-exporter` and `k8s-audit-metrics` apps to use the correct chart name

- [x] CHANGELOG.md has been updated (if it exists)
