### PR TITLE
Remove capi-node-labeler app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Removed
 
 - Removed `capi-node-labeler` app. From now on, the worker nodes won't have the `node-role.kubernetes.io/worker` or `node.kubernetes.io/worker` labels.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Removed `capi-node-labeler` app. From now on, the worker nodes won't have the `node-role.kubernetes.io/worker` or `node.kubernetes.io/worker` labels.
+
 ## [3.0.1] - 2025-09-12
 
 ### Changed

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -30,13 +30,6 @@ Configuration of apps that are part of the cluster.
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
 | `global.apps.PATTERN` | **App configurations from parent chart** - Not used in this chart. This is here to keep the schemas compatible.|**Type:** `[object]`<br/>**Key pattern:**<br/>`PATTERN`=`[a-z][a-zA-Z]+`<br/>|
-| `global.apps.capiNodeLabeler` | **App resource** - Configuration of a default app that is part of the cluster and is deployed as an App resource.|**Type:** `[object]`<br/>|
-| `global.apps.capiNodeLabeler.extraConfigs` | **Extra config maps or secrets** - Extra config maps or secrets that will be used to customize to the app. The desired values must be under configmap or secret key 'values'. The values are merged in the order given, with the later values overwriting earlier, and then inline values overwriting those. Resources must be in the same namespace as the cluster.|**Type:** `[array]`<br/>|
-| `global.apps.capiNodeLabeler.extraConfigs[*]` | **Config map or secret**|**Type:** `[object]`<br/>|
-| `global.apps.capiNodeLabeler.extraConfigs[*].kind` | **Kind** - Specifies whether the resource is a config map or a secret.|**Type:** `[string]`<br/>|
-| `global.apps.capiNodeLabeler.extraConfigs[*].name` | **Name** - Name of the config map or secret. The object must exist in the same namespace as the cluster App.|**Type:** `[string]`<br/>|
-| `global.apps.capiNodeLabeler.extraConfigs[*].priority` | **Priority**|**Type:** `[integer]`<br/>**Default:** `25`|
-| `global.apps.capiNodeLabeler.values` | **Config map** - Helm Values to be passed to the app as user config.|**Type:** `[object]`<br/>|
 | `global.apps.certExporter` | **App resource** - Configuration of a default app that is part of the cluster and is deployed as an App resource.|**Type:** `[object]`<br/>|
 | `global.apps.certExporter.extraConfigs` | **Extra config maps or secrets** - Extra config maps or secrets that will be used to customize to the app. The desired values must be under configmap or secret key 'values'. The values are merged in the order given, with the later values overwriting earlier, and then inline values overwriting those. Resources must be in the same namespace as the cluster.|**Type:** `[array]`<br/>|
 | `global.apps.certExporter.extraConfigs[*]` | **Config map or secret**|**Type:** `[object]`<br/>|
@@ -469,9 +462,6 @@ Provider-specific properties that can be set by cluster-$provider chart in order
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
 | `providerIntegration.apps` | **Apps** - Provider-specific config for apps.|**Type:** `[object]`<br/>|
-| `providerIntegration.apps.capiNodeLabeler` | **Provider integration app config** - App config used to additionally configure an app for a specific provider|**Type:** `[object]`<br/>|
-| `providerIntegration.apps.capiNodeLabeler.configTemplateName` | **Config template name** - Name of the Helm template that has provider-specific app config. Provider-specific app config overrides provider-independent app config, while custom user config overrides both provider-independent and provider-specific default app config.|**Type:** `[string]`<br/>|
-| `providerIntegration.apps.capiNodeLabeler.enable` | **Enable** - Flag that indicates if an app is enabled for a provider. It is false by default, which allows for more incremental and safer adoption of the cluster chart.|**Type:** `[boolean]`<br/>**Default:** `false`|
 | `providerIntegration.apps.certExporter` | **Provider integration app config** - App config used to additionally configure an app for a specific provider|**Type:** `[object]`<br/>|
 | `providerIntegration.apps.certExporter.configTemplateName` | **Config template name** - Name of the Helm template that has provider-specific app config. Provider-specific app config overrides provider-independent app config, while custom user config overrides both provider-independent and provider-specific default app config.|**Type:** `[string]`<br/>|
 | `providerIntegration.apps.certExporter.enable` | **Enable** - Flag that indicates if an app is enabled for a provider. It is false by default, which allows for more incremental and safer adoption of the cluster chart.|**Type:** `[boolean]`<br/>**Default:** `false`|

--- a/helm/cluster/ci/ci-values.yaml
+++ b/helm/cluster/ci/ci-values.yaml
@@ -69,16 +69,6 @@ global:
         - endpoint: private-example-2.azurecr.io
           auth: c3VwZXJfc2VjcmV0X2F1dGg=
   apps:
-    capiNodeLabeler:
-      values:
-        foo: bar
-      extraConfigs:
-      - name: my-secret-extra-config-1
-        kind: secret
-        priority: 110
-      - name: my-extra-config-2
-        kind: configMap
-        priority: 120
     certManager:
       values:
         ingressShim:
@@ -286,8 +276,6 @@ internal:
       renderWithoutReleaseResource: true
 providerIntegration:
   apps:
-    capiNodeLabeler:
-      enable: true
     certExporter:
       enable: true
       configTemplateName: cluster.test.providerIntegration.apps.certExporter.config

--- a/helm/cluster/files/apps/capi-node-labeler.yaml
+++ b/helm/cluster/files/apps/capi-node-labeler.yaml
@@ -1,9 +1,0 @@
-appName: capi-node-labeler
-configKey: capiNodeLabeler
-clusterValues:
-  configMap: true
-  secret: false
-namespace: kube-system
-# used by renovate
-# repo: giantswarm/capi-node-labeler-app
-version: 1.1.3

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1170,12 +1170,6 @@
                         }
                     },
                     "properties": {
-                        "capiNodeLabeler": {
-                            "$ref": "#/$defs/app",
-                            "type": "object",
-                            "title": "capi-node-labeler",
-                            "description": "Configuration of capi-node-labeler. For all available values see https://github.com/giantswarm/capi-node-labeler."
-                        },
                         "certExporter": {
                             "$ref": "#/$defs/app",
                             "type": "object",
@@ -2248,9 +2242,6 @@
                     "description": "Provider-specific config for apps.",
                     "additionalProperties": false,
                     "properties": {
-                        "capiNodeLabeler": {
-                            "$ref": "#/$defs/providerIntegrationAppConfig"
-                        },
                         "certExporter": {
                             "$ref": "#/$defs/providerIntegrationAppConfig"
                         },

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -2,7 +2,6 @@
 
 global:
   apps:
-    capiNodeLabeler: {}
     certExporter: {}
     certManager: {}
     chartOperatorExtensions: {}
@@ -118,8 +117,6 @@ internal:
     offlineTesting: {}
 providerIntegration:
   apps:
-    capiNodeLabeler:
-      enable: false
     certExporter:
       enable: false
     certManager:


### PR DESCRIPTION
### What does this PR do?

Towards https://github.com/giantswarm/giantswarm/issues/33938

### What is the effect of this change to users?

From now on, the worker nodes won't have the `node-role.kubernetes.io/worker` or `node.kubernetes.io/worker` labels.

### Any background context you can provide?

We've checked all WCs and found no customers relying on these worker labels, so we've decided to remove them. Our own apps using them have been changed already to use alternative methods when needed.

We are planning on releasing this as a new major release of the cluster chart and the provider charts, and including those in v33.

### Should this change be mentioned in the release notes?

- [X] CHANGELOG.md has been updated (if it exists)
