### PR TITLE
Insecure kubelet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Kubelet insecure mode
+
 ## [0.31.3] - 2024-06-12
 
 ### Fixed

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -320,6 +320,7 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.advancedConfiguration.kubelet` | **Kubelet configuration** - Kubelet configuration settings for the whole cluster.|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.kubelet.containerLogMaxFiles` | **Maximum number of container log files** - Specifies the maximum number of container log files that can be present for a container.|**Type:** `integer`<br/>**Default:** `0`|
 | `internal.advancedConfiguration.kubelet.containerLogMaxSize` | **Maximum size of the container log** - Specifies the maximum size of the container log file before it is rotated. For example: "5Mi" or "256Ki".|**Type:** `string`<br/>**Default:** `""`|
+| `internal.advancedConfiguration.kubelet.insecure` | **Kubelet Authentication** - Disables kubelet authentication, anyone with access to the port can talk to the API.|**Type:** `boolean`<br/>**Default:** `false`|
 | `internal.advancedConfiguration.kubelet.kubeReserved` | **Kube reserved resources configuration** - Resources configuration for Kubernetes system services.|**Type:** `object`<br/>|
 | `internal.advancedConfiguration.kubelet.kubeReserved.cpu` | **Kube reserved CPU** - CPU reserved for Kubernetes system services.|**Type:** `string`<br/>**Default:** `"350m"`|
 | `internal.advancedConfiguration.kubelet.kubeReserved.ephemeralStorage` | **Kube reserved ephemeral storage** - Ephemeral storage reserved for kubernetes system services.|**Type:** `string`<br/>**Default:** `"1024Mi"`|

--- a/helm/cluster/files/etc/kubernetes/patches/kubeletconfiguration.yaml
+++ b/helm/cluster/files/etc/kubernetes/patches/kubeletconfiguration.yaml
@@ -51,3 +51,12 @@ containerLogMaxSize: {{ $.Values.internal.advancedConfiguration.kubelet.containe
 {{- if $.Values.internal.advancedConfiguration.kubelet.containerLogMaxFiles }}
 containerLogMaxFiles: {{ $.Values.internal.advancedConfiguration.kubelet.containerLogMaxFiles }}
 {{- end }}
+{{- if $.Values.internal.advancedConfiguration.kubelet.insecure }}
+authentication:
+  anonymous:
+    enabled: true
+  webhook:
+    enabled: false
+authorization:
+  mode: AlwaysAllow
+{{- end }}

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1811,6 +1811,12 @@
                                     "description": "Specifies the maximum size of the container log file before it is rotated. For example: \"5Mi\" or \"256Ki\".",
                                     "default": ""
                                 },
+                                "insecure": {
+                                    "type": "boolean",
+                                    "title": "Kubelet Authentication",
+                                    "description": "Disables kubelet authentication, anyone with access to the port can talk to the API.",
+                                    "default": false
+                                },
                                 "kubeReserved": {
                                     "type": "object",
                                     "title": "Kube reserved resources configuration",

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -80,6 +80,7 @@ internal:
     kubelet:
       containerLogMaxFiles: 0
       containerLogMaxSize: ""
+      insecure: false
       kubeReserved:
         cpu: 350m
         ephemeralStorage: 1024Mi


### PR DESCRIPTION
### What does this PR do?

Allows disabling kubelet authentication, mainly for migration as it was disabled in Vintage

### What is the effect of this change to users?

### How does it look like?

(Please add anything that represents the change visually. Screenshots, output, logs, ...)

### Any background context you can provide?

(Please link public issues or summarize if not public.)

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
