### PR TITLE
Allow configuring `node-cidr-mask-size` flag on `kube-controller-manager`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Allow configuring `kube-controller-manager` `--node-cidr-mask-size` flag.
+
 ## [1.3.0] - 2024-09-06
 
 ### Added

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -244,6 +244,7 @@ Configuration of connectivity and networking options.
 | `global.connectivity.network.pods` | **Pods**|**Type:** `object`<br/>|
 | `global.connectivity.network.pods.cidrBlocks` | **Pod subnets**|**Type:** `array`<br/>**Default:** `["100.64.0.0/12"]`|
 | `global.connectivity.network.pods.cidrBlocks[*]` | **Pod subnet** - IPv4 address range for pods, in CIDR notation.|**Type:** `string`<br/>**Example:** `"10.244.0.0/16"`<br/>|
+| `global.connectivity.network.pods.nodeCidrMaskSize` | **Node CIDR mask size** - The size of the mask that is used for the node CIDR. The node CIDR is a sub-range of the pod CIDR and so the mask size and pod CIDR must be chosen such that there is enough space for the maximum number of nodes in the cluster.|**Type:** `integer`<br/>**Default:** `24`|
 | `global.connectivity.network.services` | **Services**|**Type:** `object`<br/>|
 | `global.connectivity.network.services.cidrBlocks` | **Kubernetes Service subnets**|**Type:** `array`<br/>**Default:** `["172.31.0.0/16"]`|
 | `global.connectivity.network.services.cidrBlocks[*]` | **Service subnet** - IPv4 address range for kubernetes services, in CIDR notation.|**Type:** `string`<br/>**Example:** `"172.31.0.0/16"`<br/>|

--- a/helm/cluster/files/etc/kubernetes/patches/kube-controller-manager0+json.yaml
+++ b/helm/cluster/files/etc/kubernetes/patches/kube-controller-manager0+json.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/containers/0/command/-
+  value: --node-cidr-mask-size={{ $.Values.global.connectivity.network.pods.nodeCidrMaskSize }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_files.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_files.tpl
@@ -65,6 +65,10 @@
   permissions: "0644"
   encoding: base64
   content: {{ tpl ($.Files.Get "files/etc/kubernetes/patches/kube-apiserver0+json.yaml") . | b64enc }}
+- path: /etc/kubernetes/patches/kube-controller-manager0+json.yaml
+  permissions: "0644"
+  encoding: base64
+  content: {{ tpl ($.Files.Get "files/etc/kubernetes/patches/kube-controller-manager0+json.yaml") . | b64enc }}
 {{- end }}
 {{- end }}
 

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1413,6 +1413,14 @@
                                             ],
                                             "maxItems": 1,
                                             "minItems": 1
+                                        },
+                                        "nodeCidrMaskSize": {
+                                            "type": "integer",
+                                            "title": "Node CIDR mask size",
+                                            "description": "The size of the mask that is used for the node CIDR. The node CIDR is a sub-range of the pod CIDR and so the mask size and pod CIDR must be chosen such that there is enough space for the maximum number of nodes in the cluster.",
+                                            "default": 24,
+                                            "maximum": 27,
+                                            "minimum": 16
                                         }
                                     }
                                 },

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -55,6 +55,7 @@ global:
       pods:
         cidrBlocks:
           - 100.64.0.0/12
+        nodeCidrMaskSize: 24
       services:
         cidrBlocks:
           - 172.31.0.0/16


### PR DESCRIPTION
### What does this PR do?

This allows setting the `node-cidr-mask-size` flag. The default is `/24` networks, however vintage default is `/25` which may create issues when migrating

### What is the effect of this change to users?

None on existing users, default is the same.

### How does it look like?

There is an addition value now.

### Any background context you can provide?

N/A

### What is needed from the reviewers?

N/A

### Do the docs need to be updated?

The docs in the readme have been updated, not sure how they relate to the giantswarm docs at the moment.

### Should this change be mentioned in the release notes?

Yes

- [x] CHANGELOG.md has been updated (if it exists)
