### PR TITLE
Fix app catalog and dependencies for new releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use app catalog from the Release CR if new releases are used.
+- Use app dependencies from the Release CR if new releases are used.
+- Add missing k8s-audit-metrics dependency (kyverno).
+
 ## [0.32.0] - 2024-06-18
 
 ### Added

--- a/Makefile.development.mk
+++ b/Makefile.development.mk
@@ -16,9 +16,15 @@ template: ## Output the rendered Helm template
 	$(eval CHART_DIR := "helm/cluster")
 	$(eval HELM_RELEASE_NAME := $(shell yq .global.metadata.name ${CHART_DIR}/${CI_FILE}))
 ifdef RELEASE_VERSION
-	@helm template --dry-run=server -n org-giantswarm ${HELM_RELEASE_NAME} ${CHART_DIR} --values ${CHART_DIR}/${CI_FILE} --set global.release.version="${RELEASE_VERSION}" --debug
+	@helm template --dry-run=server -n org-giantswarm ${HELM_RELEASE_NAME} ${CHART_DIR} \
+		--values ${CHART_DIR}/${CI_FILE} \
+		--set global.release.version="${RELEASE_VERSION}" \
+		--debug
 else
-	@helm template --dry-run=server -n org-giantswarm ${HELM_RELEASE_NAME} ${CHART_DIR} --values ${CHART_DIR}/${CI_FILE} --debug
+	@helm template --dry-run=server -n org-giantswarm ${HELM_RELEASE_NAME} ${CHART_DIR} \
+	--values ${CHART_DIR}/${CI_FILE} \
+	--set providerIntegration.useReleases=false \
+	--debug
 endif
 
 .PHONY: generate

--- a/Makefile.development.mk
+++ b/Makefile.development.mk
@@ -9,11 +9,17 @@ else
 CI_FILE ?= "ci/ci-values.yaml"
 endif
 
+RELEASE_VERSION ?=
+
 .PHONY: template
 template: ## Output the rendered Helm template
 	$(eval CHART_DIR := "helm/cluster")
 	$(eval HELM_RELEASE_NAME := $(shell yq .global.metadata.name ${CHART_DIR}/${CI_FILE}))
+ifdef RELEASE_VERSION
+	@helm template --dry-run=server -n org-giantswarm ${HELM_RELEASE_NAME} ${CHART_DIR} --values ${CHART_DIR}/${CI_FILE} --set global.release.version="${RELEASE_VERSION}" --debug
+else
 	@helm template --dry-run=server -n org-giantswarm ${HELM_RELEASE_NAME} ${CHART_DIR} --values ${CHART_DIR}/${CI_FILE} --debug
+endif
 
 .PHONY: generate
 generate: normalize-schema validate-schema generate-docs generate-values

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -299,6 +299,8 @@ providerIntegration:
     externalDns:
       enable: true
       configTemplateName: cluster.test.providerIntegration.apps.externalDns.config
+    k8sAuditMetrics:
+      enable: true
     k8sDnsNodeCache:
       enable: true
     metricsServer:
@@ -310,6 +312,8 @@ providerIntegration:
     nodeExporter:
       enable: true
     observabilityBundle:
+      enable: true
+    prometheusBlackboxExporter:
       enable: true
     securityBundle:
       enable: true

--- a/helm/cluster/files/apps/k8s-audit-metrics.yaml
+++ b/helm/cluster/files/apps/k8s-audit-metrics.yaml
@@ -4,6 +4,7 @@ configKey: k8sAuditMetrics
 clusterValues:
   configMap: true
   secret: false
+dependsOn: kyverno
 namespace: kube-system
 # used by renovate
 # repo: giantswarm/k8s-audit-metrics

--- a/helm/cluster/files/apps/k8s-audit-metrics.yaml
+++ b/helm/cluster/files/apps/k8s-audit-metrics.yaml
@@ -1,5 +1,4 @@
 appName: k8s-audit-metrics
-chartName: k8s-audit-metrics
 configKey: k8sAuditMetrics
 clusterValues:
   configMap: true

--- a/helm/cluster/files/apps/prometheus-blackbox-exporter.yaml
+++ b/helm/cluster/files/apps/prometheus-blackbox-exporter.yaml
@@ -1,5 +1,4 @@
 appName: prometheus-blackbox-exporter
-chartName: prometheus-blackbox-exporter
 configKey: prometheusBlackboxExporter
 dependsOn: prometheus-operator-crd
 clusterValues:

--- a/helm/cluster/templates/_helpers.tpl
+++ b/helm/cluster/templates/_helpers.tpl
@@ -62,6 +62,9 @@ giantswarm.io/organization: {{ required "You must provide an existing organizati
 giantswarm.io/service-priority: {{ .Values.global.metadata.servicePriority }}
 cluster.x-k8s.io/cluster-name: {{ include "cluster.resource.name" $ | quote }}
 cluster.x-k8s.io/watch-filter: capi
+{{- if $.Values.providerIntegration.useReleases }}
+release.giantswarm.io/version: {{ .Values.global.release.version | trimPrefix "v" | quote }}
+{{- end }}
 {{- end -}}
 
 {{- define "cluster.labels.preventDeletion" }}

--- a/helm/cluster/templates/_helpers.tpl
+++ b/helm/cluster/templates/_helpers.tpl
@@ -282,6 +282,29 @@ Where `data` is the data to hash and `global` is the top level scope.
 {{- end }}
 
 {{/*
+  cluster.app.catalog is a public named helper template that returns a catalog of the app that is specified under
+  property 'appName' in the object that is passed to the template. App catalog is obtained from the Release resource.
+
+  Example usage in template:
+
+    {{- $_ := set $ "appName" "foo-bar-controller" }}
+    {{- $appCatalog := include "cluster.app.catalog" $ }}
+    catalog: {{ $appCatalog }}
+*/}}
+{{- define "cluster.app.catalog" }}
+{{- $appCatalog := "" }}
+{{- $_ := (include "cluster.internal.get-release-resource" $) }}
+{{- if $.GiantSwarm.Release }}
+{{- range $_, $app := $.GiantSwarm.Release.spec.apps }}
+{{- if eq $app.name $.appName }}
+{{- $appCatalog = $app.catalog }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- $appCatalog }}
+{{- end }}
+
+{{/*
   cluster.app.dependencies is a public named helper template that renders a YAML array with app's dependencies for the
   app that is specified under property 'appName' in the object that is passed to the template. App dependencies are
   obtained from the Release resource.

--- a/helm/cluster/templates/_helpers.tpl
+++ b/helm/cluster/templates/_helpers.tpl
@@ -282,6 +282,32 @@ Where `data` is the data to hash and `global` is the top level scope.
 {{- end }}
 
 {{/*
+  cluster.internal.app.dependencies is a public named helper template that renders a YAML array with app's dependencies for the
+  app that is specified under property 'appName' in the object that is passed to the template. App dependencies are
+  obtained from the Release resource.
+
+  Example usage in template:
+
+    {{- $_ := set $ "appName" "foo-bar-controller" }}
+    {{- $appVersion := include "cluster.app.dependencies" $ }}
+    version: {{ $appVersion }}
+*/}}
+{{- define "cluster.internal.app.dependencies" }}
+{{- $dependencies := list }}
+{{- $_ := (include "cluster.internal.get-release-resource" $) }}
+{{- if $.GiantSwarm.Release }}
+  {{- range $_, $app := $.GiantSwarm.Release.spec.apps }}
+    {{- if eq $app.name $.appName }}
+      {{- range $_, $dependency := $app.dependsOn }}
+      {{- $dependencies = append $dependencies $dependency }}
+      {{- end}}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- $dependencies | toYaml }}
+{{- end }}
+
+{{/*
   cluster.component.version is a public named helper template that returns a version of the component that is specified
   under property 'componentName' in the object that is passed to the template. Component version is obtained from the
   Release resource.

--- a/helm/cluster/templates/_helpers.tpl
+++ b/helm/cluster/templates/_helpers.tpl
@@ -282,17 +282,19 @@ Where `data` is the data to hash and `global` is the top level scope.
 {{- end }}
 
 {{/*
-  cluster.internal.app.dependencies is a public named helper template that renders a YAML array with app's dependencies for the
+  cluster.app.dependencies is a public named helper template that renders a YAML array with app's dependencies for the
   app that is specified under property 'appName' in the object that is passed to the template. App dependencies are
   obtained from the Release resource.
 
   Example usage in template:
 
-    {{- $_ := set $ "appName" "foo-bar-controller" }}
-    {{- $appVersion := include "cluster.app.dependencies" $ }}
-    version: {{ $appVersion }}
+    {{- $_ := set $ "appName" "foo-exporter" }}
+    {{- $dependenciesFromRelease := include "cluster.app.dependencies" $ | fromYamlArray }}
+    {{- range $_, $dependency := $dependenciesFromRelease }}
+      {{- $dependencies = append $dependencies $dependency }}
+    {{- end }}
 */}}
-{{- define "cluster.internal.app.dependencies" }}
+{{- define "cluster.app.dependencies" }}
 {{- $dependencies := list }}
 {{- $_ := (include "cluster.internal.get-release-resource" $) }}
 {{- if $.GiantSwarm.Release }}

--- a/helm/cluster/templates/apps/apps.yaml
+++ b/helm/cluster/templates/apps/apps.yaml
@@ -31,7 +31,17 @@ apiVersion: application.giantswarm.io/v1alpha1
 kind: App
 metadata:
   {{- $annotations := include "cluster.annotations.common.all" $ }}
-  {{- if or $annotations $app.dependsOn }}
+  {{- $dependencies := list }}
+  {{- if $.Values.providerIntegration.useReleases}}
+    {{- $_ := set $ "appName" $appName }}
+    {{- $dependenciesFromRelease := include "cluster.internal.app.dependencies" $ | fromYamlArray }}
+    {{- range $_, $dependency := $dependenciesFromRelease }}
+      {{- $dependencies = append $dependencies (printf "%s-%s" $.Values.global.metadata.name $dependency) }}
+    {{- end }}
+  {{- else if $app.dependsOn }}
+    {{- $dependencies = append $dependencies (printf "%s-%s" $.Values.global.metadata.name $app.dependsOn) }}
+  {{- end }}
+  {{- if or $annotations $dependencies }}
   annotations:
     {{- if $annotations }}
     {{- $annotations | indent 4 }}
@@ -40,9 +50,9 @@ metadata:
     # explicitly instruct app-operator that this App depends on a HelmRelease (otherwise it will just check App resources)
     app-operator.giantswarm.io/depends-on-helmrelease: "true"
     {{- end }}
-    {{- if $app.dependsOn }}
+    {{- if $dependencies }}
     # app-operator will make sure that the app on which it depends is installed before
-    app-operator.giantswarm.io/depends-on: {{ printf "%s-%s" $.Values.global.metadata.name $app.dependsOn -}}
+    app-operator.giantswarm.io/depends-on: {{ $dependencies | join "," | quote -}}
     {{- end }}
   {{- end }}
   labels:

--- a/helm/cluster/templates/apps/apps.yaml
+++ b/helm/cluster/templates/apps/apps.yaml
@@ -34,7 +34,7 @@ metadata:
   {{- $dependencies := list }}
   {{- if $.Values.providerIntegration.useReleases}}
     {{- $_ := set $ "appName" $appName }}
-    {{- $dependenciesFromRelease := include "cluster.internal.app.dependencies" $ | fromYamlArray }}
+    {{- $dependenciesFromRelease := include "cluster.app.dependencies" $ | fromYamlArray }}
     {{- range $_, $dependency := $dependenciesFromRelease }}
       {{- $dependencies = append $dependencies (printf "%s-%s" $.Values.global.metadata.name $dependency) }}
     {{- end }}

--- a/helm/cluster/templates/apps/apps.yaml
+++ b/helm/cluster/templates/apps/apps.yaml
@@ -64,7 +64,12 @@ metadata:
   name: {{ $.Values.global.metadata.name }}-{{ $app.appName }}
   namespace: {{ $.Release.Namespace }}
 spec:
-  catalog: {{ $ephemeralConfig.catalogOverride | default $app.catalog | default "default" }}
+  {{- $appCatalog := $app.catalog -}}
+  {{- if $.Values.providerIntegration.useReleases }}
+  {{- $_ := set $ "appName" $app.appName }}
+  {{- $appCatalog = include "cluster.app.catalog" $ }}
+  {{- end }}
+  catalog: {{ $ephemeralConfig.catalogOverride | default $appCatalog | default "default" }}
   name: {{ $app.chartName | default $app.appName }}
   {{- if $app.inCluster }}
   namespace: {{ $.Release.Namespace }}

--- a/helm/cluster/templates/apps/helmreleases.yaml
+++ b/helm/cluster/templates/apps/helmreleases.yaml
@@ -63,9 +63,19 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: {{ include "cluster.resource.name" $ }}-{{ $ephemeralConfig.catalogOverride | default $app.catalog | default "default" }}
-  {{- if $app.dependsOn }}
+  {{- $dependencies := list }}
+  {{- if $.Values.providerIntegration.useReleases}}
+    {{- $_ := set $ "appName" $appName }}
+    {{- $dependenciesFromRelease := include "cluster.internal.app.dependencies" $ | fromYamlArray }}
+    {{- range $_, $dependency := $dependenciesFromRelease }}
+      {{- $dependencies = append $dependencies $dependency }}
+    {{- end }}
+  {{- else if $app.dependsOn }}
+    {{- $dependencies = $app.dependsOn }}
+  {{- end }}
+  {{- if $dependencies }}
   dependsOn:
-  {{- range $_, $dependency := $app.dependsOn }}
+  {{- range $_, $dependency := $dependencies }}
   - name: {{ include "cluster.resource.name" $ }}-{{ $dependency }}
     namespace: {{ $.Release.Namespace }}
   {{- end }}

--- a/helm/cluster/templates/apps/helmreleases.yaml
+++ b/helm/cluster/templates/apps/helmreleases.yaml
@@ -54,15 +54,17 @@ spec:
   chart:
     spec:
       chart: {{ $app.chartName | default $app.appName }}
+      {{- $appCatalog := $app.catalog -}}
       {{- $appVersion := $app.version -}}
       {{- if $.Values.providerIntegration.useReleases }}
       {{- $_ := set $ "appName" $app.appName }}
+      {{- $appCatalog = include "cluster.app.catalog" $ }}
       {{- $appVersion = include "cluster.app.version" $ }}
       {{- end }}
       version: {{ $ephemeralConfig.versionOverride | default $appVersion }}
       sourceRef:
         kind: HelmRepository
-        name: {{ include "cluster.resource.name" $ }}-{{ $ephemeralConfig.catalogOverride | default $app.catalog | default "default" }}
+        name: {{ include "cluster.resource.name" $ }}-{{ $ephemeralConfig.catalogOverride | default $appCatalog | default "default" }}
   {{- $dependencies := list }}
   {{- if $.Values.providerIntegration.useReleases}}
     {{- $_ := set $ "appName" $appName }}

--- a/helm/cluster/templates/apps/helmreleases.yaml
+++ b/helm/cluster/templates/apps/helmreleases.yaml
@@ -66,7 +66,7 @@ spec:
   {{- $dependencies := list }}
   {{- if $.Values.providerIntegration.useReleases}}
     {{- $_ := set $ "appName" $appName }}
-    {{- $dependenciesFromRelease := include "cluster.internal.app.dependencies" $ | fromYamlArray }}
+    {{- $dependenciesFromRelease := include "cluster.app.dependencies" $ | fromYamlArray }}
     {{- range $_, $dependency := $dependenciesFromRelease }}
       {{- $dependencies = append $dependencies $dependency }}
     {{- end }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3466

### What does this PR do?

### Added

- Use app catalog from the Release CR if new releases are used
- Use app dependencies from the Release CR if new releases are used
- Add missing k8s-audit-metrics dependency (kyverno)

### What is the effect of this change to users?

Clusters created with new releases will correctly use app dependencies from the Release CR.

### How does it look like?

No changes for customers.

### Any background context you can provide?

https://github.com/giantswarm/roadmap/issues/3466

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
