### PR TITLE
Configure the kubelet to register CP nodes with the node-role.kubernetes.io/control-plane taint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `providerIntegration.kubeadmConfig.taints`
   - `providerIntegration.controlPlane.kubeadmConfig.taints`
   - `providerIntegration.workers.kubeadmConfig.taints`
+- Configure the `kubelet` to register Control Plane nodes with the `node-role.kubernetes.io/control-plane` taint.
 
 ### Changed
 

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_initconfiguration.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_initconfiguration.tpl
@@ -12,6 +12,7 @@ nodeRegistration:
     node-ip: {{ printf "${%s}" $.Values.providerIntegration.environmentVariables.ipv4 }}
     node-labels: ip={{ printf "${%s}" $.Values.providerIntegration.environmentVariables.ipv4 }}
     v: "2"
+    register-with-taints: 'node-role.kubernetes.io/control-plane="":NoSchedule'
   name: {{ printf "${%s}" $.Values.providerIntegration.environmentVariables.hostName }}
   {{- with (concat $.Values.providerIntegration.kubeadmConfig.taints $.Values.providerIntegration.controlPlane.kubeadmConfig.taints $.Values.global.controlPlane.customNodeTaints ) }}
   taints:

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_joinconfiguration.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_joinconfiguration.tpl
@@ -8,6 +8,7 @@ nodeRegistration:
     cloud-provider: external
     node-ip: {{ printf "${%s}" $.Values.providerIntegration.environmentVariables.ipv4 }}
     node-labels: ip={{ printf "${%s}" $.Values.providerIntegration.environmentVariables.ipv4 }}
+    register-with-taints: 'node-role.kubernetes.io/control-plane="":NoSchedule'
   name: {{ printf "${%s}" $.Values.providerIntegration.environmentVariables.hostName }}
   {{- with (concat $.Values.providerIntegration.kubeadmConfig.taints $.Values.providerIntegration.controlPlane.kubeadmConfig.taints $.Values.global.controlPlane.customNodeTaints ) }}
   taints:


### PR DESCRIPTION
### What does this PR do?

This is necessary during disaster recovery scenarios, where we restore an etcd snapshot on a running cluster and we need to restart the kubelet to register an existing CP node to the recovered cluster state. Without this the CP node would get registered without the taint, allowing any Pod to get scheduled on it.

For context, normally this taint is added automatically by `kubeadm init` or `kubeadm join`, which will just proceed normally if it's already added by the kubelet before. Kubeadm is not involved during a DR scenario, since it's not designed to be re-run on an already bootstrapped node.

### What is the effect of this change to users?

The CP nodes will roll

### How does it look like?

(Please add anything that represents the change visually. Screenshots, output, logs, ...)

### Any background context you can provide?

Related to https://github.com/giantswarm/giantswarm/issues/30439

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
