### PR TITLE
Helpers: Fail `cluster.app.catalog` if the app is not listed in the release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - :warning: Kubernetes >= v1.30 **Remove outdated TLS cipher suites `TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305`.**
 - Changed `teleport` data directory to `/`
+- Check that apps requested by `include "cluster.app.catalog"` are listed in the `Release` since else, empty catalog names are produced and the chart deploys fine but fails later at `App`/`HelmRelease` deployment
 
 ## [1.7.0] - 2024-12-06
 

--- a/helm/cluster/templates/_helpers.tpl
+++ b/helm/cluster/templates/_helpers.tpl
@@ -298,7 +298,7 @@ Where `data` is the data to hash and `global` is the top level scope.
 {{- $renderWithoutReleaseResource := ((($.GiantSwarm.internal).ephemeralConfiguration).offlineTesting).renderWithoutReleaseResource | default false }}
 {{- if $appCatalog }}
 {{- $appCatalog }}
-{{- else if $renderWithoutReleaseResource }}
+{{- else if $renderWithoutReleaseResource -}}
 fake-app-catalog-from-offline-cluster-chart-rendering
 {{- else }}
 {{- fail (printf "Application not found in Release/%s: %s" (($.GiantSwarm.Release).metadata).name $.appName) }}

--- a/helm/cluster/templates/_helpers.tpl
+++ b/helm/cluster/templates/_helpers.tpl
@@ -295,7 +295,14 @@ Where `data` is the data to hash and `global` is the top level scope.
 {{- end }}
 {{- end }}
 {{- end }}
+{{- $renderWithoutReleaseResource := ((($.GiantSwarm.internal).ephemeralConfiguration).offlineTesting).renderWithoutReleaseResource | default false }}
+{{- if $appCatalog }}
 {{- $appCatalog }}
+{{- else if $renderWithoutReleaseResource }}
+fake-app-catalog-from-offline-cluster-chart-rendering
+{{- else }}
+{{- fail (printf "Application not found in Release/%s: %s" (($.GiantSwarm.Release).metadata).name $.appName) }}
+{{- end }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
### What does this PR do?

Fail chart deployment instead of deploying this if a (new) application isn't listed in `Release.spec.apps`:

```
sourceRef:
  kind: HelmRepository
  name: mycluster-
```

### What is the effect of this change to users?

Invalid `Release`s can't even be deployed 👍 

### How does it look like?

No change

### Any background context you can provide?

I came here from a failing E2E test whose base `Release` didn't have the new aws-node-termination-handler application, as expected ([comment](https://github.com/giantswarm/cluster-aws/pull/945#issuecomment-2523133158)). I'd rather have a hard error and easy-to-troubleshoot E2E test that searching for an empty string deep within the YAML jungle.

### Do the docs need to be updated?

No

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
