### PR TITLE
Allow karpenter configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Allow additional properties on Nodepools to enable karpenter configuration.
+
 ## [2.6.0] - 2025-08-13
 
 ### Added

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -802,6 +802,7 @@
         "nodePool": {
             "type": "object",
             "title": "Node pool",
+            "additionalProperties": true,
             "properties": {
                 "type": {
                     "type": "string",


### PR DESCRIPTION
### What does this PR do?

Karpenter will expose all configuration options within the nodepool object as seen https://github.com/giantswarm/cluster-aws/blob/remvove-karpenter-nodepools-chart/helm/cluster-aws/ci/test-karpenter-full-values.yaml

It does not make sense to add all these options here as it only makes sense for karpenter AWS, not any other provider.

### What is the effect of this change to users?

### How does it look like?

(Please add anything that represents the change visually. Screenshots, output, logs, ...)

### Any background context you can provide?

(Please link public issues or summarize if not public.)

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [ ] CHANGELOG.md has been updated (if it exists)
