### PR TITLE
Chart: Reduce Cilium reconciliation interval to 1 minute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Chart: Reduce Cilium reconciliation interval to 1 minute.
+
 ## [4.0.1] - 2025-09-24
 
 ### Fixed

--- a/helm/cluster/files/helmreleases/cilium.yaml
+++ b/helm/cluster/files/helmreleases/cilium.yaml
@@ -4,6 +4,7 @@ namespace: kube-system
 # used by renovate
 # repo: giantswarm/cilium-app
 version: 1.3.1
+interval: 1m
 timeout: 1h
 remediationRetries: 0
 defaultValues:


### PR DESCRIPTION
Currently the Cilium HelmRelease CR is only being reconciled every 5 minutes (hard-coded default value in the Helm Releases templating).

Since this CR is being created at the same time as the Cluster and Infrastructure CRs, it might happen Cilium gets first installed after 5 minutes, which would be ok, but often it happens to take 10 minutes or even 15 minutes. In general a reconciliation (and with that retry) interval of 5 minutes seems quite high for such an important core component. Keep in mind: Nodes are not getting ready without the CNI, so you cannot install anything else anyway as long you are not ignoring these taints.

Therefore I'd ask to reduce it to 1 minute with this change.