### PR TITLE
Only use customNodeLabels if it's set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Chart: Support multiple service account issuers.\
   Change `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.serviceAccountIssuer` to plural `providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.serviceAccountIssuers` and render them in the specified order as `--service-account-issuer` parameters for the API server.
 
+### Changed
+
+- Only add the `customNodeLabels` value to the kubelet `node-labels` argument in the `KubeadmConfig` when `customNodeLabels` is defined.
+
 ## [1.3.0] - 2024-09-06
 
 ### Added

--- a/helm/cluster/templates/clusterapi/workers/_helpers_joinconfiguration.tpl
+++ b/helm/cluster/templates/clusterapi/workers/_helpers_joinconfiguration.tpl
@@ -22,7 +22,7 @@ nodeRegistration:
     {{- end }}
     healthz-bind-address: 0.0.0.0
     node-ip: {{ printf "${%s}" $.Values.providerIntegration.environmentVariables.ipv4 }}
-    node-labels: ip={{ printf "${%s}" $.Values.providerIntegration.environmentVariables.ipv4 }},role=worker,giantswarm.io/machine-pool={{ include "cluster.resource.name" $ }}-{{ $nodePool.name }},{{- join "," $nodePool.config.customNodeLabels }}
+    node-labels: ip={{ printf "${%s}" $.Values.providerIntegration.environmentVariables.ipv4 }},role=worker,giantswarm.io/machine-pool={{ include "cluster.resource.name" $ }}-{{ $nodePool.name }}{{- if $nodePool.config.customNodeLabels }},{{ join "," $nodePool.config.customNodeLabels }}{{- end }}
     v: "2"
   {{- if $nodePool.config.customNodeTaints }}
   taints:


### PR DESCRIPTION
### What does this PR do?

I've seen a workload cluster that got created without setting `customNodeLabels`, and the kubelet arguments look like this (notice the trailing comma)
```
healthz-bind-address: 0.0.0.0
node-ip: ${COREOS_EC2_IPV4_LOCAL}
node-labels: ip=${COREOS_EC2_IPV4_LOCAL},role=worker,giantswarm.io/machine-pool=fer01-nodepool0,
v: "2"
```

With the change in this PR, the `customNodeLabels` are only appended to the argument if they are defined.

### What is the effect of this change to users?

Users can now skip setting the `customNodeLabels` field, and there won't be a trailing comma in the kubelet arguments.

### Should this change be mentioned in the release notes?

- [X] CHANGELOG.md has been updated (if it exists)
