### PR TITLE
Feature Gates: Remove `CronJobTimeZone`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+This release removes the `CronJobTimeZone` feature gate as it becomes stable and is included in Kubernetes v1.29.
+
+For Kubernetes <v1.29, you will need to re-enable it using the respective values.
+
+### Removed
+
+- Feature Gates: Remove `CronJobTimeZone`. ([#267](https://github.com/giantswarm/cluster/pull/267))
+
 ## [0.35.0] - 2024-07-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ cluster:
             apiAudiences:
               templateName: awsApiServerApiAudiences # name of the Helm template that renders api-audiences value
             featureGates:
-              - enabled: true
-                name: CronJobTimeZone
+            - name: StatefulSetAutoDeletePVC
+              enabled: true
             serviceAccountIssuer:
               clusterDomainPrefix: irsa # which sets service-account-issuer to irsa.<cluster name>.<base domain>
 ```

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -363,8 +363,6 @@ providerIntegration:
           apiAudiences:
             templateName: "cluster.test.kubeadmControlPlane.kubeadmConfigSpec.clusterConfiguration.apiServer.apiAudiences"
           featureGates:
-          - name: CronJobTimeZone
-            enabled: true
           - name: DownwardAPIHugePages
             enabled: false
           serviceAccountIssuer:

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_controllermanager.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_controllermanager.tpl
@@ -25,11 +25,10 @@ extraVolumes:
 {{- end }}
 
 {{- define "cluster.internal.controlPlane.kubeadm.clusterConfiguration.controllerManager.featureGates" }}
-{{- $defaultFeatureGates := list (dict "name" "CronJobTimeZone" "enabled" true) }}
 {{- $providerFeatureGates := $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.controllerManager.featureGates | default list }}
 {{- $internalFeatureGates := $.Values.internal.advancedConfiguration.controlPlane.controllerManager.featureGates | default list }}
 {{- $mergedFeatureGates := dict }}
-{{- range (concat $defaultFeatureGates $providerFeatureGates $internalFeatureGates) }}
+{{- range (concat $providerFeatureGates $internalFeatureGates) }}
 {{- $_ := set $mergedFeatureGates (trim .name) .enabled }}
 {{- end }}
 {{- $featureGates := list }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_scheduler.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_scheduler.tpl
@@ -2,5 +2,4 @@
 extraArgs:
   authorization-always-allow-paths: "/healthz,/readyz,/livez,/metrics"
   bind-address: 0.0.0.0
-  feature-gates: CronJobTimeZone=true
 {{- end }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_initconfiguration.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_initconfiguration.tpl
@@ -11,7 +11,6 @@ nodeRegistration:
     cgroup-driver: cgroupfs
     {{- end }}
     cloud-provider: external
-    feature-gates: CronJobTimeZone=true
     healthz-bind-address: 0.0.0.0
     node-ip: {{ printf "${%s}" $.Values.providerIntegration.environmentVariables.ipv4 }}
     node-labels: ip={{ printf "${%s}" $.Values.providerIntegration.environmentVariables.ipv4 }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_joinconfiguration.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_joinconfiguration.tpl
@@ -9,7 +9,6 @@ nodeRegistration:
     cgroup-driver: cgroupfs
     {{- end }}
     cloud-provider: external
-    feature-gates: CronJobTimeZone=true
     node-ip: {{ printf "${%s}" $.Values.providerIntegration.environmentVariables.ipv4 }}
     node-labels: ip={{ printf "${%s}" $.Values.providerIntegration.environmentVariables.ipv4 }}
   name: {{ printf "${%s}" $.Values.providerIntegration.environmentVariables.hostName }}

--- a/helm/cluster/templates/clusterapi/workers/_helpers_joinconfiguration.tpl
+++ b/helm/cluster/templates/clusterapi/workers/_helpers_joinconfiguration.tpl
@@ -20,7 +20,6 @@ nodeRegistration:
     {{- if $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.cloudConfig  }}
     cloud-config: {{ $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.cloudConfig  }}
     {{- end }}
-    feature-gates: CronJobTimeZone=true
     healthz-bind-address: 0.0.0.0
     node-ip: {{ printf "${%s}" $.Values.providerIntegration.environmentVariables.ipv4 }}
     node-labels: ip={{ printf "${%s}" $.Values.providerIntegration.environmentVariables.ipv4 }},role=worker,giantswarm.io/machine-pool={{ include "cluster.resource.name" $ }}-{{ $nodePool.name }},{{- join "," $nodePool.config.customNodeLabels }}


### PR DESCRIPTION
This PR removes the `CronJobTimeZone` feature gate as it becomes stable and is included in Kubernetes v1.29.

For Kubernetes <v1.29, you will need to re-enable it using the respective values.