### PR TITLE
Fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.34.0] - 2024-07-04
 
-## [0.33.2] - 2024-07-04
-
 ### Changed
 
 - Enable `StatefulSetAutoDeletePVC` feature gate on all clusters.
+- Update observability-bundle version from 1.3.4 to 1.4.0.
+- Update cert-manager-app version from 3.7.7 to 3.7.8.
 
 ## [0.33.1] - 2024-07-02
 


### PR DESCRIPTION
### What does this PR do?

Update changelog so it shows the latest changes (previously released as v0.33.2) to be the part of v0.34.0 release (no new changes compared to v0.33.2, we just needed a new minor instead of new patch).

### Any background context you can provide?

These changes were included in v0.33.2, while we needed a new minor (v0.34.0) for these:
- https://github.com/giantswarm/cluster/pull/244
- https://github.com/giantswarm/cluster/pull/245
- https://github.com/giantswarm/cluster/pull/246

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
