### PR TITLE
Ensure SSH config is deployed to nodes when giantswarm user creation is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure SSH config is deployed to nodes when `giantswarm` user creation is enabled.
+
 ## [1.2.0] - 2024-08-14
 
 ### Added

--- a/helm/cluster/templates/clusterapi/_helpers_files.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_files.tpl
@@ -45,8 +45,7 @@
 {{- end }}
 
 {{- define "cluster.internal.kubeadm.files.ssh" }}
-{{- if $.Values.providerIntegration.resourcesApi.bastionResourceEnabled }}
-{{- if .Values.global.connectivity.bastion.enabled }}
+{{- if or (and .Values.providerIntegration.resourcesApi.bastionResourceEnabled .Values.global.connectivity.bastion.enabled) .Values.providerIntegration.kubeadmConfig.enableGiantswarmUser }}
 - path: /etc/ssh/trusted-user-ca-keys.pem
   permissions: "0600"
   encoding: base64
@@ -55,7 +54,6 @@
   permissions: "0600"
   encoding: base64
   content: {{ $.Files.Get "files/etc/ssh/sshd_config" | b64enc }}
-{{- end }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
### What does this PR do?

Deploys SSH config and SSH CA cert to nodes when the `giantswarm` user is enabled.

This was missed in #296

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
