### PR TITLE
Fix cluster.os.version template docs

### DIFF
--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -955,7 +955,7 @@ cluster-\<provider\> charts should use this template when building the operating
 Named template that returns the operating system version.
 
 If the provider is using the new releases with the Release resource, then the operating system version is obtained
-from the Release resource, otherwise it is obtained from the provider integration Helm value .
+from the Release resource, otherwise it is obtained from the provider integration Helm value `.Values.providerIntegration.osImage.version`.
 
 cluster-\<provider\> charts should use this template when building the operating system image name.
 


### PR DESCRIPTION
### What does this PR do?

Add missing Hem value reference in the docs. :see_no_evil: 

### Any background context you can provide?

Missed it in this PR https://github.com/giantswarm/cluster/pull/288.

### Should this change be mentioned in the release notes?

No.