### PR TITLE
Chart: Require `global.release.version` if using Releases to give a better rendering error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Control Plane: Make etcd image tag configurable. ([#841](https://github.com/giantswarm/cluster/pull/841))
 
+### Fixed
+
+- Chart: Require `global.release.version` if using Releases to give a better rendering error message.
+
 ## [6.4.0] - 2026-04-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Control Plane: Make etcd image tag configurable. ([#841](https://github.com/giantswarm/cluster/pull/841))
-
-### Fixed
-
 - Chart: Require `global.release.version` if using Releases to give a better rendering error message.
 
 ## [6.4.0] - 2026-04-15

--- a/helm/cluster/templates/_helpers.tpl
+++ b/helm/cluster/templates/_helpers.tpl
@@ -57,7 +57,7 @@ giantswarm.io/service-priority: {{ .Values.global.metadata.servicePriority }}
 cluster.x-k8s.io/cluster-name: {{ include "cluster.resource.name" $ | quote }}
 cluster.x-k8s.io/watch-filter: capi
 {{- if $.Values.providerIntegration.useReleases }}
-release.giantswarm.io/version: {{ .Values.global.release.version | trimPrefix "v" | quote }}
+release.giantswarm.io/version: {{ .Values.global.release.version | required "global.release.version is required" | trimPrefix "v" | quote }}
 {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
### What does this PR do?

To get a better error than

```
    Reason:         template: cluster-eks/charts/cluster/templates/clusterapi/workers/machinepool.yaml:18:8: executing "cluster-eks/charts/cluster/templates/clusterapi/workers/machinepool.yaml" at <include "cluster.labels.common" $>: error calling include: template: cluster-eks/charts/cluster/templates/_helpers.tpl:60:78: executing "cluster.labels.common" at <"v">: invalid value; expected string
    Status:         not-installed
```

Oh, and I'll fix kubectl-gs next – which didn't output the release version (for EKS).

Slightly related to my [EKS testing issue](https://github.com/giantswarm/giantswarm/issues/36119).

### What is the effect of this change to users?

None, I think

### Do the docs need to be updated?

No

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
