### PR TITLE
Make nodeCidrMaskSize default to 25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed `teleport` data directory to `/`
 - Check that apps requested by `include "cluster.app.catalog"` are listed in the `Release` since else, empty catalog names are produced and the chart deploys fine but fails later at `App`/`HelmRelease` deployment
 - Set `.install.remediation.retries` of `.spec.install` and `.spec.upgrade` of HelmReleases to -1
+- Make `nodeCidrMaskSize` default to 25 instead of 24.
 
 ## [1.7.0] - 2024-12-06
 

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -244,7 +244,7 @@ Configuration of connectivity and networking options.
 | `global.connectivity.network.pods` | **Pods**|**Type:** `object`<br/>|
 | `global.connectivity.network.pods.cidrBlocks` | **Pod subnets**|**Type:** `array`<br/>**Default:** `["100.64.0.0/12"]`|
 | `global.connectivity.network.pods.cidrBlocks[*]` | **Pod subnet** - IPv4 address range for pods, in CIDR notation.|**Type:** `string`<br/>**Example:** `"10.244.0.0/16"`<br/>|
-| `global.connectivity.network.pods.nodeCidrMaskSize` | **Node CIDR mask size** - The size of the mask that is used for the node CIDR. The node CIDR is a sub-range of the pod CIDR and so the mask size and pod CIDR must be chosen such that there is enough space for the maximum number of nodes in the cluster.|**Type:** `integer`<br/>**Default:** `24`|
+| `global.connectivity.network.pods.nodeCidrMaskSize` | **Node CIDR mask size** - The size of the mask that is used for the node CIDR. The node CIDR is a sub-range of the pod CIDR and so the mask size and pod CIDR must be chosen such that there is enough space for the maximum number of nodes in the cluster.|**Type:** `integer`<br/>**Default:** `25`|
 | `global.connectivity.network.services` | **Services**|**Type:** `object`<br/>|
 | `global.connectivity.network.services.cidrBlocks` | **Kubernetes Service subnets**|**Type:** `array`<br/>**Default:** `["172.31.0.0/16"]`|
 | `global.connectivity.network.services.cidrBlocks[*]` | **Service subnet** - IPv4 address range for kubernetes services, in CIDR notation.|**Type:** `string`<br/>**Example:** `"172.31.0.0/16"`<br/>|

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1533,7 +1533,7 @@
                                             "type": "integer",
                                             "title": "Node CIDR mask size",
                                             "description": "The size of the mask that is used for the node CIDR. The node CIDR is a sub-range of the pod CIDR and so the mask size and pod CIDR must be chosen such that there is enough space for the maximum number of nodes in the cluster.",
-                                            "default": 24,
+                                            "default": 25,
                                             "maximum": 27,
                                             "minimum": 16
                                         }

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -55,7 +55,7 @@ global:
       pods:
         cidrBlocks:
           - 100.64.0.0/12
-        nodeCidrMaskSize: 24
+        nodeCidrMaskSize: 25
       services:
         cidrBlocks:
           - 172.31.0.0/16


### PR DESCRIPTION
### What does this PR do?

Towards https://github.com/giantswarm/giantswarm/issues/32461

### What is the effect of this change to users?

Each node in the cluster will take less pods.

### Any background context you can provide?

On vintage we used 25, so we wan to keep using it.

### Should this change be mentioned in the release notes?

- [X] CHANGELOG.md has been updated (if it exists)
