### PR TITLE
feat(selinux): configure nodes for custom SELinux policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- SELinux: Add `global.components.selinux.writablePolicyStore` value (default `true`) to allow loading additional SELinux policies.
+
+### Changed
+
+- SELinux: Keep AVC audit logs (required for SELinux policy generation).
+- SELinux: Relabel the whole filesystem except read-only `/usr` (previously only `/etc/kubernetes`).
+
+### Fixed
+
+- SELinux: Correctly label CA certificates in `/etc/ssl/certs` for mounting into containers.
+
 ## [8.0.0] - 2026-08-21
 
 ### Changed

--- a/helm/cluster/README.md
+++ b/helm/cluster/README.md
@@ -335,6 +335,7 @@ Advanced configuration of components that are running on all nodes.
 | `global.components.containerd.selinux.enabled` | **Enabled** - Enabling this will configure containerd to do SELinux relabeling to containers.|**Type:** `boolean`<br/>**Default:** `false`|
 | `global.components.selinux` | **SELinux** - Configuration of SELinux.|**Type:** `object`<br/>|
 | `global.components.selinux.mode` | **SELinux mode** - Configure SELinux mode: 'enforcing', 'permissive' or 'disabled'.|**Type:** `string`<br/>**Allowed values:** `enforcing`, `permissive`, `disabled`<br/>**Default:** `"permissive"`|
+| `global.components.selinux.writablePolicyStore` | **Writable SELinux policy store** - Make /var/lib/selinux writable for loading additional policies.|**Type:** `boolean`<br/>**Default:** `true`|
 
 ### Connectivity
 Properties within the `.global.connectivity` object

--- a/helm/cluster/files/etc/selinux/flatcar-containerd-patch.cil
+++ b/helm/cluster/files/etc/selinux/flatcar-containerd-patch.cil
@@ -1,0 +1,11 @@
+; Flatcar containerd/runc runs as kernel_t (because of unlabeled /usr)
+; kernel_t doesn't have the right permissions for a container runtime, but container_engine_t does.
+; container_engine_t belongs to container_engine_domain and container_engine_system_domain, which provide those permissions
+
+; TODO: Remove when containerd/runc doesn't run as kernel_t
+; HACK: Add kernel_t to container_engine_domain and container_engine_system_domain
+(typeattributeset container_engine_domain (kernel_t))
+(typeattributeset container_engine_system_domain (kernel_t))
+; HACK: Allow container_domain to access kernel_t for container operations (copied from container_t perms)
+(allow container_domain kernel_t (fd (use)))
+(allow container_domain kernel_t (fifo_file (append getattr ioctl open read write)))

--- a/helm/cluster/templates/clusterapi/_helpers_files.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_files.tpl
@@ -25,6 +25,12 @@
   permissions: "0644"
   encoding: base64
   content: {{ tpl ($.Files.Get "files/etc/selinux/config") . | b64enc }}
+{{- if and (ne $.Values.global.components.selinux.mode "disabled") $.Values.global.components.selinux.writablePolicyStore }}
+- path: /etc/selinux/flatcar-containerd-patch.cil
+  permissions: "0644"
+  encoding: base64
+  content: {{ tpl ($.Files.Get "files/etc/selinux/flatcar-containerd-patch.cil") . | b64enc }}
+{{- end }}
 {{- end }}
 
 {{- define "cluster.internal.kubeadm.files.systemd" }}

--- a/helm/cluster/templates/clusterapi/_helpers_prekubeadmcommands.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_prekubeadmcommands.tpl
@@ -18,6 +18,10 @@
 
 {{- define "cluster.internal.kubeadm.preKubeadmCommands.selinux" }}
 {{- if ne $.Values.global.components.selinux.mode "disabled" }}
+# Remove audit rules that suppress SELinux AVC logs in Flatcar
+# Required for generating SELinux policies (e.g. using security-profiles-operator)
+- rm -f /etc/audit/rules.d/80-selinux.rules
+- systemctl restart audit-rules
 # All certs in /etc/ssl/certs are symlinked to /usr/share/ca-certificates in Flatcar
 # /usr is unlabeled and read-only in Flatcar. Copy certs to /etc/ssl/certs for correct labeling
 # Required for mounting /etc/ssl/certs into containers (e.g. kube-apiserver, cluster-autoscaler)

--- a/helm/cluster/templates/clusterapi/_helpers_prekubeadmcommands.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_prekubeadmcommands.tpl
@@ -18,6 +18,12 @@
 
 {{- define "cluster.internal.kubeadm.preKubeadmCommands.selinux" }}
 {{- if ne $.Values.global.components.selinux.mode "disabled" }}
+{{- if $.Values.global.components.selinux.writablePolicyStore }}
+# Make `/var/lib/selinux` writable for loading additional policies
+- rm -rf /var/lib/selinux
+- cp -a /usr/lib/selinux/policy /var/lib/selinux
+- semodule -DB
+{{- end }}
 # Remove audit rules that suppress SELinux AVC logs in Flatcar
 # Required for generating SELinux policies (e.g. using security-profiles-operator)
 - rm -f /etc/audit/rules.d/80-selinux.rules

--- a/helm/cluster/templates/clusterapi/_helpers_prekubeadmcommands.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_prekubeadmcommands.tpl
@@ -18,11 +18,16 @@
 
 {{- define "cluster.internal.kubeadm.preKubeadmCommands.selinux" }}
 {{- if ne $.Values.global.components.selinux.mode "disabled" }}
-# Fix label for kube-apiserver audit log directory
+# All certs in /etc/ssl/certs are symlinked to /usr/share/ca-certificates in Flatcar
+# /usr is unlabeled and read-only in Flatcar. Copy certs to /etc/ssl/certs for correct labeling
+# Required for mounting /etc/ssl/certs into containers (e.g. kube-apiserver, cluster-autoscaler)
+- rm -rf /etc/ssl/certs
+- cp -a /usr/share/ca-certificates /etc/ssl/certs
+# Fix SELinux labels for everything except `/usr` (read-only in Flatcar)
+- restorecon -RFv -e /usr /
+# Change label for kube-apiserver audit log directory for access from containers
 - mkdir -p /var/log/apiserver
 - chcon -R -t container_file_t /var/log/apiserver
-# Fix labels for `/etc/kubernetes`
-- restorecon -RFv /etc/kubernetes
 {{- end }}
 {{- end }}
 

--- a/helm/cluster/templates/clusterapi/_helpers_prekubeadmcommands.tpl
+++ b/helm/cluster/templates/clusterapi/_helpers_prekubeadmcommands.tpl
@@ -23,6 +23,8 @@
 - rm -rf /var/lib/selinux
 - cp -a /usr/lib/selinux/policy /var/lib/selinux
 - semodule -DB
+# Load policy for containerd to work with any container_domain type (other than container_t)
+- semodule -i /etc/selinux/flatcar-containerd-patch.cil
 {{- end }}
 # Remove audit rules that suppress SELinux AVC logs in Flatcar
 # Required for generating SELinux policies (e.g. using security-profiles-operator)

--- a/helm/cluster/values.schema.json
+++ b/helm/cluster/values.schema.json
@@ -1660,6 +1660,12 @@
                                         "disabled"
                                     ],
                                     "default": "permissive"
+                                },
+                                "writablePolicyStore": {
+                                    "type": "boolean",
+                                    "title": "Writable SELinux policy store",
+                                    "description": "Make /var/lib/selinux writable for loading additional policies.",
+                                    "default": true
                                 }
                             }
                         }

--- a/helm/cluster/values.yaml
+++ b/helm/cluster/values.yaml
@@ -61,6 +61,7 @@ global:
         enabled: false
     selinux:
       mode: permissive
+      writablePolicyStore: true
   connectivity:
     bastion:
       enabled: true


### PR DESCRIPTION
### What does this PR do?

Configure Flatcar nodes so that custom SELinux policies for workloads can be loaded and utilized, e.g. policies installed by [security-profiles-operator](https://github.com/kubernetes-sigs/security-profiles-operator).

- **Writable SELinux policy store** (new value `global.components.selinux.writablePolicyStore`, default `true`): `/var/lib/selinux` on Flatcar is symlinked under `/usr`, so no additional policy modules can be installed. The store is now copied instead of symlinking to make it writable.
- **Flatcar containerd patch policy** (`/etc/selinux/flatcar-containerd-patch.cil`): containerd/runc runs as `kernel_t` on Flatcar because `/usr` is unlabeled. `kernel_t` works fine with the default `container_t` type, but not with other `container_domain` types like the ones security-profiles-operator installs. The patch grants `kernel_t` the container-engine permissions so any `container_domain` types work. Temporary until Flatcar labels containerd correctly.
- **Keep AVC audit logs**: remove Flatcar's audit rules that suppress SELinux AVC events and disable dontaudit rules (`semodule -D`), required for generating SELinux policies.
- **Correct filesystem labels**: relabel everything except read-only `/usr` (previously only `/etc/kubernetes`), and copy CA certificates out of `/usr/share/ca-certificates` to `/etc/ssl/certs` so they get correct labels for mounting into containers (e.g. kube-apiserver, cluster-autoscaler).

### What is the effect of this change to users?

No behavior change when `global.components.selinux.mode` is `disabled`. Otherwise, nodes keep SELinux AVC audit logs, get correct filesystem labels, and with `writablePolicyStore: true` additional SELinux policy modules can be loaded, enabling workloads with custom SELinux profiles (e.g. via security-profiles-operator).

Note: `writablePolicyStore: false` with `mode: enforcing` still works for workloads running as the default `container_t` type, only custom `container_domain` types require the patch policy.

### Any background context you can provide?

Towards https://github.com/giantswarm/giantswarm/issues/35494
As containerd cannot run with the correct SELinux context on Flatcar, we need a workaround to run workloads with custom SELinux policies. Additionally, security-profiles-operator needs to install SELinux policy modules and read AVC audit events on nodes, both disabled by default on Flatcar.

### Do the docs need to be updated?

README.md has been regenerated.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
