### PR TITLE
Enable different KSM custom resources in observability-bundle

### DIFF
--- a/helm/cluster/files/apps/observability-bundle.yaml
+++ b/helm/cluster/files/apps/observability-bundle.yaml
@@ -14,7 +14,7 @@ version: 1.12.0-632d76d83cf2f25a07bd8aa933891ea5848fc384
 catalog: default-test
 defaultValues:
   kubeStateMetricsCustomResources:
-    {{- if include "cluster.internal.isManagementCluster" $ }}
+    {{- if eq (include "cluster.internal.isManagementCluster" $) "true" }}
     flux_kustomization_v1: true
     flux_helmrelease_v2beta1: true
     flux_gitrepository_v1: true

--- a/helm/cluster/files/apps/observability-bundle.yaml
+++ b/helm/cluster/files/apps/observability-bundle.yaml
@@ -1,3 +1,16 @@
+{{- $ksmCustomResources := list -}}
+{{- if eq (include "cluster.internal.isManagementCluster" $) "true" }}
+  {{- $ksmCustomResources = concat $ksmCustomResources (list "flux_kustomization_v1" "flux_helmrelease_v2beta1" "flux_gitrepository_v1" "flux_bucket_v1beta2" "flux_helmrepository_v1beta1" "flux_helmchart_v1beta2" "flux_ocirepository_v1beta2" "flux_alert_v1beta2" "flux_provider_v1beta2" "flux_receiver_v1" "flux_imagerepository_v1beta2" "flux_imagepolicy_v1beta2" "flux_imageupdateautomation_v1beta1" "capi_machinehealthcheck_v1beta1" "capi_machinedeployment_v1beta1" "capi_machine_v1beta1" "capi_cluster_v1beta1" "capi_kubeadmcontrolplane_v1beta1" "capi_kubeadmconfig_v1beta1" "capi_machineset_v1beta1" "capi_machinepool_v1beta1") -}}
+
+  {{- if eq $.Values.providerIntegration.provider "azure" }}
+    {{- $ksmCustomResources = concat $ksmCustomResources (list "capi_azurecluster_v1beta1" "capi_azuremachine_v1beta1" "capi_azuremachinepool_v1beta1" "capi_azuremachinepoolmachine_v1beta1") -}}
+  {{- else if eq $.Values.providerIntegration.provider "cloud-director" }}
+    {{- $ksmCustomResources = concat $ksmCustomResources (list "capi_vcdcluster_v1beta2" "capi_vcdmachine_v1beta2") -}}
+  {{- else if eq $.Values.providerIntegration.provider "vsphere" }}
+    {{- $ksmCustomResources = concat $ksmCustomResources (list "capi_vspherecluster_v1beta1" "capi_vspheremachine_v1beta1" "capi_vspherevm_v1beta1") -}}
+  {{- end -}}
+{{- end -}}
+
 # Includes prometheus-operator-crd
 appName: observability-bundle
 configKey: observabilityBundle
@@ -10,43 +23,12 @@ dependsOn: coredns
 namespace: kube-system
 # used by renovate
 # repo: giantswarm/observability-bundle
-version: 1.12.0-632d76d83cf2f25a07bd8aa933891ea5848fc384
+version: 1.12.0-2bc911131b445bd48bdd35a4d55f195df3e7d9ef
 catalog: default-test
 defaultValues:
+  {{- if $ksmCustomResources }}
   kubeStateMetricsCustomResources:
-    {{- if eq (include "cluster.internal.isManagementCluster" $) "true" }}
-    flux_kustomization_v1: true
-    flux_helmrelease_v2beta1: true
-    flux_gitrepository_v1: true
-    flux_bucket_v1beta2: true
-    flux_helmrepository_v1beta1: true
-    flux_helmchart_v1beta2: true
-    flux_ocirepository_v1beta2: true
-    flux_alert_v1beta2: true
-    flux_provider_v1beta2: true
-    flux_receiver_v1: true
-    flux_imagerepository_v1beta2: true
-    flux_imagepolicy_v1beta2: true
-    flux_imageupdateautomation_v1beta1: true
-    capi_machinehealthcheck_v1beta1: true
-    capi_machinedeployment_v1beta1: true
-    capi_machine_v1beta1: true
-    capi_cluster_v1beta1: true
-    capi_kubeadmcontrolplane_v1beta1: true
-    capi_kubeadmconfig_v1beta1: true
-    capi_machineset_v1beta1: true
-    capi_machinepool_v1beta1: true
-    {{- if eq $.Values.providerIntegration.provider "azure" }}
-    capi_azurecluster_v1beta1: true
-    capi_azuremachine_v1beta1: true
-    capi_azuremachinepool_v1beta1: true
-    capi_azuremachinepoolmachine_v1beta1: true
-    {{- else if eq $.Values.providerIntegration.provider "cloud-director" }}
-    capi_vcdcluster_v1beta2: true
-    capi_vcdmachine_v1beta2: true
-    {{- else if eq $.Values.providerIntegration.provider "vsphere" }}
-    capi_vspherecluster_v1beta1: true
-    capi_vspheremachine_v1beta1: true
-    capi_vspherevm_v1beta1: true
+    {{- range $r := $ksmCustomResources }}
+    {{ $r }}: true
     {{- end }}
-    {{- end }}
+  {{- end }}

--- a/helm/cluster/files/apps/observability-bundle.yaml
+++ b/helm/cluster/files/apps/observability-bundle.yaml
@@ -10,7 +10,8 @@ dependsOn: coredns
 namespace: kube-system
 # used by renovate
 # repo: giantswarm/observability-bundle
-version: 1.12.0
+version: 1.12.0-632d76d83cf2f25a07bd8aa933891ea5848fc384
+catalog: default-test
 defaultValues:
   kubeStateMetricsCustomResources:
     {{- if include "cluster.internal.isManagementCluster" $ }}

--- a/helm/cluster/files/apps/observability-bundle.yaml
+++ b/helm/cluster/files/apps/observability-bundle.yaml
@@ -16,7 +16,7 @@ defaultValues:
     {{- if include "cluster.internal.hasKarpenterNodePool" $ }}
     karpenter_machine_v1: true
     {{- end }}
-    {{- if include "cluster.internal.isMC" $ }}
+    {{- if include "cluster.internal.isManagementCluster" $ }}
     flux_kustomization_v1: true
     flux_helmrelease_v2beta1: true
     flux_gitrepository_v1: true

--- a/helm/cluster/files/apps/observability-bundle.yaml
+++ b/helm/cluster/files/apps/observability-bundle.yaml
@@ -13,9 +13,6 @@ namespace: kube-system
 version: 1.12.0
 defaultValues:
   kubeStateMetricsCustomResources:
-    {{- if include "cluster.internal.hasKarpenterNodePool" $ }}
-    karpenter_machine_v1: true
-    {{- end }}
     {{- if include "cluster.internal.isManagementCluster" $ }}
     flux_kustomization_v1: true
     flux_helmrelease_v2beta1: true

--- a/helm/cluster/files/apps/observability-bundle.yaml
+++ b/helm/cluster/files/apps/observability-bundle.yaml
@@ -11,3 +11,44 @@ namespace: kube-system
 # used by renovate
 # repo: giantswarm/observability-bundle
 version: 1.12.0
+defaultValues:
+  kubeStateMetricsCustomResources:
+    {{- if include "cluster.internal.hasKarpenterNodePool" $ }}
+    karpenter_machine_v1: true
+    {{- end }}
+    {{- if include "cluster.internal.isMC" $ }}
+    flux_kustomization_v1: true
+    flux_helmrelease_v2beta1: true
+    flux_gitrepository_v1: true
+    flux_bucket_v1beta2: true
+    flux_helmrepository_v1beta1: true
+    flux_helmchart_v1beta2: true
+    flux_ocirepository_v1beta2: true
+    flux_alert_v1beta2: true
+    flux_provider_v1beta2: true
+    flux_receiver_v1: true
+    flux_imagerepository_v1beta2: true
+    flux_imagepolicy_v1beta2: true
+    flux_imageupdateautomation_v1beta1: true
+    capi_machinehealthcheck_v1beta1: true
+    capi_machinedeployment_v1beta1: true
+    capi_machine_v1beta1: true
+    capi_cluster_v1beta1: true
+    capi_kubeadmcontrolplane_v1beta1: true
+    capi_kubeadmconfig_v1beta1: true
+    capi_machineset_v1beta1: true
+    capi_machinepool_v1beta1: true
+    {{- if eq $.Values.providerIntegration.provider "azure" }}
+    capi_azurecluster_v1beta1: true
+    capi_azuremachine_v1beta1: true
+    capi_azuremachinepool_v1beta1: true
+    capi_azuremachinepoolmachine_v1beta1: true
+    {{- else if eq $.Values.providerIntegration.provider "cloud-director" }}
+    capi_vcdcluster_v1beta2: true
+    capi_vcdmachine_v1beta2: true
+    {{- else if eq $.Values.providerIntegration.provider "vsphere" }}
+    capi_vspherecluster_v1beta1: true
+    capi_vspheremachine_v1beta1: true
+    capi_vspherevm_v1beta1: true
+    {{- end }}
+    {{- end }}

--- a/helm/cluster/templates/_helpers.tpl
+++ b/helm/cluster/templates/_helpers.tpl
@@ -524,19 +524,6 @@ Where `data` is the data to hash and `global` is the top level scope.
 {{- end }}
 
 {{/*
-  cluster.internal.hasKarpenterNodePool is a public named template that returns true if the cluster has a Karpenter
-  node pool, otherwise it returns false.
-*/}}
-{{- define "cluster.internal.hasKarpenterNodePool" -}}
-{{- range $name, $value := (coalesce $.Values.global.nodePools $.Values.providerIntegration.workers.defaultNodePools) -}}
-  {{- if eq $value.nodepoolType "karpenter" -}}
-    {{- print "true" -}}
-    {{- break -}}
-  {{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
   cluster.internal.isManagementCluster is a public named template that returns true if the cluster is a management cluster, otherwise
   it returns false.
 */}}

--- a/helm/cluster/templates/_helpers.tpl
+++ b/helm/cluster/templates/_helpers.tpl
@@ -537,10 +537,10 @@ Where `data` is the data to hash and `global` is the top level scope.
 {{- end -}}
 
 {{/*
-  cluster.internal.isMC is a public named template that returns true if the cluster is a management cluster, otherwise
+  cluster.internal.isManagementCluster is a public named template that returns true if the cluster is a management cluster, otherwise
   it returns false.
 */}}
-{{- define "cluster.internal.isMC" -}}
+{{- define "cluster.internal.isManagementCluster" -}}
 {{- if eq $.Values.global.managementCluster (include "cluster.resource.name" $) -}}
   {{- print "true" -}}
 {{- else -}}

--- a/helm/cluster/templates/_helpers.tpl
+++ b/helm/cluster/templates/_helpers.tpl
@@ -522,3 +522,28 @@ Where `data` is the data to hash and `global` is the top level scope.
     {{- fail "Cannot determine OS tooling version" }}
 {{- end }}
 {{- end }}
+
+{{/*
+  cluster.internal.hasKarpenterNodePool is a public named template that returns true if the cluster has a Karpenter
+  node pool, otherwise it returns false.
+*/}}
+{{- define "cluster.internal.hasKarpenterNodePool" -}}
+{{- range $name, $value := (coalesce $.Values.global.nodePools $.Values.providerIntegration.workers.defaultNodePools) -}}
+  {{- if eq $value.nodepoolType "karpenter" -}}
+    {{- print "true" -}}
+    {{- break -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+  cluster.internal.isMC is a public named template that returns true if the cluster is a management cluster, otherwise
+  it returns false.
+*/}}
+{{- define "cluster.internal.isMC" -}}
+{{- if eq $.Values.global.managementCluster (include "cluster.resource.name" $) -}}
+  {{- print "true" -}}
+{{- else -}}
+  {{- print "false" -}}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
### What does this PR do?

(Please set a descriptive PR title. Use this space for additional explanations.)

It will enable different custom resources in KSM depending on different conditions:

- if there's karpenter it will enable the karpenter CRs (note that this is not yet ready. Will be part of cluster-aws with https://github.com/giantswarm/cluster-aws/pull/1038)
- if it's an MC it will enable the different CAPI provider CRs

Towards https://github.com/giantswarm/giantswarm/issues/32502

### What is the effect of this change to users?

### How does it look like?

(Please add anything that represents the change visually. Screenshots, output, logs, ...)

### Any background context you can provide?

(Please link public issues or summarize if not public.)

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [ ] CHANGELOG.md has been updated (if it exists)
