### PR TITLE
refactor(coredns): migrate values to new zone-aware interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Migrate `coredns` HelmRelease values to the new `coredns-app` zone-aware interface.
+
 ## [6.8.0] - 2026-07-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Migrate `coredns` HelmRelease values to the new `coredns-app` zone-aware interface.
+- Rename the internal `coredns` control plane helper to align with the `controlPlane` values key.
 
 ## [6.8.0] - 2026-07-14
 

--- a/helm/cluster/files/helmreleases/coredns.yaml
+++ b/helm/cluster/files/helmreleases/coredns.yaml
@@ -7,16 +7,14 @@ namespace: kube-system
 version: 1.31.0
 dependsOn: {{ if not (eq $.Values.providerIntegration.provider "aks") }}["cilium"]{{ else }}[]{{ end }}
 defaultValues:
-  cluster:
-    calico:
-      CIDR: {{ first .Values.global.connectivity.network.pods.cidrBlocks | quote }}
-    kubernetes:
-      API:
-        clusterIPRange: {{ first .Values.global.connectivity.network.services.cidrBlocks | quote }}
-      DNS:
-        IP: {{ include "cluster.internal.apps.coredns.dns" $ | quote }}
+  coredns:
+    cluster:
+      podCIDR: {{ first .Values.global.connectivity.network.pods.cidrBlocks | quote }}
+      serviceCIDR: {{ first .Values.global.connectivity.network.services.cidrBlocks | quote }}
+  service:
+    clusterIP: {{ include "cluster.internal.apps.coredns.dns" $ | quote }}
   global:
     podSecurityStandards:
       enforced: {{ .Values.global.podSecurityStandards.enforced }}
-  mastersInstance:
+  controlPlane:
     enabled: {{ include "cluster.internal.apps.coredns.mastersInstance.enabled" $ }}

--- a/helm/cluster/files/helmreleases/coredns.yaml
+++ b/helm/cluster/files/helmreleases/coredns.yaml
@@ -17,4 +17,4 @@ defaultValues:
     podSecurityStandards:
       enforced: {{ .Values.global.podSecurityStandards.enforced }}
   controlPlane:
-    enabled: {{ include "cluster.internal.apps.coredns.mastersInstance.enabled" $ }}
+    enabled: {{ include "cluster.internal.apps.coredns.controlPlane.enabled" $ }}

--- a/helm/cluster/templates/apps/_helpers.tpl
+++ b/helm/cluster/templates/apps/_helpers.tpl
@@ -17,7 +17,7 @@
 {{/*
 There are cases where we don't want to deploy the coreDns control plane components (for example when using Kamaji.)
 */}}
-{{- define "cluster.internal.apps.coredns.mastersInstance.enabled" -}}
+{{- define "cluster.internal.apps.coredns.controlPlane.enabled" -}}
     {{- if not (include "kamaji.isEnabled" $) -}}
         {{- printf "true" -}}
     {{- else -}}


### PR DESCRIPTION
Migrate the `coredns` HelmRelease `defaultValues` to the new zone-aware values interface introduced in `coredns-app` 1.31.0.

Path changes:
- `cluster.calico.CIDR` → `coredns.cluster.podCIDR`
- `cluster.kubernetes.API.clusterIPRange` → `coredns.cluster.serviceCIDR`
- `cluster.kubernetes.DNS.IP` → `service.clusterIP`
- `mastersInstance.enabled` → `controlPlane.enabled`

The refactor is backward compatible; the new paths take effect with `coredns-app` 1.31.0 (already pinned in this file).

Towards https://github.com/giantswarm/giantswarm/issues/36742