### PR TITLE
feat(rbac): enable cluster-reader for default view bindings

### DIFF
--- a/helm/cluster/files/helmreleases/rbac-bootstrap.yaml
+++ b/helm/cluster/files/helmreleases/rbac-bootstrap.yaml
@@ -4,9 +4,11 @@ configKey: rbacBootstrap
 namespace: kube-system
 # used by renovate
 # repo: giantswarm/rbac-bootstrap-app
-version: 0.2.3
+version: 0.3.0
 interval: 1m
 defaultValues:
+  clusterReader:
+    enabled: true
   bindings:
     - role: view
       groups:

--- a/helm/cluster/files/helmreleases/rbac-bootstrap.yaml
+++ b/helm/cluster/files/helmreleases/rbac-bootstrap.yaml
@@ -4,7 +4,7 @@ configKey: rbacBootstrap
 namespace: kube-system
 # used by renovate
 # repo: giantswarm/rbac-bootstrap-app
-version: 0.3.0
+version: 0.2.3
 interval: 1m
 defaultValues:
   clusterReader:


### PR DESCRIPTION
Towards https://gigantic.slack.com/archives/C0ALXPMB1PW/p1780299573716949

- Bumps `rbac-bootstrap` chart `0.2.3` → `0.3.0`.
- Enables the new `clusterReader` toggle so the default `view` bindings for `giantswarm-admins` gain read access to nodes, PVs, CRDs, webhook configurations, and other cluster-scoped resources needed for troubleshooting workload clusters.
