### PR TITLE
Values.global.release object is not yet required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Change Helm values validation so that `Values.global.release` object is not yet required.
+
 ## [0.31.1] - 2024-06-12
 
 ### Fixed

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1003,8 +1003,7 @@
                 "components",
                 "connectivity",
                 "controlPlane",
-                "metadata",
-                "release"
+                "metadata"
             ],
             "additionalProperties": true,
             "properties": {


### PR DESCRIPTION
### What does this PR do?

Change Helm values validation so that `Values.global.release` object is not yet required.

### Any background context you can provide?

New Helm value was mistakenly made required here https://github.com/giantswarm/cluster/pull/211.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
