### PR TITLE
Apps: Remove source config from external-dns defaults.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Apps: Remove source config from external-dns defaults.
+
 ## [2.1.1] - 2025-03-03
 
 ### Changed

--- a/helm/cluster/files/apps/external-dns.yaml
+++ b/helm/cluster/files/apps/external-dns.yaml
@@ -17,7 +17,5 @@ defaultValues:
   txtPrefix: {{ $.Values.global.metadata.name }}
   registry: txt
   annotationFilter: giantswarm.io/external-dns=managed
-  sources:
-  - service
   ciliumNetworkPolicy:
     enabled: true


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

### What does this PR do?

remove source config from external-dns values

### Any background context you can provide?

Default value changed in the latest app, but this is overriding.

- [x] CHANGELOG.md has been updated (if it exists)
