### PR TITLE
fix(selinux): cluster setup with selinux enforced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Control Plane: Ensure components start correctly when SELinux is set to enforcing.
+
 ## [6.6.0] - 2026-06-01
 
 ### Added

--- a/helm/cluster/files/etc/kubernetes/patches/kube-apiserver1selinux+json.yaml
+++ b/helm/cluster/files/etc/kubernetes/patches/kube-apiserver1selinux+json.yaml
@@ -1,0 +1,6 @@
+# Ensure kube-apiserver runs without a random MCS category level so audit logs can be
+# shared with other processes (k8s-audit-metrics).
+- op: add
+  path: /spec/securityContext/seLinuxOptions
+  value:
+    level: s0

--- a/helm/cluster/templates/clusterapi/_helpers_prekubeadmcommands.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_prekubeadmcommands.tpl
@@ -18,6 +18,9 @@
 
 {{- define "cluster.internal.kubeadm.preKubeadmCommands.selinux" }}
 {{- if ne $.Values.global.components.selinux.mode "disabled" }}
+# Fix label for kube-apiserver audit log directory
+- mkdir -p /var/log/apiserver
+- chcon -R -t container_file_t /var/log/apiserver
 # Fix labels for `/etc/kubernetes`
 - restorecon -RFv /etc/kubernetes
 {{- end }}

--- a/helm/cluster/templates/clusterapi/_helpers_prekubeadmcommands.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_prekubeadmcommands.tpl
@@ -11,8 +11,16 @@
 {{- include "cluster.internal.kubeadm.preKubeadmCommands.flatcar" $ }}
 {{- include "cluster.internal.kubeadm.preKubeadmCommands.ssh" $ }}
 {{- include "cluster.internal.kubeadm.preKubeadmCommands.proxy" $ }}
+{{- include "cluster.internal.kubeadm.preKubeadmCommands.selinux" $ }}
 {{- include "cluster.internal.kubeadm.preKubeadmCommands.provider" $ }}
 {{- include "cluster.internal.kubeadm.preKubeadmCommands.custom" $ }}
+{{- end }}
+
+{{- define "cluster.internal.kubeadm.preKubeadmCommands.selinux" }}
+{{- if ne $.Values.global.components.selinux.mode "disabled" }}
+# Fix labels for `/etc/kubernetes`
+- restorecon -RFv /etc/kubernetes
+{{- end }}
 {{- end }}
 
 {{- define "cluster.internal.kubeadm.preKubeadmCommands.flatcar" }}

--- a/helm/cluster/templates/clusterapi/controlplane/_helpers_files.tpl
+++ b/helm/cluster/templates/clusterapi/controlplane/_helpers_files.tpl
@@ -4,6 +4,7 @@
 {{- include "cluster.internal.controlPlane.kubeadm.files.audit" $ }}
 {{- include "cluster.internal.controlPlane.kubeadm.files.encryption" $ }}
 {{- include "cluster.internal.controlPlane.kubeadm.files.fairness" $ }}
+{{- include "cluster.internal.controlPlane.kubeadm.files.selinux" $ }}
 {{- include "cluster.internal.controlPlane.kubeadm.files.oidc" $ }}
 {{- include "cluster.internal.controlPlane.kubeadm.files.provider" $ }}
 {{- include "cluster.internal.controlPlane.kubeadm.files.custom" $ }}
@@ -70,6 +71,15 @@
   permissions: "0644"
   encoding: base64
   content: {{ tpl ($.Files.Get "files/etc/kubernetes/patches/kube-controller-manager0+json.yaml") . | b64enc }}
+{{- end }}
+
+{{- define "cluster.internal.controlPlane.kubeadm.files.selinux" }}
+{{- if ne $.Values.global.components.selinux.mode "disabled" }}
+- path: /etc/kubernetes/patches/kube-apiserver1selinux+json.yaml
+  permissions: "0644"
+  encoding: base64
+  content: {{ tpl ($.Files.Get "files/etc/kubernetes/patches/kube-apiserver1selinux+json.yaml") . | b64enc }}
+{{- end }}
 {{- end }}
 
 {{- define "cluster.internal.controlPlane.kubeadm.files.oidc" }}


### PR DESCRIPTION
### What does this PR do?
Towards https://github.com/giantswarm/giantswarm/issues/35494
Fixes issues in kubeadm script and kube-apiserver due to incorrect labels on the root filesystem that makes it impossible to start a cluster with SELinux enforced.

### What is the effect of this change to users?

Clusters created using:
```yaml
global:
  components:
    selinux:
      mode: enforcing
    containerd:
      selinux:
        enabled: true
```
should now start but individual workload might still need additional policies to function properly.

### Any background context you can provide?

(Please link public issues or summarize if not public.)

### Do the docs need to be updated?
No

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
