### PR TITLE
Escape PR branch name in workflow

### DIFF
--- a/.github/workflows/cluster-provider-test-pull-request.yaml
+++ b/.github/workflows/cluster-provider-test-pull-request.yaml
@@ -68,7 +68,7 @@ jobs:
         latest_release=$(gh release view --json tagName --jq ".tagName")
         latest_release="${latest_release#v}"
 
-        git checkout "${{ env.cluster_chart_pr_branch_name }}"
+        git checkout "${cluster_chart_pr_branch_name}"
         latest_commit_sha=$(git rev-parse --verify HEAD)
 
         echo "Custom cluster chart version is $latest_release-$latest_commit_sha"


### PR DESCRIPTION
### What does this PR do?

Towards https://github.com/giantswarm/giantswarm/issues/32276 / follow-up from https://github.com/giantswarm/cluster/pull/405. One more value to escape

### Do the docs need to be updated?

No

### Should this change be mentioned in the release notes?

No
