### PR TITLE
chore: migrate cert-manager values for v4.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -458,6 +458,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Apps: Bump `cluster-autoscaler` to v1.29.3-gs1. ([#286](https://github.com/giantswarm/cluster/pull/286))
 - Deprecate `cluster.component.flatcar.version` named template in favor of `cluster.os.version`.
 
+### Changed
+
+- Updated `cert-manager` to v4.0.0 and migrated the values to match the new chart's schema.
+
 ## [1.0.0] - 2024-07-24
 
 ### Changed

--- a/helm/cluster/files/apps/cert-manager.yaml
+++ b/helm/cluster/files/apps/cert-manager.yaml
@@ -10,13 +10,14 @@ namespace: kube-system
 # repo: giantswarm/cert-manager-app
 version: 4.0.1
 defaultValues:
-  # cert-manager's DNS01 solver by default tries to reach authoritative nameservers directly, using
-  # their public IPs. Since those are not reachable from private clusters, we instead rely on the
-  # recursive nameserver (e.g. for AWS, that's normally the default nameserver requested in EC2 instances).
-  dns01RecursiveNameserversOnly: true
-  ingressShim:
-    defaultIssuerName: letsencrypt-giantswarm
-    defaultIssuerKind: ClusterIssuer
-    defaultIssuerGroup: cert-manager.io
+  cert-manager:
+    # cert-manager's DNS01 solver by default tries to reach authoritative nameservers directly, using
+    # their public IPs. Since those are not reachable from private clusters, we instead rely on the
+    # recursive nameserver (e.g. for AWS, that's normally the default nameserver requested in EC2 instances).
+    dns01RecursiveNameserversOnly: true
+    ingressShim:
+      defaultIssuerName: letsencrypt-giantswarm
+      defaultIssuerKind: ClusterIssuer
+      defaultIssuerGroup: cert-manager.io
   ciliumNetworkPolicy:
     enabled: true

--- a/helm/cluster/files/apps/cert-manager.yaml
+++ b/helm/cluster/files/apps/cert-manager.yaml
@@ -12,8 +12,11 @@ version: 4.0.1
 defaultValues:
   # Since v4.0.0, cert-manager upstream values need to be under the cert-manager key.
   # This gates the config based on the cert-manager app version
+  {{- $certManagerVersion := "N/A" }}
+  {{- if $.Values.providerIntegration.useReleases }}
   {{- $_ := set $ "appName" "cert-manager" }}
-  {{- $certManagerVersion := include "cluster.app.version" $ | trim }}
+  {{- $certManagerVersion = include "cluster.app.version" $ | trim }}
+  {{- end }}
   {{- if or (eq $certManagerVersion "N/A") (semverCompare ">=4.0.0" $certManagerVersion) }}
   cert-manager:
     # cert-manager's DNS01 solver by default tries to reach authoritative nameservers directly, using

--- a/helm/cluster/files/apps/cert-manager.yaml
+++ b/helm/cluster/files/apps/cert-manager.yaml
@@ -10,6 +10,14 @@ namespace: kube-system
 # repo: giantswarm/cert-manager-app
 version: 4.0.1
 defaultValues:
+  # Since v4.0.0, cert-manager upstream values need to be under the cert-manager key.
+  # This gates the config based on the cert-manager app version
+  {{- $certManagerVersion := "N/A" }}
+  {{- if $.Values.providerIntegration.useReleases }}
+  {{- $_ := set $ "appName" "cert-manager" }}
+  {{- $certManagerVersion = include "cluster.app.version" $ | trim }}
+  {{- end }}
+  {{- if or (eq $certManagerVersion "N/A") (semverCompare ">=4.0.0" $certManagerVersion) }}
   cert-manager:
     # cert-manager's DNS01 solver by default tries to reach authoritative nameservers directly, using
     # their public IPs. Since those are not reachable from private clusters, we instead rely on the
@@ -19,5 +27,13 @@ defaultValues:
       defaultIssuerName: letsencrypt-giantswarm
       defaultIssuerKind: ClusterIssuer
       defaultIssuerGroup: cert-manager.io
+  {{- else }}
+  # Duplicated block for < v4.0.0 versions
+  dns01RecursiveNameserversOnly: true
+  ingressShim:
+    defaultIssuerName: letsencrypt-giantswarm
+    defaultIssuerKind: ClusterIssuer
+    defaultIssuerGroup: cert-manager.io
+  {{- end }}
   ciliumNetworkPolicy:
     enabled: true

--- a/helm/cluster/files/apps/cert-manager.yaml
+++ b/helm/cluster/files/apps/cert-manager.yaml
@@ -12,11 +12,8 @@ version: 4.0.1
 defaultValues:
   # Since v4.0.0, cert-manager upstream values need to be under the cert-manager key.
   # This gates the config based on the cert-manager app version
-  {{- $certManagerVersion := "N/A" }}
-  {{- if $.Values.providerIntegration.useReleases }}
   {{- $_ := set $ "appName" "cert-manager" }}
-  {{- $certManagerVersion = include "cluster.app.version" $ | trim }}
-  {{- end }}
+  {{- $certManagerVersion := include "cluster.app.version" $ | trim }}
   {{- if or (eq $certManagerVersion "N/A") (semverCompare ">=4.0.0" $certManagerVersion) }}
   cert-manager:
     # cert-manager's DNS01 solver by default tries to reach authoritative nameservers directly, using

--- a/helm/cluster/templates/_helpers.tpl
+++ b/helm/cluster/templates/_helpers.tpl
@@ -276,11 +276,13 @@ Where `data` is the data to hash and `global` is the top level scope.
 */}}
 {{- define "cluster.app.version" }}
 {{- $appVersion := "N/A" }}
+{{- if $.Values.providerIntegration.useReleases }}
 {{- $_ := (include "cluster.internal.get-release-resource" $) }}
 {{- if $.GiantSwarm.Release }}
 {{- range $_, $app := $.GiantSwarm.Release.spec.apps }}
 {{- if eq $app.name $.appName }}
 {{- $appVersion = $app.version }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/cluster/templates/_helpers.tpl
+++ b/helm/cluster/templates/_helpers.tpl
@@ -276,13 +276,11 @@ Where `data` is the data to hash and `global` is the top level scope.
 */}}
 {{- define "cluster.app.version" }}
 {{- $appVersion := "N/A" }}
-{{- if $.Values.providerIntegration.useReleases }}
 {{- $_ := (include "cluster.internal.get-release-resource" $) }}
 {{- if $.GiantSwarm.Release }}
 {{- range $_, $app := $.GiantSwarm.Release.spec.apps }}
 {{- if eq $app.name $.appName }}
 {{- $appVersion = $app.version }}
-{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
> [!WARNING]
> This PR depends on the v4.0.1 cert-manager release:
> https://github.com/giantswarm/cert-manager-app/releases/tag/v4.0.1

`cert-manager` now vendors upstream `cert-manager` as a subchart, so its upstream values live under a `cert-manager`: key. The values we pass to `cert-manager-app` from the cluster charts need to move accordingly.

Towards: https://github.com/giantswarm/giantswarm/issues/36890

