### PR TITLE
Restoring single dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Restore single dependency for `k8s-audit-metrics` app.
+
 ## [0.34.0] - 2024-07-04
 
 ### Changed

--- a/helm/cluster/files/apps/k8s-audit-metrics.yaml
+++ b/helm/cluster/files/apps/k8s-audit-metrics.yaml
@@ -4,7 +4,7 @@ clusterValues:
   configMap: true
   secret: false
 dependsOnHelmRelease: true
-dependsOn: kyverno, cilium, prometheus-operator-crd
+dependsOn: kyverno
 namespace: kube-system
 # used by renovate
 # repo: giantswarm/k8s-audit-metrics


### PR DESCRIPTION
### What does this PR do?

Restores single dependency for K8s Audit Metrics app.

### What is the effect of this change to users?

### How does it look like?

N/A

### Any background context you can provide?

The list is not supported yet.

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
