### PR TITLE
Enable setting taints on (all/worker/controller) nodes through provider integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for region-specific container registry mirror configuration via `mirrorsTemplateName` property.
 - Make `ntpd` configurable.
+- Enables setting taints on worker nodes, controller nodes, or all of them, by adding the following values:
+  - `providerIntegration.kubeadmConfig.taints`
+  - `providerIntegration.controlPlane.kubeadmConfig.taints`
+  - `providerIntegration.workers.kubeadmConfig.taints`
 
 ### Changed
 

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -275,7 +275,7 @@ Configuration of the control plane.
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
 | `global.controlPlane.apiServerPort` | **API server port** - The API server Load Balancer port. This option sets the Spec.ClusterNetwork.APIServerPort field on the Cluster CR. In CAPI this field isn't used currently. It is instead used in providers. In CAPA this sets only the public facing port of the Load Balancer. In CAPZ both the public facing and the destination port are set to this value. CAPV and CAPVCD do not use it.|**Type:** `integer`<br/>**Default:** `6443`|
-| `global.controlPlane.customNodeTaints` | **Custom node taints**|**Type:** `array`<br/>|
+| `global.controlPlane.customNodeTaints` | **Custom node taints**|**Type:** `array`<br/>**Default:** `[]`|
 | `global.controlPlane.customNodeTaints[*]` |**None**|**Type:** `object`<br/>|
 | `global.controlPlane.customNodeTaints[*].effect` | **Effect**|**Type:** `string`<br/>|
 | `global.controlPlane.customNodeTaints[*].key` | **Key**|**Type:** `string`<br/>|
@@ -431,7 +431,7 @@ Properties within the `.global.nodePools` object
 | `global.nodePools.PATTERN.cgroupsv1` | **Cgroups v1** - Flag that indicates if cgroups v1 should be used.|**Type:** `boolean`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>**Default:** `false`|
 | `global.nodePools.PATTERN.customNodeLabels` | **Node labels** - Labels that are passed to kubelet argument 'node-labels'.|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 | `global.nodePools.PATTERN.customNodeLabels[*]` | **Label**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
-| `global.nodePools.PATTERN.customNodeTaints` | **Custom node taints**|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
+| `global.nodePools.PATTERN.customNodeTaints` | **Custom node taints**|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>**Default:** `[]`|
 | `global.nodePools.PATTERN.customNodeTaints[*]` |**None**|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 | `global.nodePools.PATTERN.customNodeTaints[*].effect` | **Effect**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 | `global.nodePools.PATTERN.customNodeTaints[*].key` | **Key**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
@@ -771,6 +771,11 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.controlPlane.kubeadmConfig.postKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.preKubeadmCommands` | **Pre-kubeadm commands** - Extra commands to run before kubeadm runs.|**Type:** `array`<br/>|
 | `providerIntegration.controlPlane.kubeadmConfig.preKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.taints` | **Custom node taints**|**Type:** `array`<br/>**Default:** `[]`|
+| `providerIntegration.controlPlane.kubeadmConfig.taints[*]` |**None**|**Type:** `object`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.taints[*].effect` | **Effect**|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.taints[*].key` | **Key**|**Type:** `string`<br/>|
+| `providerIntegration.controlPlane.kubeadmConfig.taints[*].value` | **Value**|**Type:** `string`<br/>|
 | `providerIntegration.controlPlane.resources` | **Resources configuration** - GVK and other configuration for control plane resources.|**Type:** `object`<br/>|
 | `providerIntegration.controlPlane.resources.controlPlane` | **Control plane resource config**|**Type:** `object`<br/>**Default:** `{"api":{"group":"controlplane.cluster.x-k8s.io","kind":"KubeadmControlPlane","version":"v1beta1"}}`|
 | `providerIntegration.controlPlane.resources.controlPlane.api` | **Schema for Kubernetes API group, version and kind** - It can be used to specify which CustomResourceDefinition is used.|**Type:** `object`<br/>|
@@ -881,6 +886,11 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.kubeadmConfig.postKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
 | `providerIntegration.kubeadmConfig.preKubeadmCommands` | **Pre-kubeadm commands** - Extra commands to run before kubeadm runs.|**Type:** `array`<br/>|
 | `providerIntegration.kubeadmConfig.preKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
+| `providerIntegration.kubeadmConfig.taints` | **Custom node taints**|**Type:** `array`<br/>**Default:** `[]`|
+| `providerIntegration.kubeadmConfig.taints[*]` |**None**|**Type:** `object`<br/>|
+| `providerIntegration.kubeadmConfig.taints[*].effect` | **Effect**|**Type:** `string`<br/>|
+| `providerIntegration.kubeadmConfig.taints[*].key` | **Key**|**Type:** `string`<br/>|
+| `providerIntegration.kubeadmConfig.taints[*].value` | **Value**|**Type:** `string`<br/>|
 | `providerIntegration.kubernetesVersion` | **Kubernetes version**|**Type:** `string`<br/>**Default:** `"1.25.16"`|
 | `providerIntegration.osImage` | **OS image (deprecated)** - OS image Helm values have been deprecated. All OS-related information should now be obtained from the Release resource.|**Type:** `object`<br/>|
 | `providerIntegration.osImage.channel` | **Channel**|**Type:** `string`<br/>**Default:** `"stable"`|
@@ -920,7 +930,7 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.workers.defaultNodePools.PATTERN.cgroupsv1` | **Cgroups v1** - Flag that indicates if cgroups v1 should be used.|**Type:** `boolean`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>**Default:** `false`|
 | `providerIntegration.workers.defaultNodePools.PATTERN.customNodeLabels` | **Node labels** - Labels that are passed to kubelet argument 'node-labels'.|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 | `providerIntegration.workers.defaultNodePools.PATTERN.customNodeLabels[*]` | **Label**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
-| `providerIntegration.workers.defaultNodePools.PATTERN.customNodeTaints` | **Custom node taints**|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
+| `providerIntegration.workers.defaultNodePools.PATTERN.customNodeTaints` | **Custom node taints**|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>**Default:** `[]`|
 | `providerIntegration.workers.defaultNodePools.PATTERN.customNodeTaints[*]` |**None**|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 | `providerIntegration.workers.defaultNodePools.PATTERN.customNodeTaints[*].effect` | **Effect**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 | `providerIntegration.workers.defaultNodePools.PATTERN.customNodeTaints[*].key` | **Key**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
@@ -1030,6 +1040,11 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | `providerIntegration.workers.kubeadmConfig.postKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
 | `providerIntegration.workers.kubeadmConfig.preKubeadmCommands` | **Pre-kubeadm commands** - Extra commands to run before kubeadm runs.|**Type:** `array`<br/>|
 | `providerIntegration.workers.kubeadmConfig.preKubeadmCommands[*]` |**None**|**Type:** `string`<br/>|
+| `providerIntegration.workers.kubeadmConfig.taints` | **Custom node taints**|**Type:** `array`<br/>**Default:** `[]`|
+| `providerIntegration.workers.kubeadmConfig.taints[*]` |**None**|**Type:** `object`<br/>|
+| `providerIntegration.workers.kubeadmConfig.taints[*].effect` | **Effect**|**Type:** `string`<br/>|
+| `providerIntegration.workers.kubeadmConfig.taints[*].key` | **Key**|**Type:** `string`<br/>|
+| `providerIntegration.workers.kubeadmConfig.taints[*].value` | **Value**|**Type:** `string`<br/>|
 | `providerIntegration.workers.resources` | **Resources configuration** - Infrastructure template for worker resources when using MachineDeployment.|**Type:** `object`<br/>|
 | `providerIntegration.workers.resources.infrastructureMachineTemplateSpecTemplateName` | **Infrastructure Machine template spec template name** - The name of Helm template that renders Infrastructure Machine template spec.|**Type:** `string`<br/>|
 

--- a/helm/cluster/ci/test-multiple-taint-levels.yaml
+++ b/helm/cluster/ci/test-multiple-taint-levels.yaml
@@ -10,9 +10,48 @@ providerIntegration:
         - key: taint.at/level
           value: control-plane
           effect: NoSchedule
+
+    # Required values
+    resources:
+      infrastructureMachineTemplate:
+        group: infrastructure.cluster.x-k8s.io
+        version: v1beta1
+        kind: AWSMachineTemplate
+      infrastructureMachineTemplateSpecTemplateName: "cluster.internal.test.controlPlane.machineTemplate.spec"
+
   workers:
     kubeadmConfig:
       taints:
         - key: taint.at/level
           value: workers
           effect: NoSchedule
+
+    # Required value
+    defaultNodePools:
+      def00: {}
+
+  # Required values
+  provider: aws
+  resourcesApi:
+    clusterResourceEnabled: true
+    controlPlaneResourceEnabled: true
+    machinePoolResourcesEnabled: true
+    machineHealthCheckResourceEnabled: true
+    bastionResourceEnabled: false
+    infrastructureCluster:
+      group: infrastructure.cluster.x-k8s.io
+      version: v1beta1
+      kind: AWSCluster
+    nodePoolKind: MachinePool
+    infrastructureMachinePool:
+      group: infrastructure.cluster.x-k8s.io
+      version: v1beta1
+      kind: AWSMachinePool
+
+# Required values
+global:
+  connectivity:
+    baseDomain: example.gigantic.io
+  metadata:
+    name: tainted
+    organization: org-mcorgface

--- a/helm/cluster/ci/test-multiple-taint-levels.yaml
+++ b/helm/cluster/ci/test-multiple-taint-levels.yaml
@@ -1,0 +1,18 @@
+providerIntegration:
+  kubeadmConfig:
+    taints:
+      - key: taint.at/level
+        value: all-nodes
+        effect: NoSchedule
+  controlPlane:
+    kubeadmConfig:
+      taints:
+        - key: taint.at/level
+          value: control-plane
+          effect: NoSchedule
+  workers:
+    kubeadmConfig:
+      taints:
+        - key: taint.at/level
+          value: workers
+          effect: NoSchedule

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_initconfiguration.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_initconfiguration.tpl
@@ -13,7 +13,7 @@ nodeRegistration:
     node-labels: ip={{ printf "${%s}" $.Values.providerIntegration.environmentVariables.ipv4 }}
     v: "2"
   name: {{ printf "${%s}" $.Values.providerIntegration.environmentVariables.hostName }}
-  {{- with $.Values.global.controlPlane.customNodeTaints }}
+  {{- with (concat $.Values.providerIntegration.kubeadmConfig.taints $.Values.providerIntegration.controlPlane.kubeadmConfig.taints $.Values.global.controlPlane.customNodeTaints ) }}
   taints:
     {{- toYaml . | nindent 2 }}
   {{- end }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_joinconfiguration.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_joinconfiguration.tpl
@@ -9,7 +9,7 @@ nodeRegistration:
     node-ip: {{ printf "${%s}" $.Values.providerIntegration.environmentVariables.ipv4 }}
     node-labels: ip={{ printf "${%s}" $.Values.providerIntegration.environmentVariables.ipv4 }}
   name: {{ printf "${%s}" $.Values.providerIntegration.environmentVariables.hostName }}
-  {{- with $.Values.global.controlPlane.customNodeTaints }}
+  {{- with (concat $.Values.providerIntegration.kubeadmConfig.taints $.Values.providerIntegration.controlPlane.kubeadmConfig.taints $.Values.global.controlPlane.customNodeTaints ) }}
   taints:
     {{- toYaml . | nindent 2 }}
   {{- end }}

--- a/helm/cluster/templates/clusterapi/workers/_helpers_joinconfiguration.tpl
+++ b/helm/cluster/templates/clusterapi/workers/_helpers_joinconfiguration.tpl
@@ -24,7 +24,7 @@ nodeRegistration:
     node-ip: {{ printf "${%s}" $.Values.providerIntegration.environmentVariables.ipv4 }}
     node-labels: ip={{ printf "${%s}" $.Values.providerIntegration.environmentVariables.ipv4 }},role=worker,giantswarm.io/machine-pool={{ include "cluster.resource.name" $ }}-{{ $nodePool.name }}{{- if $nodePool.config.customNodeLabels }},{{ join "," $nodePool.config.customNodeLabels }}{{- end }}
     v: "2"
-  {{- with $nodePool.config.customNodeTaints }}
+  {{- with (concat $.Values.providerIntegration.kubeadmConfig.taints $.Values.providerIntegration.workers.kubeadmConfig.taints (or $nodePool.config.customNodeTaints list) ) }}
   taints:
     {{- toYaml . | nindent 2 }}
   {{- end }}

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -108,7 +108,8 @@
                         "title": "Value"
                     }
                 }
-            }
+            },
+            "default": []
         },
         "featureGates": {
             "type": "array",
@@ -2651,6 +2652,9 @@
                                 },
                                 "preKubeadmCommands": {
                                     "$ref": "#/$defs/preKubeadmCommands"
+                                },
+                                "taints": {
+                                    "$ref": "#/$defs/customNodeTaints"
                                 }
                             }
                         },
@@ -2747,6 +2751,9 @@
                         },
                         "preKubeadmCommands": {
                             "$ref": "#/$defs/preKubeadmCommands"
+                        },
+                        "taints": {
+                            "$ref": "#/$defs/customNodeTaints"
                         }
                     }
                 },
@@ -3054,6 +3061,9 @@
                                 },
                                 "preKubeadmCommands": {
                                     "$ref": "#/$defs/preKubeadmCommands"
+                                },
+                                "taints": {
+                                    "$ref": "#/$defs/customNodeTaints"
                                 }
                             }
                         },

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -65,6 +65,7 @@ global:
       enabled: false
   controlPlane:
     apiServerPort: 6443
+    customNodeTaints: []
     machineHealthCheck:
       enabled: true
       maxUnhealthy: 40%
@@ -198,6 +199,7 @@ providerIntegration:
           additionalConfig:
             storage: {}
             systemd: {}
+      taints: []
     resources:
       controlPlane:
         api:
@@ -213,6 +215,7 @@ providerIntegration:
         additionalConfig:
           storage: {}
           systemd: {}
+    taints: []
   kubernetesVersion: 1.25.16
   osImage:
     channel: stable
@@ -239,4 +242,5 @@ providerIntegration:
           additionalConfig:
             storage: {}
             systemd: {}
+      taints: []
     resources: {}


### PR DESCRIPTION
### What does this PR do?

Enables setting taints on worker nodes, controller nodes, or all of them, by adding the following values:

* `providerIntegration.kubeadmConfig.taints`
* `providerIntegration.controlPlane.kubeadmConfig.taints`
* `providerIntegration.workers.kubeadmConfig.taints`

These are fed to the `KubeadmConfiguration` for all nodes created through the chart.

### What is the effect of this change to users?

Users are able to set default taints on nodes.

### How does it look like?

Success.

### Any background context you can provide?

Will enable Phoenix to solve https://github.com/giantswarm/giantswarm/issues/31687.

### What is needed from the reviewers?

We discussed this in Slack, so it should be fine. :crossed_fingers: 

### Do the docs need to be updated?

Yup, updated the generated docs.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
