### PR TITLE
Configure cilium to use the k8s hostname defined in cluster-info CM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Set defaults for net-exporter App.
+- Configure cilium to use the k8s hostname defined in the cluster-info ConfigMap
 
 ## [2.4.0] - 2025-06-03
 

--- a/helm/cluster/files/helmreleases/cilium.yaml
+++ b/helm/cluster/files/helmreleases/cilium.yaml
@@ -10,8 +10,7 @@ defaultValues:
   # For all available values see https://github.com/giantswarm/cilium-app/blob/main/helm/cilium/values.yaml
   ipam:
     mode: kubernetes
-  k8sServiceHost: api.{{ include "cluster.resource.name" $ }}.{{ .Values.global.connectivity.baseDomain }}
-  k8sServicePort: '{{ .Values.global.controlPlane.apiServerPort }}'
+  k8sServiceHost: auto
   kubeProxyReplacement: 'true'
   hubble:
     relay:


### PR DESCRIPTION
### What does this PR do?

Right now, cilium uses the external public hostname of the cluster to access the API server. This makes a critical internal component dependant on the baseDomain DNS infrastructure, which is sometimes managed by the customer, sometimes managed by us, and could be unreliable. Additionally it makes baseDomain more rigid and difficult to change on an existing cluster.

When setting `k8sServiceHost: auto`, the cilium helm chart will fetch the k8s API hostname from the `cluster-info` ConfigMap in the `kube-public` Namespace, which is set to an internal hostname or IP inside the provider network (e.g. the ELB hostname in AWS and Azure).

### What is the effect of this change to users?

None

### How does it look like?

(Please add anything that represents the change visually. Screenshots, output, logs, ...)

### Any background context you can provide?

https://gigantic.slack.com/archives/CLPMFRVU6/p1752252511295269

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
