### PR TITLE
Pass Template object through to generated systemd unit values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Pass `Template` object through to generated systemd unit values.
+
 ## [1.5.0] - 2024-10-03
 
 ### Added

--- a/helm/cluster/templates/bastion/_helpers_flatcar.tpl
+++ b/helm/cluster/templates/bastion/_helpers_flatcar.tpl
@@ -3,7 +3,7 @@ containerLinuxConfig:
   additionalConfig: |
     systemd:
       {{- if (((((($.Values.providerIntegration.bastion).kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).systemd).units }}
-      {{- $systemdUnitValues := dict "global" $.Values.global "units" $.Values.providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units }}
+      {{- $systemdUnitValues := dict "global" $.Values.global "Template" $.Template "units" $.Values.providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units }}
       units:
       {{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $systemdUnitValues | indent 6 }}
       {{- else }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_flatcar.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_flatcar.tpl
@@ -19,11 +19,11 @@ containerLinuxConfig:
 
 {{- define "cluster.internal.controlPlane.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" }}
 {{- if ((((($.Values.providerIntegration.kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).systemd).units }}
-{{- $systemdUnitValues := dict "global" $.Values.global "units" $.Values.providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units }}
+{{- $systemdUnitValues := dict "global" $.Values.global "Template" $.Template "units" $.Values.providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units }}
 {{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $systemdUnitValues }}
 {{- end }}
 {{- if (((((($.Values.providerIntegration.controlPlane).kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).systemd).units }}
-{{- $systemdUnitValues := dict "global" $.Values.global "units" $.Values.providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units }}
+{{- $systemdUnitValues := dict "global" $.Values.global "Template" $.Template "units" $.Values.providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units }}
 {{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $systemdUnitValues }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/workers/_helpers_flatcar.tpl
+++ b/helm/cluster/templates/clusterapi/workers/_helpers_flatcar.tpl
@@ -16,11 +16,11 @@ containerLinuxConfig:
 
 {{- define "cluster.internal.workers.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" }}
 {{- if ((((($.Values.providerIntegration.kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).systemd).units }}
-{{- $systemdUnitValues := dict "global" $.Values.global "units" $.Values.providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units }}
+{{- $systemdUnitValues := dict "global" $.Values.global "Template" $.Template "units" $.Values.providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units }}
 {{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $systemdUnitValues }}
 {{- end }}
 {{- if (((((($.Values.providerIntegration.workers).kubeadmConfig).ignition).containerLinuxConfig).additionalConfig).systemd).units }}
-{{- $systemdUnitValues := dict "global" $.Values.global "units" $.Values.providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units }}
+{{- $systemdUnitValues := dict "global" $.Values.global "Template" $.Template "units" $.Values.providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units }}
 {{- include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $systemdUnitValues }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
### What does this PR do?

Passes the root Template object into the generated dictionary used to template the systemd `additionalFields` value out.

### What is the effect of this change to users?

None, this is required to pass CI tests (ABS chart linting)

### How does it look like?

N/A

### Any background context you can provide?

Provider charts template out successfully locally, however when the chart linting steps are carried out in CI (on the provider chart), they fail with the following error:

```
[ERROR] templates/: template: cluster-cloud-director/charts/cluster/templates/clusterapi/workers/machinedeployment.yaml:38:79: executing "cluster-cloud-director/charts/cluster/templates/clusterapi/workers/machinedeployment.yaml" at <include "cluster.internal.workers.kubeadmConfig.spec.hash" $>: error calling include: template: cluster-cloud-director/charts/cluster/templates/clusterapi/workers/_helpers.tpl:2:12: executing "cluster.internal.workers.kubeadmConfig.spec.hash" at <include "cluster.internal.workers.kubeadmConfig.spec" $>: error calling include: template: cluster-cloud-director/charts/cluster/templates/clusterapi/workers/_helpers.tpl:8:6: executing "cluster.internal.workers.kubeadmConfig.spec" at <include "cluster.internal.workers.kubeadm.ignition" $>: error calling include: template: cluster-cloud-director/charts/cluster/templates/clusterapi/workers/_helpers_flatcar.tpl:8:10: executing "cluster.internal.workers.kubeadm.ignition" at <include "cluster.internal.workers.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $>: error calling include: template: cluster-cloud-director/charts/cluster/templates/clusterapi/workers/_helpers_flatcar.tpl:20:4: executing "cluster.internal.workers.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" at <include "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" $systemdUnitValues>: error calling include: template: cluster-cloud-director/charts/cluster/templates/clusterapi/_helpers_flatcar.tpl:76:7: executing "cluster.internal.kubeadm.ignition.containerLinuxConfig.additionalConfig.systemd.units" at <tpl .contents.service.additionalFields $>: error calling tpl: cannot retrieve Template.Basepath from values inside tpl function: {{- if $.global.connectivity.network.staticRoutes }}
ExecStart=/usr/bin/bash -cv 'sleep 3'
{{- range $.global.connectivity.network.staticRoutes }}
ExecStart=/usr/bin/bash -cv 'ip route add {{ .destination }} via {{ .via }}'
{{- end }}
{{- end }}: "BasePath" is not a value
```

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
