### PR TITLE
Set install and upgrade retries of HelmReleases to -1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - :warning: Kubernetes >= v1.30 **Remove outdated TLS cipher suites `TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305`.**
 - Changed `teleport` data directory to `/`
 - Check that apps requested by `include "cluster.app.catalog"` are listed in the `Release` since else, empty catalog names are produced and the chart deploys fine but fails later at `App`/`HelmRelease` deployment
+- Set `.install.remediation.retries` of `.spec.install` and `.spec.upgrade` of HelmReleases to -1
 
 ## [1.7.0] - 2024-12-06
 

--- a/helm/cluster/templates/apps/helmreleases.yaml
+++ b/helm/cluster/templates/apps/helmreleases.yaml
@@ -88,7 +88,10 @@ spec:
   interval: {{ $app.interval | default "5m" }}
   install:
     remediation:
-      retries: 30
+      retries: -1
+  upgrade:
+    remediation:
+      retries: -1
   {{- /* We have multiple layers of app Helm values, where every next layer overwrites the previous one. */}}
   {{- /* Layer 1: default provider-independent app Helm values */}}
   {{- $appHelmValues := $app.defaultValues | default dict -}}


### PR DESCRIPTION
### What does this PR do?

- Set `spec.install.remediation.retries` to `-1` from previous `30`
- Set `spec.upgrade.remediation.retries` to `-1`. This wasn't set at all previously

### Any background context you can provide?

This is a follow up to PR https://github.com/giantswarm/cluster/pull/394 for https://github.com/giantswarm/roadmap/issues/3664

- [x] CHANGELOG.md has been updated (if it exists)
