### PR TITLE
Preventing container with Nvidia runtime taking down the whole node going OOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Preventing container with Nvidia runtime taking down the whole node going OOM by properly isolating the container.
+
 ### Removed
 
 - Apps: Remove source config from external-dns defaults.

--- a/helm/cluster/files/etc/containerd/workers-config.toml
+++ b/helm/cluster/files/etc/containerd/workers-config.toml
@@ -61,3 +61,4 @@ sandbox_image = "{{ include "cluster.image.registry" $ }}/{{ $.Values.providerIn
   privileged_without_host_devices = false
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
     BinaryName = "/usr/bin/nvidia-container-runtime"
+    SystemdCgroup = true

--- a/helm/cluster/tests/components/files/containerd_expected_with_cgroupsv1.toml
+++ b/helm/cluster/tests/components/files/containerd_expected_with_cgroupsv1.toml
@@ -37,3 +37,4 @@ sandbox_image = "gsoci.azurecr.io/giantswarm/pause:3.9"
   privileged_without_host_devices = false
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
     BinaryName = "/usr/bin/nvidia-container-runtime"
+    SystemdCgroup = true

--- a/helm/cluster/tests/components/files/containerd_nodepool_expected_with_cgroupsv1.toml
+++ b/helm/cluster/tests/components/files/containerd_nodepool_expected_with_cgroupsv1.toml
@@ -37,3 +37,4 @@ sandbox_image = "gsoci.azurecr.io/giantswarm/pause:3.9"
   privileged_without_host_devices = false
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
     BinaryName = "/usr/bin/nvidia-container-runtime"
+    SystemdCgroup = true

--- a/helm/cluster/tests/components/files/containerd_nodepool_expected_without_cgroupsv1.toml
+++ b/helm/cluster/tests/components/files/containerd_nodepool_expected_without_cgroupsv1.toml
@@ -37,3 +37,4 @@ sandbox_image = "gsoci.azurecr.io/giantswarm/pause:3.9"
   privileged_without_host_devices = false
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
     BinaryName = "/usr/bin/nvidia-container-runtime"
+    SystemdCgroup = true


### PR DESCRIPTION
I noticed when `nvidia-smi` is called within a container and there might be memory leaks, it might take down the whole node.

Setting `SystemdCgroup = true` will isolate the containers so it doesn't affect the whole node when having issues.

That has been also tested upstream, see https://github.com/flatcar/sysext-bakery/blob/main/create_nvidia_runtime_sysext.sh#L177-L180

