### PR TITLE
Add toggle to enable creation of giantswarm user on nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add toggle to enable creation of `giantswarm` user on nodes.
+
 ### Changed
 
 - Deprecate usage of `.Values.global.connectivity.network.allowAllEgress`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Deprecate usage of `.Values.global.connectivity.network.allowAllEgress`.
+
 ## [1.1.0] - 2024-08-07
 
 ### Added

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -712,6 +712,7 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.environmentVariables.ipv4` | **IPv4** - Environment for IPv4.|**Type:** `string`<br/>|
 | `providerIntegration.hashSalt` | **Hash salt** - If specified, this token is used as a salt to the hash suffix of some resource names. Can be used to force-recreate some resources.|**Type:** `string`<br/>|
 | `providerIntegration.kubeadmConfig` | **Provider-specific kubeadm config** - Provider-specific kubeadm config that is common for all nodes, including both control plane and workers.|**Type:** `object`<br/>|
+| `providerIntegration.kubeadmConfig.enableGiantswarmUser` | **Enable giantswarm User** - If enabled, the giantswarm user will be created on all nodes.|**Type:** `boolean`<br/>**Default:** `false`|
 | `providerIntegration.kubeadmConfig.files` | **Files** - Provider-specific files that are deployed to all nodes. They are specified in the cluster-<provider> apps.|**Type:** `array`<br/>|
 | `providerIntegration.kubeadmConfig.files[*]` | **File from secret** - It defines a file with content in a Secret|**Type:** `object`<br/>|
 | `providerIntegration.kubeadmConfig.files[*].contentFrom` | **Content from** - It specifies where the file content is coming from.|**Type:** `object`<br/>|
@@ -781,7 +782,6 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.kubeadmConfig.postKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
 | `providerIntegration.kubeadmConfig.preKubeadmCommands` | **Pre-kubeadm commands** - Extra commands to run before kubeadm runs.|**Type:** `array`<br/>|
 | `providerIntegration.kubeadmConfig.preKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
-| `providerIntegration.kubeadmConfig.users` | **Users** - If enabled, the giantswarm user will be created on all nodes.|**Type:** `boolean`<br/>**Default:** `false`|
 | `providerIntegration.kubernetesVersion` | **Kubernetes version**|**Type:** `string`<br/>**Default:** `"1.25.16"`|
 | `providerIntegration.osImage` | **OS image (deprecated)** - OS image Helm values have been deprecated. All OS-related information should now be obtained from the Release resource.|**Type:** `object`<br/>|
 | `providerIntegration.osImage.channel` | **Channel**|**Type:** `string`<br/>**Default:** `"stable"`|

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -238,7 +238,7 @@ Configuration of connectivity and networking options.
 | `global.connectivity.bastion.enabled` | **Enable**|**Type:** `boolean`<br/>**Default:** `true`|
 | `global.connectivity.bastion.replicas` | **Number of hosts**|**Type:** `integer`<br/>**Default:** `1`|
 | `global.connectivity.network` | **Network**|**Type:** `object`<br/>|
-| `global.connectivity.network.allowAllEgress` | **Allow all egress**|**Type:** `boolean`<br/>**Default:** `false`|
+| `global.connectivity.network.allowAllEgress` | **Allow all egress (DEPRECATED)** - This flag has been deprecated. Currently the default value is false, which means that network-policies app will get installed. Setting this flag to true means that network-policies app is not installed, and that should not be done anymore.|**Type:** `boolean`<br/>**Default:** `false`|
 | `global.connectivity.network.pods` | **Pods**|**Type:** `object`<br/>|
 | `global.connectivity.network.pods.cidrBlocks` | **Pod subnets**|**Type:** `array`<br/>**Default:** `["100.64.0.0/12"]`|
 | `global.connectivity.network.pods.cidrBlocks[*]` | **Pod subnet** - IPv4 address range for pods, in CIDR notation.|**Type:** `string`<br/>**Example:** `"10.244.0.0/16"`<br/>|

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -781,6 +781,7 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.kubeadmConfig.postKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
 | `providerIntegration.kubeadmConfig.preKubeadmCommands` | **Pre-kubeadm commands** - Extra commands to run before kubeadm runs.|**Type:** `array`<br/>|
 | `providerIntegration.kubeadmConfig.preKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
+| `providerIntegration.kubeadmConfig.users` | **Users** - If enabled, the giantswarm user will be created on all nodes.|**Type:** `boolean`<br/>**Default:** `false`|
 | `providerIntegration.kubernetesVersion` | **Kubernetes version**|**Type:** `string`<br/>**Default:** `"1.25.16"`|
 | `providerIntegration.osImage` | **OS image (deprecated)** - OS image Helm values have been deprecated. All OS-related information should now be obtained from the Release resource.|**Type:** `object`<br/>|
 | `providerIntegration.osImage.channel` | **Channel**|**Type:** `string`<br/>**Default:** `"stable"`|

--- a/helm/cluster/files/helmreleases/cilium.yaml
+++ b/helm/cluster/files/helmreleases/cilium.yaml
@@ -3,7 +3,7 @@ configKey: cilium
 namespace: kube-system
 # used by renovate
 # repo: giantswarm/cilium-app
-version: 0.25.1
+version: 0.26.0
 defaultValues:
   # For all available values see https://github.com/giantswarm/cilium-app/blob/main/helm/cilium/values.yaml
   ipam:

--- a/helm/cluster/templates/clusterapi/_helpers_users.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_users.tpl
@@ -1,9 +1,7 @@
 {{- define "cluster.internal.kubeadm.users" }}
-{{- if $.Values.providerIntegration.resourcesApi.bastionResourceEnabled }}
-{{- if .Values.global.connectivity.bastion.enabled }}
+{{- if or (and .Values.providerIntegration.resourcesApi.bastionResourceEnabled .Values.global.connectivity.bastion.enabled) .Values.providerIntegration.kubeadmConfig.users }}
 - name: giantswarm
   groups: sudo
   sudo: ALL=(ALL) NOPASSWD:ALL
-{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/_helpers_users.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_users.tpl
@@ -1,5 +1,5 @@
 {{- define "cluster.internal.kubeadm.users" }}
-{{- if or (and .Values.providerIntegration.resourcesApi.bastionResourceEnabled .Values.global.connectivity.bastion.enabled) .Values.providerIntegration.kubeadmConfig.users }}
+{{- if or (and .Values.providerIntegration.resourcesApi.bastionResourceEnabled .Values.global.connectivity.bastion.enabled) .Values.providerIntegration.kubeadmConfig.enableGiantswarmUser }}
 - name: giantswarm
   groups: sudo
   sudo: ALL=(ALL) NOPASSWD:ALL

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1372,7 +1372,8 @@
                             "properties": {
                                 "allowAllEgress": {
                                     "type": "boolean",
-                                    "title": "Allow all egress",
+                                    "title": "Allow all egress (DEPRECATED)",
+                                    "description": "This flag has been deprecated. Currently the default value is false, which means that network-policies app will get installed. Setting this flag to true means that network-policies app is not installed, and that should not be done anymore.",
                                     "default": false
                                 },
                                 "pods": {

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -2567,6 +2567,12 @@
                         },
                         "preKubeadmCommands": {
                             "$ref": "#/$defs/preKubeadmCommands"
+                        },
+                        "users": {
+                            "type": "boolean",
+                            "title": "Users",
+                            "description": "If enabled, the giantswarm user will be created on all nodes.",
+                            "default": false
                         }
                     }
                 },

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -2551,6 +2551,12 @@
                     "description": "Provider-specific kubeadm config that is common for all nodes, including both control plane and workers.",
                     "additionalProperties": false,
                     "properties": {
+                        "enableGiantswarmUser": {
+                            "type": "boolean",
+                            "title": "Enable giantswarm User",
+                            "description": "If enabled, the giantswarm user will be created on all nodes.",
+                            "default": false
+                        },
                         "files": {
                             "type": "array",
                             "title": "Files",
@@ -2567,12 +2573,6 @@
                         },
                         "preKubeadmCommands": {
                             "$ref": "#/$defs/preKubeadmCommands"
-                        },
-                        "users": {
-                            "type": "boolean",
-                            "title": "Users",
-                            "description": "If enabled, the giantswarm user will be created on all nodes.",
-                            "default": false
                         }
                     }
                 },

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -198,12 +198,12 @@ providerIntegration:
       infrastructureMachineTemplate: {}
   environmentVariables: {}
   kubeadmConfig:
+    enableGiantswarmUser: false
     ignition:
       containerLinuxConfig:
         additionalConfig:
           storage: {}
           systemd: {}
-    users: false
   kubernetesVersion: 1.25.16
   osImage:
     channel: stable

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -203,6 +203,7 @@ providerIntegration:
         additionalConfig:
           storage: {}
           systemd: {}
+    users: false
   kubernetesVersion: 1.25.16
   osImage:
     channel: stable


### PR DESCRIPTION
### What does this PR do?

Decouples creation of the `giantswarm` user on nodes from the bastion machinedeployment.

### What is the effect of this change to users?

Nothing - the original chart behaviour is retained and the new behaviour is disabled by default (requires the provider chart integration to enable it on a per-cluster basis).

### Any background context you can provide?

CAPV and CAPVCD may not use the bastion machinedeployment as the bastions are often managed outside of the provider charts, however we still need the `giantswarm` user to exist on the nodes.

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
