### PR TITLE
Refactor templating of custom node taints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Make HelmRelease options configurable per app.
 - Set Cilium HelmRelease timeout to 1hs and disable remediation.
+- Allow setting node taints without a value
 
 ## [2.2.0] - 2025-03-18
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ There are two control plane resources, KubeadmControlPlane and MachineHealthChec
 are `controlPlaneResourceEnabled` and `machineHealthCheckResourceEnabled`, respectively.
 
 Besides the above two resource flags, there are few other values that have to be specified:
-- Group, version and kind of the provider-specific machine template resources (e.g. AWSMachineTemplate, AzureMachineTemplate, 
+- Group, version and kind of the provider-specific machine template resources (e.g. AWSMachineTemplate, AzureMachineTemplate,
   etc.) which is done by setting `.Values.cluster.providerIntegration.controlPlane.resources.infrastructureMachineTemplate`,
 - Name of the Helm template that renders the spec of the provider-specific machine template, which is done by setting
   `.Values.cluster.providerIntegration.controlPlane.resources.infrastructureMachineTemplateSpecTemplateName`. E.g. in case
@@ -482,7 +482,7 @@ WantedBy=multi-user.target
 ```
 
 The Helm templating syntax is treated as plain text by the provider chart. The cluster chart's templating function has
-access to the values under the provider chart's `.global` key so any values referenced in the template must exist 
+access to the values under the provider chart's `.global` key so any values referenced in the template must exist
 under `.global`.
 
 Note that variable scoping is important here - the templating function does not have access to the root `$.Values` object,
@@ -498,3 +498,45 @@ P.S. `.Values.cluster.internal.advancedConfiguration` is the Helm value from the
 while that value inside of cluster chart is `.Values.internal.advancedConfiguration`.
 
 More details about customizing workload cluster Helm values TBA.
+
+
+## Maintaining `values.schema.json` and `values.yaml`
+
+**tldr**:
+We only maintain `values.schema.json` and automatically generate `values.yaml` from it.
+```
+make normalize-schema
+make validate-schema
+make generate-values
+make generate-docs
+```
+
+**Details**:
+
+In order to provide a better UX we validate user values against `values.schema.json`.
+In addition we also use the JSON schema in our frontend to dynamically generate a UI for cluster creation from it.
+To succesfully do this, we have some requirements on the `values.schema.json`, which are defined in [this RFC](https://github.com/giantswarm/rfc/pull/55).
+These requirements can be checked with [schemalint](https://github.com/giantswarm/schemalint).
+`schemalint` does a couple of things:
+
+- Normalize JSON schema (indentation, white space, sorting)
+- Validate whether your schema is valid JSON schema
+- Validate whether the requirements for cluster app schemas are met
+- Check whether schema is normalized
+
+The first point can be achieved with:
+```
+make normalize-schema
+```
+The second to fourth point can be achieved with:
+```
+make validate-schema
+```
+
+The JSON schema in `values.schema.json` should contain defaults defined with the `default` keyword.
+These defaults should be same as those defined in `values.yaml`.
+This allows us to generate `values.yaml` from `values.schema.json` with:
+
+```
+make generate-values
+```

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -26,6 +26,8 @@ global:
     - key: you
       value: shall
       effect: NoExecute
+    - key: has.no/value
+      effect: NoExecute
     oidc:
       clientId: hello
       groupsClaim: groupsClaim
@@ -46,6 +48,8 @@ global:
       - key: supernodepool
         value: hello
         effect: NoSchedule
+      - key: has.no/value
+        effect: NoExecute
     verybignodepool-1234:
       replicas: 100
       customNodeLabels:

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_initconfiguration.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_initconfiguration.tpl
@@ -15,7 +15,7 @@ nodeRegistration:
   name: {{ printf "${%s}" $.Values.providerIntegration.environmentVariables.hostName }}
   {{- with $.Values.global.controlPlane.customNodeTaints }}
   taints:
-    {{- nindent 2 (toYaml .) }}
+    {{- toYaml . | nindent 2 }}
   {{- end }}
 patches:
   directory: /etc/kubernetes/patches

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_initconfiguration.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_initconfiguration.tpl
@@ -13,15 +13,9 @@ nodeRegistration:
     node-labels: ip={{ printf "${%s}" $.Values.providerIntegration.environmentVariables.ipv4 }}
     v: "2"
   name: {{ printf "${%s}" $.Values.providerIntegration.environmentVariables.hostName }}
-  {{- if $.Values.global.controlPlane.customNodeTaints }}
-  {{- if (gt (len $.Values.global.controlPlane.customNodeTaints) 0) }}
+  {{- with $.Values.global.controlPlane.customNodeTaints }}
   taints:
-  {{- range $.Values.global.controlPlane.customNodeTaints }}
-  - key: {{ .key | quote }}
-    value: {{ .value | quote }}
-    effect: {{ .effect | quote }}
-  {{- end }}
-  {{- end }}
+    {{- nindent 2 (toYaml .) }}
   {{- end }}
 patches:
   directory: /etc/kubernetes/patches

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_joinconfiguration.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_joinconfiguration.tpl
@@ -11,7 +11,7 @@ nodeRegistration:
   name: {{ printf "${%s}" $.Values.providerIntegration.environmentVariables.hostName }}
   {{- with $.Values.global.controlPlane.customNodeTaints }}
   taints:
-    {{- nindent 2 (toYaml .) }}
+    {{- toYaml . | nindent 2 }}
   {{- end }}
 patches:
   directory: /etc/kubernetes/patches

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_joinconfiguration.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_joinconfiguration.tpl
@@ -9,15 +9,9 @@ nodeRegistration:
     node-ip: {{ printf "${%s}" $.Values.providerIntegration.environmentVariables.ipv4 }}
     node-labels: ip={{ printf "${%s}" $.Values.providerIntegration.environmentVariables.ipv4 }}
   name: {{ printf "${%s}" $.Values.providerIntegration.environmentVariables.hostName }}
-  {{- if $.Values.global.controlPlane.customNodeTaints }}
-  {{- if (gt (len $.Values.global.controlPlane.customNodeTaints) 0) }}
+  {{- with $.Values.global.controlPlane.customNodeTaints }}
   taints:
-  {{- range $.Values.global.controlPlane.customNodeTaints }}
-  - key: {{ .key | quote }}
-    value: {{ .value | quote }}
-    effect: {{ .effect | quote }}
-  {{- end }}
-  {{- end }}
+    {{- nindent 2 (toYaml .) }}
   {{- end }}
 patches:
   directory: /etc/kubernetes/patches

--- a/helm/cluster/templates/clusterapi/workers/_helpers_joinconfiguration.tpl
+++ b/helm/cluster/templates/clusterapi/workers/_helpers_joinconfiguration.tpl
@@ -26,7 +26,7 @@ nodeRegistration:
     v: "2"
   {{- with $nodePool.config.customNodeTaints }}
   taints:
-    {{- nindent 2 (toYaml .) }}
+    {{- toYaml . | nindent 2 }}
   {{- end }}
 patches:
   directory: /etc/kubernetes/patches

--- a/helm/cluster/templates/clusterapi/workers/_helpers_joinconfiguration.tpl
+++ b/helm/cluster/templates/clusterapi/workers/_helpers_joinconfiguration.tpl
@@ -24,13 +24,9 @@ nodeRegistration:
     node-ip: {{ printf "${%s}" $.Values.providerIntegration.environmentVariables.ipv4 }}
     node-labels: ip={{ printf "${%s}" $.Values.providerIntegration.environmentVariables.ipv4 }},role=worker,giantswarm.io/machine-pool={{ include "cluster.resource.name" $ }}-{{ $nodePool.name }}{{- if $nodePool.config.customNodeLabels }},{{ join "," $nodePool.config.customNodeLabels }}{{- end }}
     v: "2"
-  {{- if $nodePool.config.customNodeTaints }}
+  {{- with $nodePool.config.customNodeTaints }}
   taints:
-  {{- range $nodePool.config.customNodeTaints }}
-  - key: {{ .key | quote }}
-    value: {{ .value | quote }}
-    effect: {{ .effect | quote }}
-  {{- end }}
+    {{- nindent 2 (toYaml .) }}
   {{- end }}
 patches:
   directory: /etc/kubernetes/patches

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -87,8 +87,7 @@
                 "type": "object",
                 "required": [
                     "effect",
-                    "key",
-                    "value"
+                    "key"
                 ],
                 "properties": {
                     "effect": {
@@ -772,36 +771,7 @@
                     }
                 },
                 "customNodeTaints": {
-                    "type": "array",
-                    "title": "Custom node taints",
-                    "items": {
-                        "type": "object",
-                        "required": [
-                            "effect",
-                            "key",
-                            "value"
-                        ],
-                        "additionalProperties": false,
-                        "properties": {
-                            "effect": {
-                                "type": "string",
-                                "title": "Effect",
-                                "enum": [
-                                    "NoSchedule",
-                                    "PreferNoSchedule",
-                                    "NoExecute"
-                                ]
-                            },
-                            "key": {
-                                "type": "string",
-                                "title": "Key"
-                            },
-                            "value": {
-                                "type": "string",
-                                "title": "Value"
-                            }
-                        }
-                    }
+                    "$ref": "#/$defs/customNodeTaints"
                 },
                 "labels": {
                     "type": "object",


### PR DESCRIPTION
### What does this PR do?

The most important change is that the `value` attribute of a taint is actually optional, while it was marked as required in our value schema. I also updated the taint templating to use a `with` loop and `toYaml` for rendering the data instead of specifying individual dict keys.

### What is the effect of this change to users?

Users will be able to specify node taints without a value.

### How does it look like?

Taints look slightly different in the rendered output.

### Any background context you can provide?

Discovered while working on https://github.com/giantswarm/giantswarm/issues/31687

### What is needed from the reviewers?

_:sparkles: Good vibes :sparkles:_

### Do the docs need to be updated?

I doubt it.

### Should this change be mentioned in the release notes?

Would be nice.

- [x] CHANGELOG.md has been updated (if it exists)
