### PR TITLE
Teleport: Add initial join token & handling for it on service level

### DIFF
--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -887,8 +887,9 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.resourcesApi.machinePoolResourcesEnabled` | **Machine pool resources enabled** - Flag that indicates if the machine pool resources are enabled and templated. This is meant only for the initial development purposes for the sake of incrementally integrating cluster chart into cluster-$provider apps.|**Type:** `boolean`<br/>**Default:** `true`|
 | `providerIntegration.teleport` | **Teleport**|**Type:** `object`<br/>|
 | `providerIntegration.teleport.enabled` | **Enable teleport**|**Type:** `boolean`<br/>**Default:** `true`|
+| `providerIntegration.teleport.initialJoinToken` | **Teleport initial Node Join Token**|**Type:** `string`<br/>**Default:** `""`|
 | `providerIntegration.teleport.proxyAddr` | **Teleport proxy address**|**Type:** `string`<br/>**Default:** `"teleport.giantswarm.io:443"`|
-| `providerIntegration.teleport.version` | **Teleport version**|**Type:** `string`<br/>**Default:** `"14.1.3"`|
+| `providerIntegration.teleport.version` | **Teleport version**|**Type:** `string`<br/>**Default:** `"16.1.7"`|
 | `providerIntegration.useReleases` | **Use releases** - Flag that indicates if the provider is using release resources to get app and component versions.|**Type:** `boolean`<br/>**Default:** `false`|
 | `providerIntegration.workers` | **Provider-specific workers configuration**|**Type:** `object`<br/>|
 | `providerIntegration.workers.defaultNodePools` | **Default node pools**|**Type:** `object`<br/>|

--- a/helm/cluster/files/etc/teleport.yaml
+++ b/helm/cluster/files/etc/teleport.yaml
@@ -1,9 +1,15 @@
 version: v3
 teleport:
   data_dir: /var/lib/teleport
+  {{- if $.Values.providerIntegration.teleport.initialJoinToken }}
+  # Use initial token before Kubernetes is ready
+  auth_token: {{ $.Values.providerIntegration.teleport.initialJoinToken }}
+  {{- else }}
+  # Use token from secret file once Kubernetes is ready
   join_params:
     token_name: /etc/teleport-join-token
     method: token
+  {{- end }}
   proxy_server: {{ .Values.providerIntegration.teleport.proxyAddr }}
   log:
     output: stderr

--- a/helm/cluster/templates/clusterapi/_helpers_flatcar.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_flatcar.tpl
@@ -266,6 +266,11 @@
     [Service]
     Type=simple
     Restart=on-failure
+    # If kubelet is active, wait for token secret and swap config
+    ExecStartPre=/bin/sh -c 'if systemctl is-active kubelet.service; then \
+      while ! test -f /etc/teleport-join-token; do sleep 1; done; \
+      sed -i "s/auth_token:.*/join_params:\\n    token_name: \\/etc\\/teleport-join-token\\n    method: token/" /etc/teleport.yaml; \
+    fi'
     ExecStart=/opt/bin/teleport start --roles=node --config=/etc/teleport.yaml --pid-file=/run/teleport.pid
     ExecReload=/bin/kill -HUP $MAINPID
     PIDFile=/run/teleport.pid

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -2942,6 +2942,11 @@
                             "title": "Enable teleport",
                             "default": true
                         },
+                        "initialJoinToken": {
+                            "type": "string",
+                            "title": "Teleport initial Node Join Token",
+                            "default": ""
+                        },
                         "proxyAddr": {
                             "type": "string",
                             "title": "Teleport proxy address",
@@ -2951,11 +2956,6 @@
                             "type": "string",
                             "title": "Teleport version",
                             "default": "14.1.3"
-                        },
-                        "initialJoinToken": {
-                            "type": "string",
-                            "title": "Teleport initial Node Join Token",
-                            "default": ""
                         }
                     }
                 },

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -2951,6 +2951,11 @@
                             "type": "string",
                             "title": "Teleport version",
                             "default": "14.1.3"
+                        },
+                        "initialJoinToken": {
+                            "type": "string",
+                            "title": "Teleport initial Node Join Token",
+                            "default": ""
                         }
                     }
                 },

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -2955,7 +2955,7 @@
                         "version": {
                             "type": "string",
                             "title": "Teleport version",
-                            "default": "14.1.3"
+                            "default": "16.1.7"
                         }
                     }
                 },

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -223,7 +223,8 @@ providerIntegration:
   teleport:
     enabled: true
     proxyAddr: teleport.giantswarm.io:443
-    version: 14.1.3
+    version: 16.1.7
+    initialJoinToken: ""
   useReleases: false
   workers:
     kubeadmConfig:

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -222,9 +222,9 @@ providerIntegration:
     machinePoolResourcesEnabled: true
   teleport:
     enabled: true
-    proxyAddr: teleport.giantswarm.io:443
-    version: 16.1.7
     initialJoinToken: ""
+    proxyAddr: teleport.giantswarm.io:443
+    version: 14.1.3
   useReleases: false
   workers:
     kubeadmConfig:

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -224,7 +224,7 @@ providerIntegration:
     enabled: true
     initialJoinToken: ""
     proxyAddr: teleport.giantswarm.io:443
-    version: 14.1.3
+    version: 16.1.7
   useReleases: false
   workers:
     kubeadmConfig:


### PR DESCRIPTION
### What does this PR do?
Enables SSH access to nodes before Kubernetes is ready by introducing an initial Teleport join token. Once Kubernetes is ready, the service restarts to use the token from secret.

### Effect on users
- SSH access available immediately during node bootstrap
- No changes needed for existing clusters
- Optional `initialJoinToken` for new clusters needing early access

### Background
Currently, nodes require Kubernetes to be ready and nodes rolling before allowing SSH access. 
This creates issues when troubleshooting Kubernetes nodes while bootstraping.

### Reviewer focus needed on
- Token transition reliability
- Service restart handling

### Release notes
```markdown
- Added support for early SSH access during node bootstrap
```

- [x] CHANGELOG.md has been updated (if it exists)