### PR TITLE
Chart: Render `cloud-provider` flag for Kubernetes < v1.33.0 only.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Chart: Render `cloud-provider` flag for Kubernetes < v1.33.0 only. ([#647](https://github.com/giantswarm/cluster/pull/647))
+
 ## [4.0.1] - 2025-09-24
 
 ### Fixed

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_apiserver.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_apiserver.tpl
@@ -25,7 +25,10 @@ extraArgs:
   audit-log-maxsize: "100"
   audit-log-path: /var/log/apiserver/audit.log
   audit-policy-file: /etc/kubernetes/policies/audit-policy.yaml
+  {{- $k8sVersion := include "cluster.component.kubernetes.version" $ | trimPrefix "v" }}
+  {{- if or (eq $k8sVersion "N/A") (semverCompare "<1.33.0-0" $k8sVersion) }}
   cloud-provider: external
+  {{- end }}
   {{- if $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.cloudConfig  }}
   cloud-config: {{ $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.cloudConfig  }}
   {{- end }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_controllermanager.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_clusterconfiguration_controllermanager.tpl
@@ -3,7 +3,10 @@ extraArgs:
   allocate-node-cidrs: "true"
   authorization-always-allow-paths: "/healthz,/readyz,/livez,/metrics"
   bind-address: 0.0.0.0
+  {{- $k8sVersion := include "cluster.component.kubernetes.version" $ | trimPrefix "v" }}
+  {{- if or (eq $k8sVersion "N/A") (semverCompare "<1.33.0-0" $k8sVersion) }}
   cloud-provider: external
+  {{- end }}
 {{- if $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.cloudConfig  }}
   cloud-config: {{ $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.cloudConfig  }}
 {{- end }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_initconfiguration.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_initconfiguration.tpl
@@ -7,7 +7,10 @@ localAPIEndpoint:
   bindPort: {{ $.Values.internal.advancedConfiguration.controlPlane.apiServer.bindPort | default 6443 }}
 nodeRegistration:
   kubeletExtraArgs:
+    {{- $k8sVersion := include "cluster.component.kubernetes.version" $ | trimPrefix "v" }}
+    {{- if or (eq $k8sVersion "N/A") (semverCompare "<1.33.0-0" $k8sVersion) }}
     cloud-provider: external
+    {{- end }}
     cgroup-driver: systemd
     healthz-bind-address: 0.0.0.0
     node-ip: {{ printf "${%s}" $.Values.providerIntegration.environmentVariables.ipv4 }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_joinconfiguration.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_joinconfiguration.tpl
@@ -5,7 +5,10 @@ controlPlane:
     bindPort: {{ $.Values.internal.advancedConfiguration.controlPlane.apiServer.bindPort | default 6443 }}
 nodeRegistration:
   kubeletExtraArgs:
+    {{- $k8sVersion := include "cluster.component.kubernetes.version" $ | trimPrefix "v" }}
+    {{- if or (eq $k8sVersion "N/A") (semverCompare "<1.33.0-0" $k8sVersion) }}
     cloud-provider: external
+    {{- end }}
     cgroup-driver: systemd
     node-ip: {{ printf "${%s}" $.Values.providerIntegration.environmentVariables.ipv4 }}
     node-labels: ip={{ printf "${%s}" $.Values.providerIntegration.environmentVariables.ipv4 }}

--- a/helm/cluster/templates/clusterapi/workers/_helpers_joinconfiguration.tpl
+++ b/helm/cluster/templates/clusterapi/workers/_helpers_joinconfiguration.tpl
@@ -10,7 +10,10 @@
 nodeRegistration:
   name: {{ printf "${%s}" $.Values.providerIntegration.environmentVariables.hostName }}
   kubeletExtraArgs:
+    {{- $k8sVersion := include "cluster.component.kubernetes.version" $ | trimPrefix "v" }}
+    {{- if or (eq $k8sVersion "N/A") (semverCompare "<1.33.0-0" $k8sVersion) }}
     cloud-provider: external
+    {{- end }}
     cgroup-driver: systemd
     {{- if $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.cloudConfig  }}
     cloud-config: {{ $.Values.providerIntegration.controlPlane.kubeadmConfig.clusterConfiguration.apiServer.cloudConfig  }}


### PR DESCRIPTION
This flag got removed in Kubernetes v1.33.0 and should therefore only be rendered in lower versions.