### PR TITLE
set teleport data_dir: /teleport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - :warning: Kubernetes >= v1.30 **Remove outdated TLS cipher suites `TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305`.**
 - Changed `teleport` data directory to `/`
 
-
 ## [1.7.0] - 2024-12-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Changed `teleport` data directory to `/`
+
 - Improve `teleport` service reliability by adding proper file and service dependencies and pre-start checks
 
 ## [1.6.0] - 2024-10-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - :warning: Kubernetes >= v1.30 **Remove outdated TLS cipher suites `TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305`.**
+- Changed `teleport` data directory to `/`
+
 
 ## [1.7.0] - 2024-12-06
 
@@ -18,8 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `teleport-init` systemd unit to handle initial token setup before `teleport` service starts
 
 ### Changed
-
-- Changed `teleport` data directory to `/`
 
 - Improve `teleport` service reliability by adding proper file and service dependencies and pre-start checks
 

--- a/helm/cluster/files/etc/teleport.yaml
+++ b/helm/cluster/files/etc/teleport.yaml
@@ -1,6 +1,6 @@
 version: v3
 teleport:
-  data_dir: /var/lib/teleport
+  data_dir: /teleport
   join_params:
     token_name: /etc/teleport-join-token
     method: token


### PR DESCRIPTION
### What does this PR do?

Towards: https://github.com/giantswarm/roadmap/issues/3797

Changes `Teleport's` data directory to `/` to prevent login issues when `/var/lib` fills up.

### Should this change be mentioned in the release notes?

- [ ] CHANGELOG.md has been updated (if it exists)
