### PR TITLE
chore: bumping Flux API versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump Flux OCIRepository version to v1.
+
 ## [6.5.0] - 2026-05-20
 
 ### Changed

--- a/helm/cluster/templates/apps/helmreleases.yaml
+++ b/helm/cluster/templates/apps/helmreleases.yaml
@@ -9,7 +9,7 @@
 {{- $app := tpl (.Files.Get $path) $ | fromYaml }}
 {{- $appName := $app.appName }}
 
-{{- /* For hr installations targeting the MC, we want to add the cluster name as a prefix to the appName 
+{{- /* For hr installations targeting the MC, we want to add the cluster name as a prefix to the appName
 to avoid naming conflicts in case of multiple clusters deployed in the same namespace.
 */}}
 {{- $releaseName := $appName }}
@@ -68,7 +68,7 @@ to avoid naming conflicts in case of multiple clusters deployed in the same name
 {{- end }}
 {{- if $app.useOCISource }}
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
   name: {{ include "cluster.resource.name" $ }}-{{ $appName }}


### PR DESCRIPTION
Towards Flux >= 2.7.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
