### PR TITLE
Values: Fix schema.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.7.0] - 2024-12-06
+### Changed
 
+- Values: Fix schema. ([#580](https://github.com/giantswarm/cluster/pull/580))
+
+## [1.7.0] - 2024-12-06
 
 ### Added
 

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -2860,9 +2860,13 @@
                             },
                             "then": {
                                 "required": [
+                                    "infrastructureMachinePool",
                                     "nodePoolKind"
                                 ],
                                 "properties": {
+                                    "infrastructureMachinePool": {
+                                        "$ref": "#/$defs/infrastructureMachinePool"
+                                    },
                                     "nodePoolKind": {
                                         "type": "string",
                                         "title": "Node pool kind",
@@ -2871,29 +2875,6 @@
                                             "MachineDeployment",
                                             "MachinePool"
                                         ]
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "if": {
-                                "type": "object",
-                                "properties": {
-                                    "machinePoolResourcesEnabled": {
-                                        "const": true
-                                    },
-                                    "nodePoolKind": {
-                                        "const": "MachinePool"
-                                    }
-                                }
-                            },
-                            "then": {
-                                "required": [
-                                    "infrastructureMachinePool"
-                                ],
-                                "properties": {
-                                    "infrastructureMachinePool": {
-                                        "$ref": "#/$defs/infrastructureMachinePool"
                                     }
                                 }
                             }


### PR DESCRIPTION
This change addresses an issue, which popped up after upgrading Helm to v3.18.5+ in MC Bootstrap.

https://tekton.ci.giantswarm.io/#/namespaces/mc-bootstrap/pipelineruns/pr-1354-generate-mc-capz-goose-nxr4f?pipelineTask=generate-mc&step=generate-mc

Since `cluster-azure` is not using `nodePoolKind: MachinePool`, the conditions in the schema do not evaluate to define the `infrastructureMachinePool` property and so this is not known when trying to install the chart in MC Bootstrap.

But since we are using the `infrastructureMachinePool` property in both cases - `nodePoolKind: MachinePool` and `nodePoolKind: MachineDeployment` everywhere in the code, I moved `infrastructureMachinePool` to the previous conditions so it gets defined.