### PR TITLE
feat: add support for AKS clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add support for AKS clusters
+
 ### Fixed
 
 - Control Plane: Ensure components start correctly when SELinux is set to enforcing.

--- a/helm/cluster/files/apps/cluster-autoscaler.yaml
+++ b/helm/cluster/files/apps/cluster-autoscaler.yaml
@@ -5,7 +5,7 @@ clusterValues:
   configMap: true
   secret: true
 inCluster: {{ eq $.Values.providerIntegration.provider "azure" }}
-dependsOn: {{ if not (eq $.Values.providerIntegration.provider "azure") }}kyverno-crds{{ else }}[]{{ end }}
+dependsOn: {{ if not (eq $.Values.providerIntegration.provider "azure") }}["kyverno-crds"]{{ else }}[]{{ end }}
 namespace: kube-system
 # used by renovate
 # repo: giantswarm/cluster-autoscaler-app

--- a/helm/cluster/files/apps/observability-bundle.yaml
+++ b/helm/cluster/files/apps/observability-bundle.yaml
@@ -6,7 +6,7 @@ clusterValues:
   secret: false
 inCluster: true
 dependsOnHelmRelease: true
-dependsOn: coredns
+dependsOn: {{ if not (eq $.Values.providerIntegration.provider "aks") }}coredns{{ else }}[]{{ end }}
 namespace: kube-system
 # used by renovate
 # repo: giantswarm/observability-bundle

--- a/helm/cluster/files/apps/observability-bundle.yaml
+++ b/helm/cluster/files/apps/observability-bundle.yaml
@@ -6,7 +6,7 @@ clusterValues:
   secret: false
 inCluster: true
 dependsOnHelmRelease: true
-dependsOn: {{ if not (eq $.Values.providerIntegration.provider "aks") }}coredns{{ else }}[]{{ end }}
+dependsOn: {{ if not (eq $.Values.providerIntegration.provider "aks") }}["coredns"]{{ else }}[]{{ end }}
 namespace: kube-system
 # used by renovate
 # repo: giantswarm/observability-bundle

--- a/helm/cluster/files/helmreleases/coredns.yaml
+++ b/helm/cluster/files/helmreleases/coredns.yaml
@@ -5,7 +5,7 @@ namespace: kube-system
 # used by renovate
 # repo: giantswarm/coredns-app
 version: 1.30.1
-dependsOn: {{ if not (eq $.Values.providerIntegration.provider "aks") }}cilium{{ else }}[]{{ end }}
+dependsOn: {{ if not (eq $.Values.providerIntegration.provider "aks") }}["cilium"]{{ else }}[]{{ end }}
 defaultValues:
   cluster:
     calico:

--- a/helm/cluster/files/helmreleases/coredns.yaml
+++ b/helm/cluster/files/helmreleases/coredns.yaml
@@ -5,8 +5,7 @@ namespace: kube-system
 # used by renovate
 # repo: giantswarm/coredns-app
 version: 1.30.1
-dependsOn:
-- cilium
+dependsOn: {{ if not (eq $.Values.providerIntegration.provider "aks") }}cilium{{ else }}[]{{ end }}
 defaultValues:
   cluster:
     calico:

--- a/helm/cluster/files/helmreleases/network-policies.yaml
+++ b/helm/cluster/files/helmreleases/network-policies.yaml
@@ -5,6 +5,6 @@ namespace: kube-system
 # used by renovate
 # repo: giantswarm/network-policies-app
 version: 0.1.3
-dependsOn: {{ if not (eq $.Values.providerIntegration.provider "aks") }}cilium{{ else }}[]{{ end }}
+dependsOn: {{ if not (eq $.Values.providerIntegration.provider "aks") }}["cilium"]{{ else }}[]{{ end }}
 interval: 1m
 disable: {{ .Values.global.connectivity.network.allowAllEgress }}

--- a/helm/cluster/files/helmreleases/network-policies.yaml
+++ b/helm/cluster/files/helmreleases/network-policies.yaml
@@ -5,7 +5,6 @@ namespace: kube-system
 # used by renovate
 # repo: giantswarm/network-policies-app
 version: 0.1.3
-dependsOn:
-- cilium
+dependsOn: {{ if not (eq $.Values.providerIntegration.provider "aks") }}cilium{{ else }}[]{{ end }}
 interval: 1m
 disable: {{ .Values.global.connectivity.network.allowAllEgress }}


### PR DESCRIPTION
### What does this PR do?

In AKS, cilium, coredns and metrics-server are built-in and we don't deploy our own apps, so dependant apps don't need to specify the dependency.

Towards https://github.com/giantswarm/giantswarm/issues/36639

### What is the effect of this change to users?

### How does it look like?

(Please add anything that represents the change visually. Screenshots, output, logs, ...)

### Any background context you can provide?

(Please link public issues or summarize if not public.)

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
