### PR TITLE
Add "kyverno" as a dependency for the cluster-autoscaler App

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add "kyverno" as a dependency for the cluster-autoscaler App.
+
 ### Changed
 
 - Control Plane: Make etcd image tag configurable. ([#841](https://github.com/giantswarm/cluster/pull/841))

--- a/helm/cluster/files/apps/cluster-autoscaler.yaml
+++ b/helm/cluster/files/apps/cluster-autoscaler.yaml
@@ -5,7 +5,7 @@ clusterValues:
   configMap: true
   secret: true
 inCluster: {{ eq $.Values.providerIntegration.provider "azure" }}
-dependsOn: {{ if not (eq $.Values.providerIntegration.provider "azure") }}kyverno-crds{{ else }}[]{{ end }}
+dependsOn: {{ if not (eq $.Values.providerIntegration.provider "azure") }}["kyverno-crds", "kyverno"]{{ else }}[]{{ end }}
 namespace: kube-system
 # used by renovate
 # repo: giantswarm/cluster-autoscaler-app


### PR DESCRIPTION
### What does this PR do?

This is now needed since cluster-autoscaler deploys the PolicyException CRs in the `policy-exceptions` namespace, which is created by the kyverno App

### What is the effect of this change to users?

### How does it look like?

(Please add anything that represents the change visually. Screenshots, output, logs, ...)

### Any background context you can provide?

(Please link public issues or summarize if not public.)

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
