### PR TITLE
feat: honor extraConfigs priority in HelmRelease valuesFrom ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Migrate default applications from App CRs to Flux HelmRelease CRs.
 - Add support for AKS clusters
+- HelmReleases: honor the App platform `priority` field (1-150, default 25) on `extraConfigs` entries. `valuesFrom` entries are now ordered by priority around the cluster config (slot 50) and user config (slot 100) layers instead of list order, preserving the App CR merge semantics after the migration. When an extraConfig has priority above 100, the app's merged values are delivered via a `<cluster>-<app>-user-values` ConfigMap at the user-config slot instead of inline `spec.values`, so that entry can still override user config. ([giantswarm#36096](https://github.com/giantswarm/giantswarm/issues/36096))
 
 ### Fixed
 

--- a/helm/cluster/ci/test-extraconfigs-priority-ordering-values.yaml
+++ b/helm/cluster/ci/test-extraconfigs-priority-ordering-values.yaml
@@ -58,10 +58,7 @@ global:
         - kind: secret
           name: sec-pre-cluster-1
           priority: 30
-          # sortAlpha is case-sensitive, a capital letter is sorted before the lowercase one.
-          # The value schema already prevents that, but not all systems might run the checks or can be skipped too.
-          # The sort helper converts them to a numerical value and calls lower() too.
-        - kind: CONFIGMAP
+        - kind: configMap
           name: cm-pre-cluster
           priority: 20
         - kind: secret
@@ -75,7 +72,7 @@ global:
         - kind: configMap
           name: cm-pre-user
           priority: 90
-        - kind: SECRET
+        - kind: secret
           name: sec-pre-cluster-2
           priority: 30
         - kind: configMap
@@ -93,10 +90,7 @@ global:
         - kind: secret
           name: sec-pre-cluster-1
           priority: 30
-          # sortAlpha is case-sensitive, a capital letter is sorted before the lowercase one.
-          # The value schema already prevents that, but not all systems might run the checks or can be skipped too.
-          # The sort helper converts them to a numerical value and calls lower() too.
-        - kind: CONFIGMAP
+        - kind: configMap
           name: cm-pre-cluster
           priority: 20
         - kind: secret
@@ -104,7 +98,7 @@ global:
           priority: 130
         - kind: configMap
           name: cm-default        # no priority -> defaults to 25
-        - kind: SECRET
+        - kind: secret
           name: sec-pre-user
           priority: 90
         - kind: configMap

--- a/helm/cluster/ci/test-extraconfigs-priority-ordering-values.yaml
+++ b/helm/cluster/ci/test-extraconfigs-priority-ordering-values.yaml
@@ -1,0 +1,142 @@
+# Exercises the App-platform `priority` ordering of extraConfigs as reproduced
+# in the HelmRelease `spec.valuesFrom` list (see the `cluster.app.sortedValuesFrom`
+# helper and giantswarm/giantswarm#36096).
+#
+# App platform built the configMap layers and the secret layers in two independent
+# passes and merged the secret blob OVER the configMap blob, so:
+#   * ALL configMaps merge before ALL secrets (a secret always overrides a configMap,
+#     regardless of priority);
+#   * within each kind the order is, by priority band:
+#       extras priority <= 50  ->  cluster-values slot (50)  ->
+#       extras 50 < priority <= 100  ->  user-values slot (100)  ->
+#       extras priority > 100
+#   * equal-priority extras keep their authored order;
+#   * an extra with no priority defaults to 25.
+#
+# Flux merges `valuesFrom` strictly top-to-bottom (later wins), so the rendered list
+# must already be in that order. The merged default+provider+user values are delivered
+# through a `<cluster>-<app>-user-values` ConfigMap at the user-config slot (NOT inline
+# `spec.values`, which Flux always merges last).
+#
+# No default app sets `clusterValues`, so the cluster-values slot (50) does not appear
+# in practice; the entries below straddle it to document where it would land.
+#
+# Each app's extraConfigs are authored DELIBERATELY OUT OF ORDER and with mixed kinds.
+# Expected rendered `spec.valuesFrom` for both apps (configMaps first, then secrets):
+#   - ConfigMap cm-pre-cluster          (priority 20)
+#   - ConfigMap cm-default              (priority 25, defaulted)
+#   - ConfigMap cm-pre-user             (priority 90)
+#   - ConfigMap <cluster>-<app>-user-values   (user-values slot, 100)
+#   - ConfigMap cm-post-user            (priority 120)
+#   - Secret    sec-pre-cluster         (priority 30)
+#   - Secret    sec-pre-user            (priority 90)
+#   - Secret    sec-post-user           (priority 130)
+
+global:
+  managementCluster: giantmc
+  release:
+    version: v27.0.0-alpha.1
+  metadata:
+    name: awesome
+    organization: giantswarm
+  connectivity:
+    baseDomain: example.gigantic.io
+  nodePools:
+    def00:
+      minSize: 3
+      maxSize: 20
+  apps:
+    # WC-targeted, non-bundle default app.
+    certExporter:
+      values:
+        # Lands in the <cluster>-cert-exporter-user-values ConfigMap (user-config slot 100).
+        sentinel: from-user-values
+      extraConfigs:
+        - kind: configMap
+          name: cm-post-user
+          priority: 120
+        - kind: secret
+          name: sec-pre-cluster
+          priority: 30
+        - kind: configMap
+          name: cm-pre-cluster
+          priority: 20
+        - kind: secret
+          name: sec-post-user
+          priority: 130
+        - kind: configMap
+          name: cm-default        # no priority -> defaults to 25
+        - kind: secret
+          name: sec-pre-user
+          priority: 90
+        - kind: configMap
+          name: cm-pre-user
+          priority: 90
+    # MC-targeted (inCluster) bundle. Same extraConfigs mix to show the ordering
+    # logic is identical regardless of where the HelmRelease targets.
+    securityBundle:
+      values:
+        sentinel: from-user-values
+      extraConfigs:
+        - kind: configMap
+          name: cm-post-user
+          priority: 120
+        - kind: secret
+          name: sec-pre-cluster
+          priority: 30
+        - kind: configMap
+          name: cm-pre-cluster
+          priority: 20
+        - kind: secret
+          name: sec-post-user
+          priority: 130
+        - kind: configMap
+          name: cm-default
+        - kind: secret
+          name: sec-pre-user
+          priority: 90
+        - kind: configMap
+          name: cm-pre-user
+          priority: 90
+providerIntegration:
+  environmentVariables:
+    hostName: COREOS_EC2_HOSTNAME
+    ipv4: COREOS_EC2_IPV4_LOCAL
+  provider: aws
+  apps:
+    certExporter:
+      enable: true
+    securityBundle:
+      enable: true
+  resourcesApi:
+    bastionResourceEnabled: false
+    clusterResourceEnabled: true
+    controlPlaneResource:
+      enabled: true
+      provider: kubeadm
+    infrastructureCluster:
+      group: infrastructure.cluster.x-k8s.io
+      kind: AWSCluster
+      version: v1beta1
+    machineHealthCheckResourceEnabled: true
+    machinePoolResourcesEnabled: true
+    nodePoolKind: MachinePool
+    infrastructureMachinePool:
+      group: infrastructure.cluster.x-k8s.io
+      version: v1beta1
+      kind: AWSMachinePool
+    helmRepositoryResourcesEnabled: true
+  controlPlane:
+    resources:
+      infrastructureMachineTemplate:
+        group: infrastructure.cluster.x-k8s.io
+        kind: AWSMachineTemplate
+        version: v1beta1
+      infrastructureMachineTemplateSpecTemplateName: cluster.internal.test.controlPlane.machineTemplate.spec
+  workers:
+    defaultNodePools:
+      def00:
+        customNodeLabels:
+        - label=default
+        maxSize: 3
+        minSize: 3

--- a/helm/cluster/ci/test-extraconfigs-priority-ordering-values.yaml
+++ b/helm/cluster/ci/test-extraconfigs-priority-ordering-values.yaml
@@ -53,12 +53,15 @@ global:
         sentinel: from-user-values
       extraConfigs:
         - kind: configMap
-          name: cm-post-user
+          name: cm-post-user-1
           priority: 120
         - kind: secret
-          name: sec-pre-cluster
+          name: sec-pre-cluster-1
           priority: 30
-        - kind: configMap
+          # sortAlpha is case-sensitive, a capital letter is sorted before the lowercase one.
+          # The value schema already prevents that, but not all systems might run the checks or can be skipped too.
+          # The sort helper converts them to a numerical value and calls lower() too.
+        - kind: CONFIGMAP
           name: cm-pre-cluster
           priority: 20
         - kind: secret
@@ -72,6 +75,12 @@ global:
         - kind: configMap
           name: cm-pre-user
           priority: 90
+        - kind: SECRET
+          name: sec-pre-cluster-2
+          priority: 30
+        - kind: configMap
+          name: cm-post-user-2
+          priority: 120
     # MC-targeted (inCluster) bundle. Same extraConfigs mix to show the ordering
     # logic is identical regardless of where the HelmRelease targets.
     securityBundle:
@@ -79,25 +88,34 @@ global:
         sentinel: from-user-values
       extraConfigs:
         - kind: configMap
-          name: cm-post-user
+          name: cm-post-user-1
           priority: 120
         - kind: secret
-          name: sec-pre-cluster
+          name: sec-pre-cluster-1
           priority: 30
-        - kind: configMap
+          # sortAlpha is case-sensitive, a capital letter is sorted before the lowercase one.
+          # The value schema already prevents that, but not all systems might run the checks or can be skipped too.
+          # The sort helper converts them to a numerical value and calls lower() too.
+        - kind: CONFIGMAP
           name: cm-pre-cluster
           priority: 20
         - kind: secret
           name: sec-post-user
           priority: 130
         - kind: configMap
-          name: cm-default
-        - kind: secret
+          name: cm-default        # no priority -> defaults to 25
+        - kind: SECRET
           name: sec-pre-user
           priority: 90
         - kind: configMap
           name: cm-pre-user
           priority: 90
+        - kind: secret
+          name: sec-pre-cluster-2
+          priority: 30
+        - kind: configMap
+          name: cm-post-user-2
+          priority: 120
 providerIntegration:
   environmentVariables:
     hostName: COREOS_EC2_HOSTNAME

--- a/helm/cluster/templates/_helpers.tpl
+++ b/helm/cluster/templates/_helpers.tpl
@@ -590,3 +590,65 @@ Note: time.ParseDuration is not available in Helm/Sprig's template FuncMap, henc
 {{- /* Return total */ -}}
 {{- $total -}}
 {{- end -}}
+
+{{- /*
+cluster.app.sortedValuesFrom — reproduce the App platform's config merge order
+as a single Flux `valuesFrom` list (Flux merges the list top-to-bottom, later
+entries overriding earlier ones).
+
+App platform (github.com/giantswarm/app/pkg/values) builds the configMap layers
+and the secret layers in two independent passes and then merges the secret blob
+OVER the configMap blob — so a secret ALWAYS overrides a configMap regardless of
+priority. Within each kind the band order is:
+  pre-cluster extras (priority <= 50) -> cluster config (slot 50)
+  -> post-cluster/pre-user extras (50 < p <= 100) -> user config (slot 100)
+  -> post-user extras (p > 100)
+Equal-priority extras keep their authored order; an extra at exactly 50/100
+precedes the platform layer at that slot (the band is half-open: minExcl < p <= max).
+
+We encode each entry as a sort key `KIND_PRIORITY_SOURCE_INDEX`:
+  KIND     0=configMap 1=secret      (all configMaps sort before all secrets)
+  PRIORITY %03d                       (numeric order via zero-pad)
+  SOURCE   0=extraConfig 1=platform   (extra precedes platform at equal priority)
+  INDEX    %03d authored position     (stable tie-break for equal-priority extras)
+then sortAlpha the keys and emit. Returns a YAML array of {kind,name} dicts.
+
+Arg: a dict with keys:
+  extraConfigs           list of {kind,name,priority}
+  clusterValuesConfigMap name | ""   (slot 50, configMap)
+  clusterValuesSecret    name | ""   (slot 50, secret)
+  userValuesConfigMap    name | ""   (slot 100, configMap)
+  root                   $ (for tpl-ing extraConfig names)
+*/ -}}
+{{- define "cluster.app.sortedValuesFrom" -}}
+{{- $keyed := dict -}}
+{{- $keys := list -}}
+{{- if .clusterValuesConfigMap -}}
+{{- $k := printf "0_%03d_1_000" 50 -}}
+{{- $keyed = set $keyed $k (dict "kind" "ConfigMap" "name" .clusterValuesConfigMap "optional" false) -}}
+{{- $keys = append $keys $k -}}
+{{- end -}}
+{{- if .clusterValuesSecret -}}
+{{- $k := printf "1_%03d_1_000" 50 -}}
+{{- $keyed = set $keyed $k (dict "kind" "Secret" "name" .clusterValuesSecret "optional" false) -}}
+{{- $keys = append $keys $k -}}
+{{- end -}}
+{{- if .userValuesConfigMap -}}
+{{- $k := printf "0_%03d_1_000" 100 -}}
+{{- $keyed = set $keyed $k (dict "kind" "ConfigMap" "name" .userValuesConfigMap "optional" false) -}}
+{{- $keys = append $keys $k -}}
+{{- end -}}
+{{- range $i, $ec := .extraConfigs -}}
+{{- $isSecret := eq (lower ($ec.kind | default "configMap")) "secret" -}}
+{{- $kindOrder := ternary "1" "0" $isSecret -}}
+{{- $prio := int ($ec.priority | default 25) -}}
+{{- $k := printf "%s_%03d_0_%03d" $kindOrder $prio $i -}}
+{{- $keyed = set $keyed $k (dict "kind" (ternary "Secret" "ConfigMap" $isSecret) "name" (tpl $ec.name $.root) "optional" ($ec.optional | default false)) -}}
+{{- $keys = append $keys $k -}}
+{{- end -}}
+{{- $out := list -}}
+{{- range $k := sortAlpha $keys -}}
+{{- $out = append $out (get $keyed $k) -}}
+{{- end -}}
+{{- $out | toYaml -}}
+{{- end -}}

--- a/helm/cluster/templates/apps/helmreleases.yaml
+++ b/helm/cluster/templates/apps/helmreleases.yaml
@@ -177,13 +177,46 @@ spec:
   {{- if $userConfig.values }}
   {{- $appHelmValues = mergeOverwrite $appHelmValues (deepCopy $userConfig.values) -}}
   {{- end }}
-  {{- if $appHelmValues }}
+  {{- /* extraConfigs carry the App platform `priority` (1-150, default 25) that fixes their
+         merge position relative to cluster config (slot 50) and user config (slot 100),
+         regardless of their position in the list. Flux merges valuesFrom strictly in list
+         order, so bucket the entries around those slots, stably sorted by priority. */}}
+  {{- $extraConfigs := concat ($app.extraConfigs | default list) ($userConfig.extraConfigs | default list) }}
+  {{- $extraConfigsLow := list }}
+  {{- $extraConfigsMid := list }}
+  {{- $extraConfigsHigh := list }}
+  {{- range $priority := untilStep 1 151 1 }}
+  {{- range $extraConfig := $extraConfigs }}
+  {{- if eq (int ($extraConfig.priority | default 25)) $priority }}
+  {{- if le $priority 50 }}
+  {{- $extraConfigsLow = append $extraConfigsLow $extraConfig }}
+  {{- else if le $priority 100 }}
+  {{- $extraConfigsMid = append $extraConfigsMid $extraConfig }}
+  {{- else }}
+  {{- $extraConfigsHigh = append $extraConfigsHigh $extraConfig }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- /* Flux merges inline `values` after every valuesFrom entry, so an extraConfig with
+         priority > 100 could never override user config delivered inline. When such entries
+         exist, ship the merged values as a ConfigMap at the user-config slot instead, so the
+         priority > 100 entries can be merged after it. */}}
+  {{- $userValuesViaConfigMap := and $extraConfigsHigh $appHelmValues }}
+  {{- if and $appHelmValues (not $userValuesViaConfigMap) }}
   values: {{- (tpl ($appHelmValues | toYaml | toString) $) | nindent 4 }}
   {{- end }}
-  {{- $extraConfigs := concat ($app.extraConfigs | default list) ($userConfig.extraConfigs | default list) }}
   {{- $hasClusterValues := or (($app.clusterValues).configMap) (($app.clusterValues).secret) }}
   {{- if or $extraConfigs $hasClusterValues }}
   valuesFrom:
+    {{- range $extraConfig := $extraConfigsLow }}
+  {{- $kind := $extraConfig.kind }}
+  {{- if eq $kind "configMap" }}{{ $kind = "ConfigMap" }}{{ else if eq $kind "secret" }}{{ $kind = "Secret" }}{{ end }}
+  - kind: {{ $kind }}
+    name: {{ $extraConfig.name }}
+    valuesKey: values
+    optional: {{ $extraConfig.optional | default false  }}
+    {{- end }}
     {{- if ($app.clusterValues).configMap }}
   - kind: ConfigMap
     name: {{ include "cluster.resource.name" $ }}-cluster-values
@@ -196,7 +229,21 @@ spec:
     valuesKey: values
     optional: false
     {{- end }}
-    {{- range $extraConfig := $extraConfigs }}
+    {{- range $extraConfig := $extraConfigsMid }}
+  {{- $kind := $extraConfig.kind }}
+  {{- if eq $kind "configMap" }}{{ $kind = "ConfigMap" }}{{ else if eq $kind "secret" }}{{ $kind = "Secret" }}{{ end }}
+  - kind: {{ $kind }}
+    name: {{ $extraConfig.name }}
+    valuesKey: values
+    optional: {{ $extraConfig.optional | default false  }}
+    {{- end }}
+    {{- if $userValuesViaConfigMap }}
+  - kind: ConfigMap
+    name: {{ include "cluster.resource.name" $ }}-{{ $appName }}-user-values
+    valuesKey: values
+    optional: false
+    {{- end }}
+    {{- range $extraConfig := $extraConfigsHigh }}
   {{- $kind := $extraConfig.kind }}
   {{- if eq $kind "configMap" }}{{ $kind = "ConfigMap" }}{{ else if eq $kind "secret" }}{{ $kind = "Secret" }}{{ end }}
   - kind: {{ $kind }}
@@ -205,6 +252,19 @@ spec:
     optional: {{ $extraConfig.optional | default false  }}
     {{- end }}
   {{- end }}
+{{- if $userValuesViaConfigMap }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "cluster.resource.name" $ }}-{{ $appName }}-user-values
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "cluster.labels.common.all" $ | nindent 4 }}
+data:
+  values: |
+    {{- (tpl ($appHelmValues | toYaml | toString) $) | nindent 4 }}
+{{- end }}
 {{- /* end if $shouldRenderApp */}}
 {{- end }}
 {{- /* end with $rootScope */}}

--- a/helm/cluster/templates/apps/helmreleases.yaml
+++ b/helm/cluster/templates/apps/helmreleases.yaml
@@ -177,87 +177,41 @@ spec:
   {{- if $userConfig.values }}
   {{- $appHelmValues = mergeOverwrite $appHelmValues (deepCopy $userConfig.values) -}}
   {{- end }}
-  {{- /* extraConfigs carry the App platform `priority` (1-150, default 25) that fixes their
-         merge position relative to cluster config (slot 50) and user config (slot 100),
-         regardless of their position in the list. Flux merges valuesFrom strictly in list
-         order, so bucket the entries around those slots, stably sorted by priority. */}}
+  {{- /* App platform honoured a `priority` (1-150, default 25) on each extraConfig that
+         fixed its merge position relative to the cluster config (slot 50) and user config
+         (slot 100) layers, and merged all configMaps before all secrets (secret always wins).
+         Flux merges `valuesFrom` strictly in list order, so we emit a single list sorted to
+         reproduce that order — see the `cluster.app.sortedValuesFrom` helper. The merged
+         default+provider+user values are delivered through the user-config slot as a
+         ConfigMap (not inline `spec.values`, which Flux always merges last and which no
+         valuesFrom entry could override). */}}
   {{- $extraConfigs := concat ($app.extraConfigs | default list) ($userConfig.extraConfigs | default list) }}
-  {{- $extraConfigsLow := list }}
-  {{- $extraConfigsMid := list }}
-  {{- $extraConfigsHigh := list }}
-  {{- range $priority := untilStep 1 151 1 }}
-  {{- range $extraConfig := $extraConfigs }}
-  {{- if eq (int ($extraConfig.priority | default 25)) $priority }}
-  {{- if le $priority 50 }}
-  {{- $extraConfigsLow = append $extraConfigsLow $extraConfig }}
-  {{- else if le $priority 100 }}
-  {{- $extraConfigsMid = append $extraConfigsMid $extraConfig }}
-  {{- else }}
-  {{- $extraConfigsHigh = append $extraConfigsHigh $extraConfig }}
+  {{- $userValuesConfigMap := "" }}
+  {{- if $appHelmValues }}
+  {{- $userValuesConfigMap = printf "%s-%s-user-values" (include "cluster.resource.name" $) $appName }}
   {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- /* Flux merges inline `values` after every valuesFrom entry, so an extraConfig with
-         priority > 100 could never override user config delivered inline. When such entries
-         exist, ship the merged values as a ConfigMap at the user-config slot instead, so the
-         priority > 100 entries can be merged after it. */}}
-  {{- $userValuesViaConfigMap := and $extraConfigsHigh $appHelmValues }}
-  {{- if and $appHelmValues (not $userValuesViaConfigMap) }}
-  values: {{- (tpl ($appHelmValues | toYaml | toString) $) | nindent 4 }}
-  {{- end }}
-  {{- $hasClusterValues := or (($app.clusterValues).configMap) (($app.clusterValues).secret) }}
-  {{- if or $extraConfigs $hasClusterValues }}
+  {{- $sortArgs := dict
+        "extraConfigs" $extraConfigs
+        "clusterValuesConfigMap" (ternary (printf "%s-cluster-values" (include "cluster.resource.name" $)) "" (not (empty ($app.clusterValues).configMap)))
+        "clusterValuesSecret" (ternary (printf "%s-cluster-values" (include "cluster.resource.name" $)) "" (not (empty ($app.clusterValues).secret)))
+        "userValuesConfigMap" $userValuesConfigMap
+        "root" $ }}
+  {{- $sortedValuesFrom := include "cluster.app.sortedValuesFrom" $sortArgs | fromYamlArray }}
+  {{- if $sortedValuesFrom }}
   valuesFrom:
-    {{- range $extraConfig := $extraConfigsLow }}
-  {{- $kind := $extraConfig.kind }}
-  {{- if eq $kind "configMap" }}{{ $kind = "ConfigMap" }}{{ else if eq $kind "secret" }}{{ $kind = "Secret" }}{{ end }}
-  - kind: {{ $kind }}
-    name: {{ $extraConfig.name }}
+  {{- range $entry := $sortedValuesFrom }}
+  - kind: {{ $entry.kind }}
+    name: {{ $entry.name }}
     valuesKey: values
-    optional: {{ $extraConfig.optional | default false  }}
-    {{- end }}
-    {{- if ($app.clusterValues).configMap }}
-  - kind: ConfigMap
-    name: {{ include "cluster.resource.name" $ }}-cluster-values
-    valuesKey: values
-    optional: false
-    {{- end }}
-    {{- if ($app.clusterValues).secret }}
-  - kind: Secret
-    name: {{ include "cluster.resource.name" $ }}-cluster-values
-    valuesKey: values
-    optional: false
-    {{- end }}
-    {{- range $extraConfig := $extraConfigsMid }}
-  {{- $kind := $extraConfig.kind }}
-  {{- if eq $kind "configMap" }}{{ $kind = "ConfigMap" }}{{ else if eq $kind "secret" }}{{ $kind = "Secret" }}{{ end }}
-  - kind: {{ $kind }}
-    name: {{ $extraConfig.name }}
-    valuesKey: values
-    optional: {{ $extraConfig.optional | default false  }}
-    {{- end }}
-    {{- if $userValuesViaConfigMap }}
-  - kind: ConfigMap
-    name: {{ include "cluster.resource.name" $ }}-{{ $appName }}-user-values
-    valuesKey: values
-    optional: false
-    {{- end }}
-    {{- range $extraConfig := $extraConfigsHigh }}
-  {{- $kind := $extraConfig.kind }}
-  {{- if eq $kind "configMap" }}{{ $kind = "ConfigMap" }}{{ else if eq $kind "secret" }}{{ $kind = "Secret" }}{{ end }}
-  - kind: {{ $kind }}
-    name: {{ $extraConfig.name }}
-    valuesKey: values
-    optional: {{ $extraConfig.optional | default false  }}
-    {{- end }}
+    optional: {{ $entry.optional }}
   {{- end }}
-{{- if $userValuesViaConfigMap }}
+  {{- end }}
+{{- if $userValuesConfigMap }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "cluster.resource.name" $ }}-{{ $appName }}-user-values
+  name: {{ $userValuesConfigMap }}
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "cluster.labels.common.all" $ | nindent 4 }}

--- a/helm/cluster/tests/components/test_extraconfigs_priority.go
+++ b/helm/cluster/tests/components/test_extraconfigs_priority.go
@@ -1,0 +1,48 @@
+package components
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/giantswarm/cluster/helm/cluster/tests/helm"
+	"github.com/giantswarm/cluster/helm/cluster/tests/yq"
+)
+
+// The App platform merged all configMaps before all secrets (secret always wins),
+// and within each kind ordered extraConfigs by priority around the cluster-values
+// (50) and user-values (100) slots. The migrated HelmReleases must reproduce that
+// order in spec.valuesFrom, which Flux merges top-to-bottom. See the
+// test-extraconfigs-priority-ordering-values.yaml file and giantswarm/giantswarm#36096.
+var _ = Describe("extraConfigs priority ordering", func() {
+	DescribeTable("renders valuesFrom in App-platform merge order",
+		func(helmReleaseName, userValuesConfigMap string) {
+			manifests := helm.Template(
+				helm.GetClusterChartDir(),
+				"test-extraconfigs-priority-ordering-values.yaml",
+				"org-giantswarm",
+				"awesome",
+			)
+
+			hr := yq.Run(manifests, `select(.kind=="HelmRelease" and .metadata.name=="`+helmReleaseName+`")`)
+			order := yq.Run(hr, `.spec.valuesFrom[] | .kind + "/" + .name`)
+
+			// configMaps first (by priority band, user-values at slot 100), then
+			// secrets (by priority) — a secret always overrides a configMap.
+			expected := []string{
+				"ConfigMap/cm-pre-cluster",  // priority 20
+				"ConfigMap/cm-default",      // priority 25 (defaulted)
+				"ConfigMap/cm-pre-user",     // priority 90
+				"ConfigMap/" + userValuesConfigMap, // user-values slot (100)
+				"ConfigMap/cm-post-user",    // priority 120
+				"Secret/sec-pre-cluster",    // priority 30
+				"Secret/sec-pre-user",       // priority 90
+				"Secret/sec-post-user",      // priority 130
+			}
+			Expect(strings.Fields(strings.TrimSpace(order))).To(Equal(expected))
+		},
+		Entry("WC-targeted app (cert-exporter)", "awesome-cert-exporter", "awesome-cert-exporter-user-values"),
+		Entry("MC-targeted bundle (security-bundle)", "awesome-security-bundle", "awesome-security-bundle-user-values"),
+	)
+})

--- a/helm/cluster/tests/components/test_extraconfigs_priority.go
+++ b/helm/cluster/tests/components/test_extraconfigs_priority.go
@@ -31,14 +31,16 @@ var _ = Describe("extraConfigs priority ordering", func() {
 			// configMaps first (by priority band, user-values at slot 100), then
 			// secrets (by priority) — a secret always overrides a configMap.
 			expected := []string{
-				"ConfigMap/cm-pre-cluster",  // priority 20
-				"ConfigMap/cm-default",      // priority 25 (defaulted)
-				"ConfigMap/cm-pre-user",     // priority 90
+				"ConfigMap/cm-pre-cluster",         // priority 20
+				"ConfigMap/cm-default",             // priority 25 (defaulted)
+				"ConfigMap/cm-pre-user",            // priority 90
 				"ConfigMap/" + userValuesConfigMap, // user-values slot (100)
-				"ConfigMap/cm-post-user",    // priority 120
-				"Secret/sec-pre-cluster",    // priority 30
-				"Secret/sec-pre-user",       // priority 90
-				"Secret/sec-post-user",      // priority 130
+				"ConfigMap/cm-post-user-1",         // priority 120, 1st in list order
+				"ConfigMap/cm-post-user-2",         // priority 120, 2nd in list order
+				"Secret/sec-pre-cluster-1",         // priority 30, 1st in list order
+				"Secret/sec-pre-cluster-2",         // priority 30, 2nd in list order
+				"Secret/sec-pre-user",              // priority 90
+				"Secret/sec-post-user",             // priority 130
 			}
 			Expect(strings.Fields(strings.TrimSpace(order))).To(Equal(expected))
 		},


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/36096

Stacked on #780.

## Problem

App CRs support a `priority` field (1-150, default 25) on `extraConfigs` entries that fixes each entry's merge position relative to the platform config layers — catalog (slot 0), cluster config (slot 50), user config (slot 100) — regardless of position in the list (see the [multi-layer-app-config RFC](https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config)). Flux merges `valuesFrom` strictly in list order and merges inline `spec.values` last, so the migrated HelmReleases silently ignore priorities. Bundle customers are known to rely on them.

## Changes

1. **Stable priority sort + slot interleaving.** `extraConfigs` are bucketed with a counting sort: entries with priority ≤ 50 render before the `-cluster-values` references, 51-100 after them, and > 100 last. Ties keep their authored order (matching App platform behavior).

2. **User values via ConfigMap when the > 100 band is used.** Flux merges inline `spec.values` after every `valuesFrom` entry, so an extraConfig with priority > 100 (meant to override user config) could never win against inline values. When such an entry exists for an app, the merged default+provider+user values are delivered through a `<cluster>-<app>-user-values` ConfigMap referenced at the user-config slot, and the > 100 entries follow it. Apps without > 100 entries keep the inline form — for them, inline-last is exactly equivalent to the user-config slot.

The CI values already exercise the > 100 band (cert-manager 110/120, external-dns 120), so `helm template` diffs demonstrate the fix directly.

## Verification

- Baseline render against `ci/ci-values.yaml`: only cert-manager and external-dns change (the two apps with priority > 100 entries) — they switch from inline values to the user-values ConfigMap, ordered `user-values → 110 → 120`.
- Three-band scenario (priorities 10/120/75 authored in non-priority order): renders `10 → 75 → user-values → 120`.
- All `ci/*.yaml` values files render cleanly; `make test` passes.

## Follow-ups (not in this PR)

- Same treatment for the provider-chart HR templates (cluster-aws) and the bundle charts (security-bundle, observability-bundle, aws-nth-bundle) — the issue calls out bundle customers specifically.