### PR TITLE
Added support for Upholds within unit section of custom systemd configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added support for `Upholds` within unit section of custom systemd configuration
+
 ## [1.5.1] - 2024-10-03
 
 ### Changed

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -593,6 +593,8 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents.unit.partOf[*]` |**None**|**Type:** `string`<br/>|
 | `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents.unit.requires` | **Requires** - systemd unit Requires.|**Type:** `array`<br/>|
 | `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents.unit.requires[*]` |**None**|**Type:** `string`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents.unit.upholds` | **Upholds** - systemd unit Upholds.|**Type:** `array`<br/>|
+| `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents.unit.upholds[*]` |**None**|**Type:** `string`<br/>|
 | `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents.unit.wants` | **Wants** - systemd unit Wants.|**Type:** `array`<br/>|
 | `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents.unit.wants[*]` |**None**|**Type:** `string`<br/>|
 | `providerIntegration.bastion.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins` | **Unit drop-ins** - The list of drop-ins for the unit|**Type:** `array`<br/>|
@@ -727,6 +729,8 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents.unit.partOf[*]` |**None**|**Type:** `string`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents.unit.requires` | **Requires** - systemd unit Requires.|**Type:** `array`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents.unit.requires[*]` |**None**|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents.unit.upholds` | **Upholds** - systemd unit Upholds.|**Type:** `array`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents.unit.upholds[*]` |**None**|**Type:** `string`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents.unit.wants` | **Wants** - systemd unit Wants.|**Type:** `array`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents.unit.wants[*]` |**None**|**Type:** `string`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins` | **Unit drop-ins** - The list of drop-ins for the unit|**Type:** `array`<br/>|
@@ -838,6 +842,8 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents.unit.partOf[*]` |**None**|**Type:** `string`<br/>|
 | `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents.unit.requires` | **Requires** - systemd unit Requires.|**Type:** `array`<br/>|
 | `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents.unit.requires[*]` |**None**|**Type:** `string`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents.unit.upholds` | **Upholds** - systemd unit Upholds.|**Type:** `array`<br/>|
+| `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents.unit.upholds[*]` |**None**|**Type:** `string`<br/>|
 | `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents.unit.wants` | **Wants** - systemd unit Wants.|**Type:** `array`<br/>|
 | `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents.unit.wants[*]` |**None**|**Type:** `string`<br/>|
 | `providerIntegration.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins` | **Unit drop-ins** - The list of drop-ins for the unit|**Type:** `array`<br/>|
@@ -982,6 +988,8 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents.unit.partOf[*]` |**None**|**Type:** `string`<br/>|
 | `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents.unit.requires` | **Requires** - systemd unit Requires.|**Type:** `array`<br/>|
 | `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents.unit.requires[*]` |**None**|**Type:** `string`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents.unit.upholds` | **Upholds** - systemd unit Upholds.|**Type:** `array`<br/>|
+| `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents.unit.upholds[*]` |**None**|**Type:** `string`<br/>|
 | `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents.unit.wants` | **Wants** - systemd unit Wants.|**Type:** `array`<br/>|
 | `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].contents.unit.wants[*]` |**None**|**Type:** `string`<br/>|
 | `providerIntegration.workers.kubeadmConfig.ignition.containerLinuxConfig.additionalConfig.systemd.units[*].dropins` | **Unit drop-ins** - The list of drop-ins for the unit|**Type:** `array`<br/>|

--- a/helm/cluster/templates/clusterapi/_helpers_flatcar.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_flatcar.tpl
@@ -41,6 +41,11 @@
     Requires={{ $requires }}
     {{- end }}
     {{- end }}
+    {{- if .contents.unit.upholds }}
+    {{- range $upholds := .contents.unit.upholds }}
+    Upholds={{ $upholds }}
+    {{- end }}
+    {{- end }}
     {{- if .contents.unit.wants }}
     {{- range $wants := .contents.unit.wants }}
     Wants={{ $wants }}

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1038,6 +1038,14 @@
                                         "type": "string"
                                     }
                                 },
+                                "upholds": {
+                                    "type": "array",
+                                    "title": "Upholds",
+                                    "description": "systemd unit Upholds.",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
                                 "wants": {
                                     "type": "array",
                                     "title": "Wants",


### PR DESCRIPTION
### What does this PR do?

Adds support for Upholds within unit section of custom systemd config

### What is the effect of this change to users?

N/A

### How does it look like?

N/A

### Any background context you can provide?

Required for cluster-cloud-director provider chart

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
