### PR TITLE
Automate cluster-aws test pull requests

### DIFF
--- a/.github/workflows/cluster-provider-test-pull-request.yaml
+++ b/.github/workflows/cluster-provider-test-pull-request.yaml
@@ -185,7 +185,7 @@ jobs:
           --body-file -
         
         cluster_aws_pr_number=$(gh pr list --repo giantswarm/cluster-aws --head ${{ env.cluster_aws_branch_name }} --json number | jq ".[0].number")
-        cluster_chart_comment="Test pull request has been created in cluster-aws repo. Go to pull request https://github.com/giantswarm/cluster-aws/pull/$cluster_aws_pr_number to test you cluster chart changes on AWS."
+        cluster_chart_comment="Hey @${{ env.cluster_chart_pr_author_username }}, a test pull request has been created for you in cluster-aws repo! Go to pull request https://github.com/giantswarm/cluster-aws/pull/$cluster_aws_pr_number in order to test you cluster chart changes on AWS."
         echo -e "$cluster_chart_comment" | gh pr comment \
           --repo giantswarm/cluster \
           --body "$cluster_chart_comment" \

--- a/.github/workflows/cluster-provider-test-pull-request.yaml
+++ b/.github/workflows/cluster-provider-test-pull-request.yaml
@@ -210,6 +210,6 @@ jobs:
         gh pr list --repo giantswarm/cluster-aws --head test-cluster-chart-pr-${{ env.cluster_chart_pr_number }} --json number --jq '.[].number' | while read pr_number; do
           gh pr close $pr_number \
             --repo giantswarm/cluster-aws \
-            --comment "Closing this pull request after closing/merging cluster chart pull request."
+            --comment "Closing this pull request after closing/merging cluster chart pull request." \
             --delete-branch
         done

--- a/.github/workflows/cluster-provider-test-pull-request.yaml
+++ b/.github/workflows/cluster-provider-test-pull-request.yaml
@@ -1,11 +1,12 @@
-name: Create or update cluster-$provider test pull requests
+name: cluster-$provider test pull requests
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, closed]
 
 jobs:
   create-or-update-test-pull-request:
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
 
     steps:
@@ -29,6 +30,7 @@ jobs:
         git clone https://github.com/giantswarm/cluster.git
 
     - name: Get cluster chart pull request details
+      id: cluster_chart_pr
       env:
         GITHUB_TOKEN: ${{ secrets.TAYLORBOT_GITHUB_ACTION }}
       run: |
@@ -183,3 +185,31 @@ jobs:
           --body-file -
       env:
         GITHUB_TOKEN: ${{ secrets.TAYLORBOT_GITHUB_ACTION }}
+
+  close-cluster-aws-pr:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Get cluster chart pull request number
+      env:
+        GITHUB_TOKEN: ${{ secrets.TAYLORBOT_GITHUB_ACTION }}
+      run: |
+        # Get pull request number
+        cluster_chart_pr_number="${{ github.event.issue.number }}"
+        if [ -z "$cluster_chart_pr_number" ]; then
+          cluster_chart_pr_number="${{ github.event.number }}"
+        fi
+        echo "Pull request number is $cluster_chart_pr_number."
+        echo "cluster_chart_pr_number=$cluster_chart_pr_number" >> $GITHUB_ENV
+
+    - name: Close cluster-aws pull requests
+      env:
+        GITHUB_TOKEN: ${{ secrets.TAYLORBOT_GITHUB_ACTION }}
+      run: |
+        gh pr list --repo giantswarm/cluster-aws --head test-cluster-chart-pr-${{ env.cluster_chart_pr_number }} --json number --jq '.[].number' | while read pr_number; do
+          gh pr close $pr_number \
+            --repo giantswarm/cluster-aws \
+            --comment "Closing this pull request after closing/merging cluster chart pull request."
+            --delete-branch
+        done

--- a/.github/workflows/cluster-provider-test-pull-request.yaml
+++ b/.github/workflows/cluster-provider-test-pull-request.yaml
@@ -183,6 +183,13 @@ jobs:
           --label testing \
           --label do-not-merge/hold \
           --body-file -
+        
+        cluster_aws_pr_number=$(gh pr list --repo giantswarm/cluster-aws --head ${{ env.cluster_aws_branch_name }} --json number | jq ".[0].number")
+        cluster_chart_comment="Test pull request has been created in cluster-aws repo. Go to pull request https://github.com/giantswarm/cluster-aws/pull/$cluster_aws_pr_number to test you cluster chart changes on AWS."
+        echo -e "$cluster_chart_comment" | gh pr comment \
+          --repo giantswarm/cluster \
+          --body "$cluster_chart_comment" \
+          ${{ env.cluster_chart_pr_number }}
       env:
         GITHUB_TOKEN: ${{ secrets.TAYLORBOT_GITHUB_ACTION }}
 

--- a/.github/workflows/create-or-update-test-pull-request.yaml
+++ b/.github/workflows/create-or-update-test-pull-request.yaml
@@ -40,7 +40,11 @@ jobs:
         echo "Pull request number is $cluster_chart_pr_number."
         echo "cluster_chart_pr_number=$cluster_chart_pr_number" >> $GITHUB_ENV
         
-        cluster_chart_pr_details=$(gh pr view $cluster_chart_pr_number --json "author,headRefName")
+        cluster_chart_pr_details=$(gh pr view $cluster_chart_pr_number --json "title,author,headRefName")
+        
+        # Get pull request title
+        cluster_chart_pr_title=$(echo $cluster_chart_pr_details | jq -r '.title')
+        echo "cluster_chart_pr_title=$cluster_chart_pr_title" >> $GITHUB_ENV
         
         # Get pull request author details
         cluster_chart_pr_author_username=$(echo $cluster_chart_pr_details | jq -r '.author.login')
@@ -163,7 +167,8 @@ jobs:
         body="> [!WARNING]"
         body="$body\n> DO NOT MERGE! This PR has been created automatically by @taylorbot on behalf of ${{ env.cluster_chart_pr_author_name }} (@${{ env.cluster_chart_pr_author_username }})."
         body="$body\n\n### Changes"
-        body="$body\n\nUpdate the cluster chart version from \`${{ env.cluster_chart_current_version }}\` to \`${{ env.custom_cluster_chart_new_version }}\` in order to test @{{ env.cluster_chart_pr_author_username }}'s cluster chart PR https://github.com/giantswarm/cluster/pull/${{ env.cluster_chart_pr_number }}."
+        body="$body\n\nUpdate the cluster chart version from \`${{ env.cluster_chart_current_version }}\` to \`${{ env.custom_cluster_chart_new_version }}\` in order to test @${{ env.cluster_chart_pr_author_username }}'s cluster chart pull request https://github.com/giantswarm/cluster/pull/${{ env.cluster_chart_pr_number }}."
+        body="$body\n\nCluster chart pull request title: \`${{ env.cluster_chart_pr_title }}\`."
         body="$body\n\n### Testing"
         body="$body\n\nPlease comment this pull request with \`/run cluster-test-suites\` in order to run e2e tests."
         # body="$body\n\n> [!NOTE]"

--- a/.github/workflows/trigger-cluster-test-suites.yaml
+++ b/.github/workflows/trigger-cluster-test-suites.yaml
@@ -32,8 +32,8 @@ jobs:
         git fetch --tags
         latest_release=$(git describe --tags $(git rev-list --tags --max-count=1))
         latest_commit_sha=$(git rev-parse --verify HEAD)
-        echo "Custom cluster chart version is $latest_release-latest_commit_sha"
-        echo "custom_cluster_chart_version=$latest_release-latest_commit_sha" >> $GITHUB_ENV
+        echo "Custom cluster chart version is $latest_release-$latest_commit_sha"
+        echo "custom_cluster_chart_version=$latest_release-$latest_commit_sha" >> $GITHUB_ENV
 
     - name: Clone cluster-aws repository
       run: |

--- a/.github/workflows/trigger-cluster-test-suites.yaml
+++ b/.github/workflows/trigger-cluster-test-suites.yaml
@@ -30,7 +30,10 @@ jobs:
       run: |
         cd cluster
         git fetch --tags
+        
+        # get the latest tag and trim 'v' prefix
         latest_release=$(git describe --tags $(git rev-list --tags --max-count=1))
+        latest_release="${latest_release#v}"
         latest_commit_sha=$(git rev-parse --verify HEAD)
         echo "Custom cluster chart version is $latest_release-$latest_commit_sha"
         echo "custom_cluster_chart_version=$latest_release-$latest_commit_sha" >> $GITHUB_ENV

--- a/.github/workflows/trigger-cluster-test-suites.yaml
+++ b/.github/workflows/trigger-cluster-test-suites.yaml
@@ -114,8 +114,9 @@ jobs:
           new_version="$new_version" yq e '.dependencies[] |= select(.name == "cluster") * {"version": strenv(new_version)}' -i Chart.yaml
           yq e '.dependencies[] |= select(.name == "cluster") * {"repository": "https://giantswarm.github.io/cluster-test-catalog"}' -i Chart.yaml
           
-          echo "Updated cluster chart version. Chart.yaml content is now:\n"
+          echo -e "Updated cluster chart version. Chart.yaml content is now:\n---"
           cat Chart.yaml
+          echo -e "---\n"
 
           # Retry logic for helm dependency update
           retry=0
@@ -169,6 +170,12 @@ jobs:
         # body="$body\n\n> [!NOTE]"
         # body="$body\n> This PR will be closed automatically when the cluster chart PR is closed."
         
-        echo -e "$body" | gh pr create --repo giantswarm/cluster-aws --head ${{ env.cluster_aws_branch_name }} --title "$title" --draft --label testing --label do-not-merge/hold -
+        echo -e "$body" | gh pr create --repo giantswarm/cluster-aws \
+          --head ${{ env.cluster_aws_branch_name }} \
+          --title "$title" \
+          --draft \
+          --label testing \
+          --label do-not-merge/hold \
+          --body-file -
       env:
         GITHUB_TOKEN: ${{ secrets.TAYLORBOT_GITHUB_ACTION }}

--- a/.github/workflows/trigger-cluster-test-suites.yaml
+++ b/.github/workflows/trigger-cluster-test-suites.yaml
@@ -18,8 +18,8 @@ jobs:
 
     - name: Set up Git
       run: |
-        git config --local user.email "dev@giantswarm.io"
-        git config --local user.name "taylorbot"
+        git config --global user.email "dev@giantswarm.io"
+        git config --global user.name "taylorbot"
 
     - name: Clone cluster chart repository
       run: |

--- a/.github/workflows/trigger-cluster-test-suites.yaml
+++ b/.github/workflows/trigger-cluster-test-suites.yaml
@@ -20,6 +20,13 @@ jobs:
       run: |
         git config --global user.email "dev@giantswarm.io"
         git config --global user.name "taylorbot"
+    
+    - uses: oleksiyrudenko/gha-git-credentials@v2.1.2
+      with:
+        global: true
+        actor: 'taylorbot'
+        email: 'dev@giantswarm.io'
+        token: '${{ secrets.TAYLORBOT_GITHUB_ACTION }}'
 
     - name: Clone cluster chart repository
       run: |
@@ -136,6 +143,8 @@ jobs:
         git add helm/cluster-aws/Chart.yaml
         git add helm/cluster-aws/Chart.lock
         git commit -m "Update cluster chart version to ${{ env.custom_cluster_chart_version }}"
+
+        git remote set-url origin https://${{ env.GITHUB_TOKEN }}@github.com/giantswarm/cluster-aws.git
         git push origin ${{ env.cluster_aws_branch_name }}
       env:
         GITHUB_TOKEN: ${{ secrets.TAYLORBOT_GITHUB_ACTION }}
@@ -143,6 +152,6 @@ jobs:
     - name: Create a draft pull request
       if: env.branch_exists == 'false'
       run: |
-        gh pr create --repo giantswarm/cluster-aws --head ${{ env.cluster_aws_branch_name }} --title "[DO NOT MERGE] Testing cluster chart PR #${{ github.event.issue.number }}" --body "This PR updates the cluster chart version to ${{ env.latest_release }}-${{ env.commit_sha }} in order to test cluster chart PR #${{ github.event.issue.number }}.\n\nThis PR will be closed automatically when cluster chart PR is closed." --draft
+        gh pr create --repo giantswarm/cluster-aws --head ${{ env.cluster_aws_branch_name }} --title "[DO NOT MERGE] Testing cluster chart PR #${{ github.event.issue.number }}" --body "Update the cluster chart version to ${{ env.custom_cluster_chart_version }} in order to test cluster chart PR #${{ github.event.issue.number }}.\n\nThis PR will be closed automatically when cluster chart PR is closed." --draft
       env:
         GITHUB_TOKEN: ${{ secrets.TAYLORBOT_GITHUB_ACTION }}

--- a/.github/workflows/trigger-cluster-test-suites.yaml
+++ b/.github/workflows/trigger-cluster-test-suites.yaml
@@ -33,6 +33,8 @@ jobs:
         git clone https://github.com/giantswarm/cluster.git
 
     - name: Get cluster chart pull request details
+      env:
+        GITHUB_TOKEN: ${{ secrets.TAYLORBOT_GITHUB_ACTION }}
       run: |
         # Get pull request number
         cluster_chart_pr_number="${{ github.event.issue.number }}"
@@ -158,15 +160,15 @@ jobs:
     - name: Create a draft pull request
       if: env.branch_exists == 'false'
       run: |
-        title="[DO NOT MERGE] Testing cluster chart PR #${{ env.cluster_chart_pr_number }}"
+        title="Test cluster chart PR #${{ env.cluster_chart_pr_number }}"
         
         body="> [!WARNING]"
         body="$body\n> DO NOT MERGE! This PR has been created automatically by @taylorbot on behalf of {{ env.cluster_chart_pr_author_name }} (@{{ env.cluster_chart_pr_author_username }})"
         body="$body\n\n### Changes"
         body="$body\n\nUpdate the cluster chart version to ${{ env.custom_cluster_chart_version }} in order to test @{{ env.cluster_chart_pr_author_username }}'s cluster chart PR https://github.com/giantswarm/cluster/pull/${{ env.cluster_chart_pr_number }}."
-        body="$body\n\n> [!NOTE]"
-        body="$body\n> This PR will be closed automatically when the cluster chart PR is closed."
+#        body="$body\n\n> [!NOTE]"
+#        body="$body\n> This PR will be closed automatically when the cluster chart PR is closed."
         
-        echo -e "$body" | gh pr create --repo giantswarm/cluster-aws --head ${{ env.cluster_aws_branch_name }} --title "$title" --draft -
+        echo -e "$body" | gh pr create --repo giantswarm/cluster-aws --head ${{ env.cluster_aws_branch_name }} --title "$title" --draft --label testing --label do-not-merge/hold -
       env:
         GITHUB_TOKEN: ${{ secrets.TAYLORBOT_GITHUB_ACTION }}

--- a/.github/workflows/trigger-cluster-test-suites.yaml
+++ b/.github/workflows/trigger-cluster-test-suites.yaml
@@ -27,7 +27,9 @@ jobs:
       run: |
         cd cluster
         git fetch --tags
-        echo "latest_release=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_ENV
+        latest_release=$(git describe --tags $(git rev-list --tags --max-count=1))
+        echo "The latest cluster chart release is $latest_release"
+        echo "latest_release=$latest_release" >> $GITHUB_ENV
 
     - name: Extract commit SHA
       id: commit_sha

--- a/.github/workflows/trigger-cluster-test-suites.yaml
+++ b/.github/workflows/trigger-cluster-test-suites.yaml
@@ -1,15 +1,11 @@
-name: Trigger cluster-test-suites
+name: Create or update cluster-$provider test pull requests
 
 on:
-  issue_comment:
-    types: [created]
-  # temporary for the sake of testing
   pull_request:
     types: [opened, synchronize, reopened]
 
 jobs:
-  trigger-cluster-test-suites:
-    # if: startsWith(github.event.comment.body, '/run cluster-test-suites') && github.event.issue.pull_request != ''
+  create-or-update-test-pull-request:
     runs-on: ubuntu-latest
 
     steps:
@@ -69,7 +65,7 @@ jobs:
         latest_commit_sha=$(git rev-parse --verify HEAD)
         
         echo "Custom cluster chart version is $latest_release-$latest_commit_sha"
-        echo "custom_cluster_chart_version=$latest_release-$latest_commit_sha" >> $GITHUB_ENV
+        echo "custom_cluster_chart_new_version=$latest_release-$latest_commit_sha" >> $GITHUB_ENV
 
     - name: Clone cluster-aws repository
       run: |
@@ -107,7 +103,8 @@ jobs:
       run: |
         cd cluster-aws/helm/cluster-aws
         current_version="$(yq e '.dependencies[] | select(.name == "cluster").version' Chart.yaml)"
-        new_version="${{ env.custom_cluster_chart_version }}"
+        echo "cluster_chart_current_version=$current_version" >> $GITHUB_ENV
+        new_version="${{ env.custom_cluster_chart_new_version }}"
 
         if [ $new_version != $current_version ]; then
           echo "Updating cluster chart version"
@@ -151,7 +148,7 @@ jobs:
         cd cluster-aws
         git add helm/cluster-aws/Chart.yaml
         git add helm/cluster-aws/Chart.lock
-        git commit -m "Update cluster chart version to ${{ env.custom_cluster_chart_version }}"
+        git commit -m "Update cluster chart version to ${{ env.custom_cluster_chart_new_version }}"
 
         git remote set-url origin https://${{ env.GITHUB_TOKEN }}@github.com/giantswarm/cluster-aws.git
         git push origin ${{ env.cluster_aws_branch_name }}
@@ -164,9 +161,9 @@ jobs:
         title="Test cluster chart PR #${{ env.cluster_chart_pr_number }}"
         
         body="> [!WARNING]"
-        body="$body\n> DO NOT MERGE! This PR has been created automatically by @taylorbot on behalf of {{ env.cluster_chart_pr_author_name }} (@{{ env.cluster_chart_pr_author_username }})"
+        body="$body\n> DO NOT MERGE! This PR has been created automatically by @taylorbot on behalf of ${{ env.cluster_chart_pr_author_name }} (@${{ env.cluster_chart_pr_author_username }})."
         body="$body\n\n### Changes"
-        body="$body\n\nUpdate the cluster chart version to ${{ env.custom_cluster_chart_version }} in order to test @{{ env.cluster_chart_pr_author_username }}'s cluster chart PR https://github.com/giantswarm/cluster/pull/${{ env.cluster_chart_pr_number }}."
+        body="$body\n\nUpdate the cluster chart version from \`${{ env.cluster_chart_current_version }}\` to \`${{ env.custom_cluster_chart_new_version }}\` in order to test @{{ env.cluster_chart_pr_author_username }}'s cluster chart PR https://github.com/giantswarm/cluster/pull/${{ env.cluster_chart_pr_number }}."
         body="$body\n\n### Testing"
         body="$body\n\nPlease comment this pull request with \`/run cluster-test-suites\` in order to run e2e tests."
         # body="$body\n\n> [!NOTE]"

--- a/.github/workflows/trigger-cluster-test-suites.yaml
+++ b/.github/workflows/trigger-cluster-test-suites.yaml
@@ -3,10 +3,13 @@ name: Trigger cluster-test-suites
 on:
   issue_comment:
     types: [created]
+  # temporary for the sake of testing
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   trigger-cluster-test-suites:
-    if: startsWith(github.event.comment.body, '/run cluster-test-suites') && github.event.issue.pull_request != ''
+    # if: startsWith(github.event.comment.body, '/run cluster-test-suites') && github.event.issue.pull_request != ''
     runs-on: ubuntu-latest
 
     steps:
@@ -22,18 +25,15 @@ jobs:
       run: |
         git clone https://github.com/giantswarm/cluster.git
 
-    - name: Extract latest cluster chart release
+    - name: Get custom cluster chart version
       id: latest_release
       run: |
         cd cluster
         git fetch --tags
         latest_release=$(git describe --tags $(git rev-list --tags --max-count=1))
-        echo "The latest cluster chart release is $latest_release"
-        echo "latest_release=$latest_release" >> $GITHUB_ENV
-
-    - name: Extract commit SHA
-      id: commit_sha
-      run: echo "commit_sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+        latest_commit_sha=$(git rev-parse --verify HEAD)
+        echo "Custom cluster chart version is $latest_release-latest_commit_sha"
+        echo "custom_cluster_chart_version=$latest_release-latest_commit_sha" >> $GITHUB_ENV
 
     - name: Clone cluster-aws repository
       run: |
@@ -67,7 +67,7 @@ jobs:
       run: |
         cd cluster-aws/helm/cluster-aws
         current_version="$(yq e '.dependencies[] | select(.name == "cluster").version' Chart.yaml)"
-        new_version="${{ env.latest_release }}-${{ env.commit_sha }}"
+        new_version="${{ env.custom_cluster_chart_version }}"
 
         if [ $new_version != $current_version ]; then
           echo "Updating cluster chart version"
@@ -106,6 +106,6 @@ jobs:
         cd cluster-aws
         git add helm/cluster-aws/Chart.yaml
         git add helm/cluster-aws/Chart.lock
-        git commit -m "Update cluster chart version to ${{ env.latest_release }}-${{ env.commit_sha }}"
+        git commit -m "Update cluster chart version to ${{ env.custom_cluster_chart_version }}"
         echo "Will push now"
         # git push origin ${{ env.cluster_aws_branch_name }}

--- a/.github/workflows/trigger-cluster-test-suites.yaml
+++ b/.github/workflows/trigger-cluster-test-suites.yaml
@@ -25,8 +25,19 @@ jobs:
       run: |
         git clone https://github.com/giantswarm/cluster.git
 
+    - name: Get cluster chart PR number
+      run: |
+        cluster_chart_pr_number="${{ github.event.issue.number }}"
+        if [ -z "$cluster_chart_pr_number" ]; then
+          cluster_chart_pr_number="${{ github.event.number }}"
+        fi
+        echo "Pull request number is $cluster_chart_pr_number."
+        echo "cluster_chart_pr_number=$cluster_chart_pr_number" >> $GITHUB_ENV
+
     - name: Get custom cluster chart version
       id: latest_release
+      env:
+        GITHUB_TOKEN: "${{ secrets.TAYLORBOT_GITHUB_ACTION }}"
       run: |
         cd cluster
         git fetch --tags
@@ -34,7 +45,14 @@ jobs:
         # get the latest tag and trim 'v' prefix
         latest_release=$(git describe --tags $(git rev-list --tags --max-count=1))
         latest_release="${latest_release#v}"
+        
+        # Now let's get the SHA of the latest commit on the tested branch
+        # Fetch the PR details using GitHub CLI
+        pr_details=$(gh pr view ${{ env.cluster_chart_pr_number }} --json headRefName)
+        branch_name=$(echo $pr_details | jq -r '.headRefName')
+        git checkout $branch_name
         latest_commit_sha=$(git rev-parse --verify HEAD)
+        
         echo "Custom cluster chart version is $latest_release-$latest_commit_sha"
         echo "custom_cluster_chart_version=$latest_release-$latest_commit_sha" >> $GITHUB_ENV
 
@@ -46,14 +64,8 @@ jobs:
       id: check_branch
       run: |
         cd cluster-aws
-        pr_number="${{ github.event.issue.number }}"
-        if [ -z "$pr_number" ]; then
-          pr_number="${{ github.event.number }}"
-        fi
-        echo "Pull request number is $pr_number."
-        
         # Check if branch exists
-        branch_name="test-cluster-chart-pr-$pr_number"
+        branch_name="test-cluster-chart-pr-${{ env.cluster_chart_pr_number }}"
         echo "cluster_aws_branch_name=$branch_name" >> $GITHUB_ENV
         repo_url="https://github.com/giantswarm/cluster-aws"
         if git ls-remote --heads "$repo_url" | grep -q "refs/heads/$branch_name"; then

--- a/.github/workflows/trigger-cluster-test-suites.yaml
+++ b/.github/workflows/trigger-cluster-test-suites.yaml
@@ -24,8 +24,8 @@ jobs:
 
     - name: Extract latest cluster chart release
       id: latest_release
-      working-directory: ./cluster
       run: |
+        cd cluster
         git fetch --tags
         echo "latest_release=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_ENV
 
@@ -39,31 +39,31 @@ jobs:
 
     - name: Check if branch exists in cluster-aws repo
       id: check_branch
-      working-directory: ./cluster-aws
       run: |
+        cd cluster-aws
         branch_name="test-cluster-chart-pr-${{ github.event.issue.number }}"
         if git ls-remote --heads "https://github.com/giantswarm/cluster-aws.git" $branch_name; then
-        echo "branch_exists=true" >> $GITHUB_ENV
+          echo "branch_exists=true" >> $GITHUB_ENV
         else
-        echo "branch_exists=false" >> $GITHUB_ENV
+          echo "branch_exists=false" >> $GITHUB_ENV
         fi
         echo "cluster_aws_branch_name=$branch_name" >> $GITHUB_ENV
 
     - name: Create new cluster-aws branch
       if: env.branch_exists == 'false'
-      working-directory: ./cluster-aws
       run: |
+        cd cluster-aws
         git checkout -b ${{ env.cluster_aws_branch_name }}
 
     - name: Checkout existing cluster-aws branch
-      if: env.branch_exists == 'false'
-      working-directory: ./cluster-aws
+      if: env.branch_exists == 'true'
       run: |
+        cd cluster-aws
         git checkout ${{ env.cluster_aws_branch_name }}
 
     - name: Update cluster chart version in Chart.yaml
-      working-directory: ./cluster-aws/helm/cluster-aws
       run: |
+        cd cluster-aws/helm/cluster-aws
         current_version="$(yq e '.dependencies[] | select(.name == "cluster").version' Chart.yaml)"
         new_version="${{ env.latest_release }}-${{ env.commit_sha }}"
 
@@ -100,9 +100,10 @@ jobs:
 
     - name: Commit and push changes
       if: env.cluster_chart_version_updated == 'true'
-      working-directory: ./cluster-aws
       run: |
+        cd cluster-aws
         git add helm/cluster-aws/Chart.yaml
         git add helm/cluster-aws/Chart.lock
         git commit -m "Update cluster chart version to ${{ env.latest_release }}-${{ env.commit_sha }}"
-        git push origin ${{ env.cluster_aws_branch_name }}
+        echo "Will push now"
+        # git push origin ${{ env.cluster_aws_branch_name }}

--- a/.github/workflows/trigger-cluster-test-suites.yaml
+++ b/.github/workflows/trigger-cluster-test-suites.yaml
@@ -43,7 +43,13 @@ jobs:
       id: check_branch
       run: |
         cd cluster-aws
-        branch_name="test-cluster-chart-pr-${{ github.event.issue.number }}"
+        pr_number="${{ github.event.issue.number }}"
+        if [ -z "$pr_number" ]; then
+          pr_number="${{ github.event.number }}"
+        fi
+        echo "Pull request number is $pr_number."
+        
+        branch_name="test-cluster-chart-pr-$pr_number"
         if git ls-remote --heads "https://github.com/giantswarm/cluster-aws.git" $branch_name; then
           echo "branch_exists=true" >> $GITHUB_ENV
         else

--- a/.github/workflows/trigger-cluster-test-suites.yaml
+++ b/.github/workflows/trigger-cluster-test-suites.yaml
@@ -49,13 +49,17 @@ jobs:
         fi
         echo "Pull request number is $pr_number."
         
+        # Check if branch exists
         branch_name="test-cluster-chart-pr-$pr_number"
-        if git ls-remote --heads "https://github.com/giantswarm/cluster-aws.git" $branch_name; then
+        echo "cluster_aws_branch_name=$branch_name" >> $GITHUB_ENV
+        repo_url="https://github.com/giantswarm/cluster-aws"
+        if git ls-remote --heads "$repo_url" | grep -q "refs/heads/$branch_name"; then
+          echo "Found that cluster-aws already has the branch $branch_name. Will update it if needed."
           echo "branch_exists=true" >> $GITHUB_ENV
         else
+          echo "Found that cluster-aws does not have the branch $branch_name. Will create it."
           echo "branch_exists=false" >> $GITHUB_ENV
         fi
-        echo "cluster_aws_branch_name=$branch_name" >> $GITHUB_ENV
 
     - name: Create new cluster-aws branch
       if: env.branch_exists == 'false'

--- a/.github/workflows/trigger-cluster-test-suites.yaml
+++ b/.github/workflows/trigger-cluster-test-suites.yaml
@@ -137,6 +137,8 @@ jobs:
         git add helm/cluster-aws/Chart.lock
         git commit -m "Update cluster chart version to ${{ env.custom_cluster_chart_version }}"
         git push origin ${{ env.cluster_aws_branch_name }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.TAYLORBOT_GITHUB_ACTION }}
 
     - name: Create a draft pull request
       if: env.branch_exists == 'false'

--- a/.github/workflows/trigger-cluster-test-suites.yaml
+++ b/.github/workflows/trigger-cluster-test-suites.yaml
@@ -136,5 +136,11 @@ jobs:
         git add helm/cluster-aws/Chart.yaml
         git add helm/cluster-aws/Chart.lock
         git commit -m "Update cluster chart version to ${{ env.custom_cluster_chart_version }}"
-        echo "Will push now"
-        # git push origin ${{ env.cluster_aws_branch_name }}
+        git push origin ${{ env.cluster_aws_branch_name }}
+
+    - name: Create a draft pull request
+      if: env.branch_exists == 'false'
+      run: |
+        gh pr create --repo giantswarm/cluster-aws --head ${{ env.cluster_aws_branch_name }} --title "[DO NOT MERGE] Testing cluster chart PR #${{ github.event.issue.number }}" --body "This PR updates the cluster chart version to ${{ env.latest_release }}-${{ env.commit_sha }} in order to test cluster chart PR #${{ github.event.issue.number }}.\n\nThis PR will be closed automatically when cluster chart PR is closed." --draft
+      env:
+        GITHUB_TOKEN: ${{ secrets.TAYLORBOT_GITHUB_ACTION }}

--- a/.github/workflows/trigger-cluster-test-suites.yaml
+++ b/.github/workflows/trigger-cluster-test-suites.yaml
@@ -167,6 +167,8 @@ jobs:
         body="$body\n> DO NOT MERGE! This PR has been created automatically by @taylorbot on behalf of {{ env.cluster_chart_pr_author_name }} (@{{ env.cluster_chart_pr_author_username }})"
         body="$body\n\n### Changes"
         body="$body\n\nUpdate the cluster chart version to ${{ env.custom_cluster_chart_version }} in order to test @{{ env.cluster_chart_pr_author_username }}'s cluster chart PR https://github.com/giantswarm/cluster/pull/${{ env.cluster_chart_pr_number }}."
+        body="$body\n\n### Testing"
+        body="$body\n\nPlease comment this pull request with \`/run cluster-test-suites\` in order to run e2e tests."
         # body="$body\n\n> [!NOTE]"
         # body="$body\n> This PR will be closed automatically when the cluster chart PR is closed."
         

--- a/.github/workflows/trigger-cluster-test-suites.yaml
+++ b/.github/workflows/trigger-cluster-test-suites.yaml
@@ -24,8 +24,8 @@ jobs:
 
     - name: Extract latest cluster chart release
       id: latest_release
+      working-directory: ./cluster
       run: |
-        cd cluster
         git fetch --tags
         echo "latest_release=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_ENV
 
@@ -37,14 +37,72 @@ jobs:
       run: |
         git clone https://github.com/giantswarm/cluster-aws.git
 
-    - name: Update cluster chart version in Chart.yaml
+    - name: Check if branch exists in cluster-aws repo
+      id: check_branch
+      working-directory: ./cluster-aws
       run: |
-        cd cluster-aws/helm/cluster-aws
+        branch_name="test-cluster-chart-pr-${{ github.event.issue.number }}"
+        if git ls-remote --heads "https://github.com/giantswarm/cluster-aws.git" $branch_name; then
+        echo "branch_exists=true" >> $GITHUB_ENV
+        else
+        echo "branch_exists=false" >> $GITHUB_ENV
+        fi
+        echo "cluster_aws_branch_name=$branch_name" >> $GITHUB_ENV
+
+    - name: Create new cluster-aws branch
+      if: env.branch_exists == 'false'
+      working-directory: ./cluster-aws
+      run: |
+        git checkout -b ${{ env.cluster_aws_branch_name }}
+
+    - name: Checkout existing cluster-aws branch
+      if: env.branch_exists == 'false'
+      working-directory: ./cluster-aws
+      run: |
+        git checkout ${{ env.cluster_aws_branch_name }}
+
+    - name: Update cluster chart version in Chart.yaml
+      working-directory: ./cluster-aws/helm/cluster-aws
+      run: |
         current_version="$(yq e '.dependencies[] | select(.name == "cluster").version' Chart.yaml)"
         new_version="${{ env.latest_release }}-${{ env.commit_sha }}"
-        
+
         if [ $new_version != $current_version ]; then
-          echo "Updating cluster chart version from $current_version to $new_version"
+          echo "Updating cluster chart version"
+          yq e '.dependencies[] |= select(.name == "cluster") * {"version": strenv(new_version)}' -i Chart.yaml
+
+          # Retry logic for helm dependency update
+          retry=0
+          max_retries=20
+          success=false
+
+          while [ $retry -lt $max_retries ]; do
+            if helm dependency update; then
+              success=true
+              break
+            else
+              retry=$((retry + 1))
+              echo "Retry $retry/$max_retries: helm dependency update failed, retrying in 15 seconds..."
+              sleep 15
+            fi
+          done
+
+          if [ "$success" = false ]; then
+            echo "helm dependency update failed after $max_retries retries"
+            exit 1
+          fi
+
+          echo "cluster_chart_version_updated=true" >> $GITHUB_ENV
         else
-          echo "Cluster chart version $current_version is already up-to-date."
+          echo "Cluster chart version is already up-to-date."
+          echo "cluster_chart_version_updated=false" >> $GITHUB_ENV
         fi
+
+    - name: Commit and push changes
+      if: env.cluster_chart_version_updated == 'true'
+      working-directory: ./cluster-aws
+      run: |
+        git add helm/cluster-aws/Chart.yaml
+        git add helm/cluster-aws/Chart.lock
+        git commit -m "Update cluster chart version to ${{ env.latest_release }}-${{ env.commit_sha }}"
+        git push origin ${{ env.cluster_aws_branch_name }}

--- a/.github/workflows/trigger-cluster-test-suites.yaml
+++ b/.github/workflows/trigger-cluster-test-suites.yaml
@@ -32,19 +32,29 @@ jobs:
       run: |
         git clone https://github.com/giantswarm/cluster.git
 
-    - name: Get cluster chart PR number
+    - name: Get cluster chart pull request details
       run: |
+        # Get pull request number
         cluster_chart_pr_number="${{ github.event.issue.number }}"
         if [ -z "$cluster_chart_pr_number" ]; then
           cluster_chart_pr_number="${{ github.event.number }}"
         fi
         echo "Pull request number is $cluster_chart_pr_number."
         echo "cluster_chart_pr_number=$cluster_chart_pr_number" >> $GITHUB_ENV
+        
+        cluster_chart_pr_details=$(gh pr view $cluster_chart_pr_number --json "author,headRefName")
+        
+        # Get pull request author details
+        cluster_chart_pr_author_username=$(echo $cluster_chart_pr_details | jq -r '.author.login')
+        cluster_chart_pr_author_name=$(echo $cluster_chart_pr_details | jq -r '.author.name')
+        echo "cluster_chart_pr_author_username=$cluster_chart_pr_author_username" >> $GITHUB_ENV
+        echo "cluster_chart_pr_author_name=$cluster_chart_pr_author_name" >> $GITHUB_ENV
+        
+        # Get pull request head branch name (the branch that has changes)
+        cluster_chart_pr_branch_name=$(echo $cluster_chart_pr_details | jq -r '.headRefName')
+        echo "cluster_chart_pr_branch_name=$cluster_chart_pr_branch_name" >> $GITHUB_ENV
 
-    - name: Get custom cluster chart version and PR author
-      id: latest_release
-      env:
-        GITHUB_TOKEN: "${{ secrets.TAYLORBOT_GITHUB_ACTION }}"
+    - name: Get cluster chart custom version for the pull request
       run: |
         cd cluster
         git fetch --tags
@@ -53,15 +63,7 @@ jobs:
         latest_release=$(git describe --tags $(git rev-list --tags --max-count=1))
         latest_release="${latest_release#v}"
         
-        # Now let's get the SHA of the latest commit on the tested branch
-        # Fetch the PR details using GitHub CLI
-        pr_details=$(gh pr view ${{ env.cluster_chart_pr_number }} --json "author,headRefName")
-        
-        author=$(echo $pr_details | jq -r '.author')
-        echo "cluster_chart_pr_author=$author" >> $GITHUB_ENV
-        
-        branch_name=$(echo $pr_details | jq -r '.headRefName')
-        git checkout $branch_name
+        git checkout "${{ env.cluster_chart_pr_branch_name }}"
         latest_commit_sha=$(git rev-parse --verify HEAD)
         
         echo "Custom cluster chart version is $latest_release-$latest_commit_sha"
@@ -159,9 +161,11 @@ jobs:
         title="[DO NOT MERGE] Testing cluster chart PR #${{ env.cluster_chart_pr_number }}"
         
         body="> [!WARNING]"
-        body="$body\n> DO NOT MERGE! This PR has been created automatically by @taylorbot on behalf of @{{ env.cluster_chart_pr_author }}"
-        body="$body\n\nUpdate the cluster chart version to ${{ env.custom_cluster_chart_version }} in order to test @{{ env.cluster_chart_pr_author }}'s' cluster chart PR https://github.com/giantswarm/cluster/pull/${{ env.cluster_chart_pr_number }}."
-        body="$body\n\nThis PR will be closed automatically when the cluster chart PR is closed."
+        body="$body\n> DO NOT MERGE! This PR has been created automatically by @taylorbot on behalf of {{ env.cluster_chart_pr_author_name }} (@{{ env.cluster_chart_pr_author_username }})"
+        body="$body\n\n### Changes"
+        body="$body\n\nUpdate the cluster chart version to ${{ env.custom_cluster_chart_version }} in order to test @{{ env.cluster_chart_pr_author_username }}'s cluster chart PR https://github.com/giantswarm/cluster/pull/${{ env.cluster_chart_pr_number }}."
+        body="$body\n\n> [!NOTE]"
+        body="$body\n> This PR will be closed automatically when the cluster chart PR is closed."
         
         echo -e "$body" | gh pr create --repo giantswarm/cluster-aws --head ${{ env.cluster_aws_branch_name }} --title "$title" --draft -
       env:

--- a/.github/workflows/trigger-cluster-test-suites.yaml
+++ b/.github/workflows/trigger-cluster-test-suites.yaml
@@ -97,6 +97,7 @@ jobs:
         if [ $new_version != $current_version ]; then
           echo "Updating cluster chart version"
           new_version="$new_version" yq e '.dependencies[] |= select(.name == "cluster") * {"version": strenv(new_version)}' -i Chart.yaml
+          yq e '.dependencies[] |= select(.name == "cluster") * {"repository": "https://giantswarm.github.io/cluster-test-catalog"}' -i Chart.yaml
           
           echo "Updated cluster chart version. Chart.yaml content is now:\n"
           cat Chart.yaml

--- a/.github/workflows/trigger-cluster-test-suites.yaml
+++ b/.github/workflows/trigger-cluster-test-suites.yaml
@@ -166,8 +166,8 @@ jobs:
         body="$body\n> DO NOT MERGE! This PR has been created automatically by @taylorbot on behalf of {{ env.cluster_chart_pr_author_name }} (@{{ env.cluster_chart_pr_author_username }})"
         body="$body\n\n### Changes"
         body="$body\n\nUpdate the cluster chart version to ${{ env.custom_cluster_chart_version }} in order to test @{{ env.cluster_chart_pr_author_username }}'s cluster chart PR https://github.com/giantswarm/cluster/pull/${{ env.cluster_chart_pr_number }}."
-#        body="$body\n\n> [!NOTE]"
-#        body="$body\n> This PR will be closed automatically when the cluster chart PR is closed."
+        # body="$body\n\n> [!NOTE]"
+        # body="$body\n> This PR will be closed automatically when the cluster chart PR is closed."
         
         echo -e "$body" | gh pr create --repo giantswarm/cluster-aws --head ${{ env.cluster_aws_branch_name }} --title "$title" --draft --label testing --label do-not-merge/hold -
       env:

--- a/.github/workflows/trigger-cluster-test-suites.yaml
+++ b/.github/workflows/trigger-cluster-test-suites.yaml
@@ -81,7 +81,10 @@ jobs:
 
         if [ $new_version != $current_version ]; then
           echo "Updating cluster chart version"
-          yq e '.dependencies[] |= select(.name == "cluster") * {"version": strenv(new_version)}' -i Chart.yaml
+          new_version="$new_version" yq e '.dependencies[] |= select(.name == "cluster") * {"version": strenv(new_version)}' -i Chart.yaml
+          
+          echo "Updated cluster chart version. Chart.yaml content is now:\n"
+          cat Chart.yaml
 
           # Retry logic for helm dependency update
           retry=0

--- a/.github/workflows/trigger-cluster-test-suites.yaml
+++ b/.github/workflows/trigger-cluster-test-suites.yaml
@@ -41,7 +41,7 @@ jobs:
         echo "Pull request number is $cluster_chart_pr_number."
         echo "cluster_chart_pr_number=$cluster_chart_pr_number" >> $GITHUB_ENV
 
-    - name: Get custom cluster chart version
+    - name: Get custom cluster chart version and PR author
       id: latest_release
       env:
         GITHUB_TOKEN: "${{ secrets.TAYLORBOT_GITHUB_ACTION }}"
@@ -55,7 +55,11 @@ jobs:
         
         # Now let's get the SHA of the latest commit on the tested branch
         # Fetch the PR details using GitHub CLI
-        pr_details=$(gh pr view ${{ env.cluster_chart_pr_number }} --json headRefName)
+        pr_details=$(gh pr view ${{ env.cluster_chart_pr_number }} --json "author,headRefName")
+        
+        author=$(echo $pr_details | jq -r '.author')
+        echo "cluster_chart_pr_author=$author" >> $GITHUB_ENV
+        
         branch_name=$(echo $pr_details | jq -r '.headRefName')
         git checkout $branch_name
         latest_commit_sha=$(git rev-parse --verify HEAD)
@@ -152,6 +156,13 @@ jobs:
     - name: Create a draft pull request
       if: env.branch_exists == 'false'
       run: |
-        gh pr create --repo giantswarm/cluster-aws --head ${{ env.cluster_aws_branch_name }} --title "[DO NOT MERGE] Testing cluster chart PR #${{ github.event.issue.number }}" --body "Update the cluster chart version to ${{ env.custom_cluster_chart_version }} in order to test cluster chart PR #${{ github.event.issue.number }}.\n\nThis PR will be closed automatically when cluster chart PR is closed." --draft
+        title="[DO NOT MERGE] Testing cluster chart PR #${{ env.cluster_chart_pr_number }}"
+        
+        body="> [!WARNING]"
+        body="$body\n> DO NOT MERGE! This PR has been created automatically by @taylorbot on behalf of @{{ env.cluster_chart_pr_author }}"
+        body="$body\n\nUpdate the cluster chart version to ${{ env.custom_cluster_chart_version }} in order to test @{{ env.cluster_chart_pr_author }}'s' cluster chart PR https://github.com/giantswarm/cluster/pull/${{ env.cluster_chart_pr_number }}."
+        body="$body\n\nThis PR will be closed automatically when the cluster chart PR is closed."
+        
+        echo -e "$body" | gh pr create --repo giantswarm/cluster-aws --head ${{ env.cluster_aws_branch_name }} --title "$title" --draft -
       env:
         GITHUB_TOKEN: ${{ secrets.TAYLORBOT_GITHUB_ACTION }}


### PR DESCRIPTION
### What does this PR do?

This PR adds a GitHub workflow that automates creation of test PRs in cluster-aws in order to test cluster chart changes.

The workflow gets triggered for every cluster chart pull request. It has 2 jobs:
1. one to create/update test PRs in cluster-aws
2. one to close cluster-aws PRs when cluster chart PRs are closed/merged.

The job that creates/updates cluster-aws PRs will do the following (simplified steps):
- Clone cluster-aws repo.
- Create a new cluster-aws branch called `test-cluster-chart-pr-{{ cluster chart PR number }}`. If the branch already existed it just checks out that branch.
- Update cluster chart version in `test-cluster-chart-pr-{{ cluster chart PR number }}` branch by setting it to a cluster chart version from the tested cluster chart PR.
- Open/update cluster-aws draft PR. See example PR here https://github.com/giantswarm/cluster-aws/pull/689.

When cluster chart PR is closed, cluster-aws PR is closed as well.

### What is the effect of this change to users?

Giant Swarm engineers can easily test provider-independent changes for CAPA.

### Any background context you can provide?

CAPA is already GA, CAPZ will be GA soon, and all other providers will also soon start to use cluster chart, so without automated cross-provider testing the risk of issues slipping through cracks due to changes not being tested is very high.

### Should this change be mentioned in the release notes?

No. This is CI change, no need to be included in the release notes.