### PR TITLE
Add OS tooling named template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Apps: Add `observability-policies` v0.0.1. ([#283](https://github.com/giantswarm/cluster/pull/283))
+- `cluster.os.name` named template that returns the operating system name.
+- `cluster.os.releaseChannel` named template that returns the operating system release channel.
+- `cluster.os.version` named template that returns the operating system version.
+- `cluster.os.tooling.version` named template which is used to obtain the OS tooling (capi-image-builder) version.
 
 ### Changed
 
@@ -18,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Apps: Depend on `kyverno-crds` instead of `kyverno`. ([#285](https://github.com/giantswarm/cluster/pull/285))
 - Set `kubeProxyReplacement` to `'true'` instead of deprecated value `strict` in cilium values.
 - Apps: Bump `cluster-autoscaler` to v1.29.3-gs1. ([#286](https://github.com/giantswarm/cluster/pull/286))
+- Deprecate `cluster.component.flatcar.version` named template in favor of `cluster.os.version`.
 
 ## [1.0.0] - 2024-07-24
 

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -777,10 +777,11 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.kubeadmConfig.preKubeadmCommands` | **Pre-kubeadm commands** - Extra commands to run before kubeadm runs.|**Type:** `array`<br/>|
 | `providerIntegration.kubeadmConfig.preKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
 | `providerIntegration.kubernetesVersion` | **Kubernetes version**|**Type:** `string`<br/>**Default:** `"1.25.16"`|
-| `providerIntegration.osImage` | **OS image** - OS image properties|**Type:** `object`<br/>|
+| `providerIntegration.osImage` | **OS image (deprecated)** - OS image Helm values have been deprecated. All OS-related information should now be obtained from the Release resource.|**Type:** `object`<br/>|
 | `providerIntegration.osImage.channel` | **Channel**|**Type:** `string`<br/>**Default:** `"stable"`|
 | `providerIntegration.osImage.name` | **Name**|**Type:** `string`<br/>|
-| `providerIntegration.osImage.variant` | **Variant**|**Type:** `string`<br/>|
+| `providerIntegration.osImage.toolingVersion` | **Tooling version** - Version of tooling that is used to build the OS image. In practice, this is the capi-image-builder version.|**Type:** `string`<br/>|
+| `providerIntegration.osImage.variant` | **Variant (deprecated)** - The usage of variant has been deprecated, use toolingVersion instead. See cluster.component.os.tooling.version helper in order to use the new OS tooling version.|**Type:** `string`<br/>|
 | `providerIntegration.osImage.version` | **Version**|**Type:** `string`<br/>|
 | `providerIntegration.pauseProperties` | **Pause properties** - A map of property names and their values that will affect setting pause annotation|**Type:** `object`<br/>|
 | `providerIntegration.pauseProperties.*` |**None**|**Types:** `string, number, integer, boolean, null`<br/>|

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -930,6 +930,35 @@ subsections, each covering a specific topic.
 
 ### Operating system
 
+#### `cluster.os.name`
+
+Named template that returns the operating system name.
+
+It returns a fixed value "flatcar".
+
+cluster-\<provider\> charts should use this template when building the operating system image name.
+
+#### `cluster.os.releaseChannel`
+
+Named template that returns the operating system release channel.
+
+It returns "stable" for all providers by default.
+
+In case some provider temporarily needs to use a different OS release channel, the value can be overridden in the
+cluster-\<provider\> chart with cluster chart Helm value `.Values.providerIntegration.osImage.channel`. A change like
+this requires a new cluster-\<provider\> chart version and then a new workload cluster release version.
+
+cluster-\<provider\> charts should use this template when building the operating system image name.
+
+#### `cluster.os.version`
+
+Named template that returns the operating system version.
+
+If the provider is using the new releases with the Release resource, then the operating system version is obtained
+from the Release resource, otherwise it is obtained from the provider integration Helm value .
+
+cluster-\<provider\> charts should use this template when building the operating system image name.
+
 #### `cluster.os.tooling.version`
 
 Named template that returns the OS tooling version.
@@ -937,3 +966,5 @@ Named template that returns the OS tooling version.
 If the provider is using new releases with the Release resource, then the OS tooling version is obtained from the
 Release resource, otherwise it is obtained from the provider integration Helm value
 `.Values.providerIntegration.osImage.toolingVersion`.
+
+cluster-\<provider\> charts should use this template when building the operating system image name.

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -1,4 +1,9 @@
-# Values schema documentation
+# Cluster chart API documentation
+
+This document includes information about everything that is considered to be an API of the cluster chart, including
+Helm values and Helm helpers that can be used from other charts that include cluster chart as a subchart.
+
+## Values schema documentation
 
 This page lists all available configuration options, based on the [configuration values schema](values.schema.json).
 
@@ -912,3 +917,23 @@ Information about the workload cluster release.
 
 
 <!-- DOCS_END -->
+
+## Helm named templates
+
+All named templates that we have in the cluster chart can be divided into public, internal and test templates.
+
+Internal templates are those whose name has `cluster.internal.` prefix. Similarly, test templates are those with
+`cluster.test.` prefix in the name. All other named templates are public.
+
+This section contains the documentation for the public named templates. Templates are documented in multiple
+subsections, each covering a specific topic.
+
+### Operating system
+
+#### `cluster.os.tooling.version`
+
+Named template that returns the OS tooling version.
+
+If the provider is using new releases with the Release resource, then the OS tooling version is obtained from the
+Release resource, otherwise it is obtained from the provider integration Helm value
+`.Values.providerIntegration.osImage.toolingVersion`.

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -532,6 +532,8 @@ providerIntegration:
   kubernetesVersion: 1.25.16
   pauseProperties:
     global.connectivity.vpcMode: private
+  osImage:
+    toolingVersion: 1.2.3
   resourcesApi:
     clusterResourceEnabled: true
     controlPlaneResourceEnabled: true

--- a/helm/cluster/templates/_helpers.tpl
+++ b/helm/cluster/templates/_helpers.tpl
@@ -431,6 +431,8 @@ Where `data` is the data to hash and `global` is the top level scope.
     {{- $_ := set $ "componentName" "os-tooling" }}
     {{- $osToolingVersion := include "cluster.component.version" $ | trimPrefix "v" }}
     {{- $osToolingVersion }}
+{{- else if $.GiantSwarm.providerIntegration.osImage }}
+    {{- $.GiantSwarm.providerIntegration.osImage.toolingVersion }}
 {{- else if not $renderWithoutReleaseResource }}
     {{- fail "Cannot determine OS tooling version" }}
 {{- end }}

--- a/helm/cluster/templates/_helpers.tpl
+++ b/helm/cluster/templates/_helpers.tpl
@@ -394,7 +394,9 @@ Where `data` is the data to hash and `global` is the top level scope.
 {{- end }}
 
 {{/*
-  cluster.component.flatcar.version is a public named helper template that returns the Flatcar image variant. If the
+  DEPRECATED, use cluster.os.tooling.version instead.
+
+  cluster.component.flatcar.variant is a public named helper template that returns the Flatcar image variant. If the
   provider is using new Releases then the Flatcar image variant is obtained from the Release resources, otherwise it is
   obtained from Helm values.
 
@@ -412,5 +414,24 @@ Where `data` is the data to hash and `global` is the top level scope.
 {{- $.GiantSwarm.providerIntegration.osImage.variant }}
 {{- else }}
 {{- fail "Cannot determine Flatcar image variant" }}
+{{- end }}
+{{- end }}
+
+{{/*
+  cluster.os.tooling.version is a public named helper template that returns the OS tooling version.
+
+  If the provider is using new releases with the Release resource, then the OS tooling version is obtained from the
+  Release resource, otherwise it is obtained from the provider integration Helm values.
+*/}}
+{{- define "cluster.os.tooling.version" }}
+{{- $_ := include "cluster.internal.get-provider-integration-values" $ }}
+{{- $_ = include "cluster.internal.get-internal-values" $ }}
+{{- $renderWithoutReleaseResource := ((($.GiantSwarm.internal).ephemeralConfiguration).offlineTesting).renderWithoutReleaseResource | default false }}
+{{- if $.GiantSwarm.providerIntegration.useReleases }}
+    {{- $_ := set $ "componentName" "os-tooling" }}
+    {{- $osToolingVersion := include "cluster.component.version" $ | trimPrefix "v" }}
+    {{- $osToolingVersion }}
+{{- else if not $renderWithoutReleaseResource }}
+    {{- fail "Cannot determine OS tooling version" }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/_helpers.tpl
+++ b/helm/cluster/templates/_helpers.tpl
@@ -372,6 +372,8 @@ Where `data` is the data to hash and `global` is the top level scope.
 {{- end }}
 
 {{/*
+  DEPRECATED, use cluster.os.version instead.
+
   cluster.component.flatcar.version is a public named helper template that returns the Flatcar version. If the
   provider is using new Releases then the Flatcar version is obtained from the Release resources, otherwise it is
   obtained from Helm values.
@@ -418,10 +420,56 @@ Where `data` is the data to hash and `global` is the top level scope.
 {{- end }}
 
 {{/*
-  cluster.os.tooling.version is a public named helper template that returns the OS tooling version.
+  cluster.os.name is a public named template that returns the operating system name.
 
-  If the provider is using new releases with the Release resource, then the OS tooling version is obtained from the
-  Release resource, otherwise it is obtained from the provider integration Helm values.
+  It returns a fixed value "flatcar".
+
+  cluster-\<provider\> charts should use this template when building the operating system image name.
+*/}}
+{{- define "cluster.os.name" }}
+{{- print "flatcar" }}
+{{- end }}
+
+{{/*
+  cluster.os.releaseChannel is a public named template that returns the operating system release channel.
+
+  It returns "stable" for all providers by default.
+
+  In case some provider temporarily needs to use a different OS release channel, the value can be overridden in the
+  cluster-<provider> chart with cluster chart Helm value .Values.providerIntegration.osImage.channel. A change like this
+  requires a new cluster-<provider> chart version and then a new workload cluster release version.
+
+  cluster-\<provider\> charts should use this template when building the operating system image name.
+*/}}
+{{- define "cluster.os.releaseChannel" }}
+{{- $_ := include "cluster.internal.get-provider-integration-values" $ }}
+{{- $.GiantSwarm.providerIntegration.osImage.channel | default "stable" }}
+{{- end }}
+
+{{/*
+  cluster.os.version is a public named template that returns the operating system version.
+
+  If the provider is using the new releases with the Release resource, then the operating system version is obtained
+  from the Release resource, otherwise it is obtained from the provider integration Helm value.
+
+  Example usage in template:
+
+    version: {{ include "cluster.os.version" $ }}
+
+  cluster-\<provider\> charts should use this template when building the operating system image name.
+*/}}
+{{- define "cluster.os.version" }}
+{{- include "cluster.component.flatcar.version" $ }}
+{{- end }}
+
+{{/*
+  cluster.os.tooling.version is a public named template that returns the OS tooling version.
+
+  If the provider is using the new releases with the Release resource, then the OS tooling version is obtained from the
+  Release resource, otherwise it is obtained from the provider integration Helm value
+  .Values.providerIntegration.osImage.toolingVersion.
+
+  cluster-\<provider\> charts should use this template when building the operating system image name.
 */}}
 {{- define "cluster.os.tooling.version" }}
 {{- $_ := include "cluster.internal.get-provider-integration-values" $ }}

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -2576,8 +2576,8 @@
                 },
                 "osImage": {
                     "type": "object",
-                    "title": "OS image",
-                    "description": "OS image properties",
+                    "title": "OS image (deprecated)",
+                    "description": "OS image Helm values have been deprecated. All OS-related information should now be obtained from the Release resource.",
                     "properties": {
                         "channel": {
                             "type": "string",
@@ -2594,9 +2594,15 @@
                             "type": "string",
                             "title": "Name"
                         },
+                        "toolingVersion": {
+                            "type": "string",
+                            "title": "Tooling version",
+                            "description": "Version of tooling that is used to build the OS image. In practice, this is the capi-image-builder version."
+                        },
                         "variant": {
                             "type": "string",
-                            "title": "Variant"
+                            "title": "Variant (deprecated)",
+                            "description": "The usage of variant has been deprecated, use toolingVersion instead. See cluster.component.os.tooling.version helper in order to use the new OS tooling version."
                         },
                         "version": {
                             "type": "string",


### PR DESCRIPTION
### What does this PR do?

This PR adds `cluster.os.tooling.version` helper which is used to obtain the OS tooling (capi-image-builder) version that is then used to build the OS image name.

Also it adds few new and align names of existing OS-related named templates:
- `cluster.os.name` - new named template that returns the operating system name (fixed return value "flatcar").
- `cluster.os.releaseChannel` - new named template that returns the operating system release channel. It returns `.Values.providerIntegration.osImage.channel` which is "stable" by default for all providers (Helm value was already there, just the template is added here).
- `cluster.os.version` - just calls `cluster.component.flatcar.version` (while `cluster.component.flatcar.version` is marked as deprecated).

### What is the effect of this change to users?

Giant Swarm engineers can add and work with `os-tooling` component in the Release CR.

This version will be always present and it will change whenever there is a new version of some binary that is baked into the OS image, as well as when capi-image-builder itself has some changes which requires building new images.

When writing manifests in cluster-\<provider\> charts, Giant Swarm engineers can now also use a set of public named templates from cluster chart (see above and see updated cluster chart docs). This way all changes in the implementation will happen in cluster chart only and will get applied to all providers by just updating cluster chart version.

### How does it look like?

(Please add anything that represents the change visually. Screenshots, output, logs, ...)

In the Release CR:

```
  components:
  - name: cluster-aws
    catalog: cluster
    version: 1.3.0
  - name: flatcar
    version: 3815.2.5
  - name: os-tooling
    version: 1.14.4
```

### Any background context you can provide?

https://github.com/giantswarm/roadmap/issues/3592

### Do the docs need to be updated?

Yes :heavy_check_mark: 

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
