### PR TITLE
Deprecate .Values.global.connectivity.network.allowAllEgress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Deprecate usage of `.Values.global.connectivity.network.allowAllEgress`.
+
 ## [1.1.0] - 2024-08-07
 
 ### Added

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -238,7 +238,7 @@ Configuration of connectivity and networking options.
 | `global.connectivity.bastion.enabled` | **Enable**|**Type:** `boolean`<br/>**Default:** `true`|
 | `global.connectivity.bastion.replicas` | **Number of hosts**|**Type:** `integer`<br/>**Default:** `1`|
 | `global.connectivity.network` | **Network**|**Type:** `object`<br/>|
-| `global.connectivity.network.allowAllEgress` | **Allow all egress**|**Type:** `boolean`<br/>**Default:** `false`|
+| `global.connectivity.network.allowAllEgress` | **Allow all egress (DEPRECATED)** - This flag has been deprecated. Currently the default value is false, which means that network-policies app will get installed. Setting this flag to true means that network-policies app is not installed, and that should not be done anymore.|**Type:** `boolean`<br/>**Default:** `false`|
 | `global.connectivity.network.pods` | **Pods**|**Type:** `object`<br/>|
 | `global.connectivity.network.pods.cidrBlocks` | **Pod subnets**|**Type:** `array`<br/>**Default:** `["100.64.0.0/12"]`|
 | `global.connectivity.network.pods.cidrBlocks[*]` | **Pod subnet** - IPv4 address range for pods, in CIDR notation.|**Type:** `string`<br/>**Example:** `"10.244.0.0/16"`<br/>|

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1372,7 +1372,8 @@
                             "properties": {
                                 "allowAllEgress": {
                                     "type": "boolean",
-                                    "title": "Allow all egress",
+                                    "title": "Allow all egress (DEPRECATED)",
+                                    "description": "This flag has been deprecated. Currently the default value is false, which means that network-policies app will get installed. Setting this flag to true means that network-policies app is not installed, and that should not be done anymore.",
                                     "default": false
                                 },
                                 "pods": {


### PR DESCRIPTION
### What does this PR do?

This PR deprecates the usage of `.Values.global.connectivity.network.allowAllEgress`.

Currently the default flag value is `false`, which means that `network-policies` app will get installed, which is desired. Setting this flag to true means that `network-policies` app is not installed, and we shouldn't disable network-policies like that anymore.

### What is the effect of this change to users?

Public API (global Helm value) that can disable netowork-policies app has been deprecated and should not be used anymore.

### Any background context you can provide?

Had more than few chats about network policies with KaaS folks. It all started here https://github.com/giantswarm/roadmap/issues/3125.

It looks like that the transition to Cilium network policies has left quite a few leftover configs across multiple (cluster-\<provider\>) apps.

I will open a similar PR in cluster-aws and cluster-azure.

cluster-vsphere has a similar flag `.internal.ciliumNetworkPolicies.enabled` which is being removed [here](https://github.com/giantswarm/cluster-vsphere/pull/262/files#diff-bb01af83b1bd47474d07984492d2206e5dc6cb461bf210f0c8bcc185d94ae2a0L112).

### What is needed from the reviewers?

Does this deprecation make sense? Do we still need this flag?

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
